### PR TITLE
fix: SonarCloud integration and issue resolution

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,9 @@ jobs:
     name: SonarCloud Analysis
     needs: ci
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ on:
         required: false
         default: "main"
 
-permissions:
-  contents: write
-
 env:
   GO_VERSION: "1.25.7"
 
@@ -29,6 +26,8 @@ jobs:
     name: Create and push tag (manual only)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,6 +62,8 @@ jobs:
     name: Check Release-Relevant Changes
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_needed: ${{ steps.filter.outputs.release_needed }}
     steps:
@@ -107,6 +108,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.release_needed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -131,6 +134,8 @@ jobs:
     needs: [changes, changelog]
     if: needs.changes.outputs.release_needed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -156,6 +161,9 @@ jobs:
     needs: [changes, release]
     if: needs.changes.outputs.release_needed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Trigger documentation rebuild
         uses: actions/github-script@v8

--- a/agent/bus_test.go
+++ b/agent/bus_test.go
@@ -112,7 +112,9 @@ func TestInMemoryBus_Subscribe_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := bus.Subscribe(ctx, "topic", func(event AgentEvent) {})
+	_, err := bus.Subscribe(ctx, "topic", func(event AgentEvent) {
+		// no-op: subscription cancelled before events arrive
+	})
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}

--- a/agent/lats.go
+++ b/agent/lats.go
@@ -10,6 +10,8 @@ import (
 	"github.com/lookatitude/beluga-ai/schema"
 )
 
+const stepFmt = "Step %d: %s\n"
+
 func init() {
 	RegisterPlanner("lats", func(cfg PlannerConfig) (Planner, error) {
 		if cfg.LLM == nil {
@@ -235,7 +237,7 @@ func (p *LATSPlanner) expandNode(ctx context.Context, input string, node *MCTSNo
 	if len(path) > 1 { // skip root
 		pathContext = "\n\nReasoning so far:\n"
 		for i, step := range path[1:] {
-			pathContext += fmt.Sprintf("Step %d: %s\n", i+1, step)
+			pathContext += fmt.Sprintf(stepFmt, i+1, step)
 		}
 	}
 
@@ -273,7 +275,7 @@ func (p *LATSPlanner) evaluateNode(ctx context.Context, input string, node *MCTS
 	path := p.extractPath(node)
 	var pathText string
 	for i, step := range path {
-		pathText += fmt.Sprintf("Step %d: %s\n", i+1, step)
+		pathText += fmt.Sprintf(stepFmt, i+1, step)
 	}
 
 	prompt := fmt.Sprintf(
@@ -382,7 +384,7 @@ func (p *LATSPlanner) synthesize(ctx context.Context, state PlannerState, path [
 		if i == 0 {
 			continue // skip root (which is just the input)
 		}
-		fmt.Fprintf(&pathText, "Step %d: %s\n", i, step)
+		fmt.Fprintf(&pathText, stepFmt, i, step)
 	}
 
 	var reflectionText string

--- a/agent/persona_test.go
+++ b/agent/persona_test.go
@@ -7,96 +7,87 @@ import (
 	"github.com/lookatitude/beluga-ai/schema"
 )
 
+func assertPersonaMessage(t *testing.T, msg *schema.SystemMessage, wantParts []string, dontWant []string) {
+	t.Helper()
+	if msg.GetRole() != schema.RoleSystem {
+		t.Errorf("role = %s, want %s", msg.GetRole(), schema.RoleSystem)
+	}
+	text := msg.Text()
+	for _, part := range wantParts {
+		if !strings.Contains(text, part) {
+			t.Errorf("text should contain %q, got:\n%s", part, text)
+		}
+	}
+	for _, part := range dontWant {
+		if strings.Contains(text, part) {
+			t.Errorf("text should NOT contain %q, got:\n%s", part, text)
+		}
+	}
+}
+
 func TestPersona_ToSystemMessage(t *testing.T) {
-	tests := []struct {
-		name       string
-		persona    Persona
-		wantNil    bool
-		wantParts  []string
-		dontWant   []string
-	}{
-		{
-			name:    "empty persona returns nil",
-			persona: Persona{},
-			wantNil: true,
-		},
-		{
-			name: "role only",
-			persona: Persona{
-				Role: "software engineer",
-			},
-			wantParts: []string{"You are a software engineer."},
-		},
-		{
-			name: "goal only",
-			persona: Persona{
-				Goal: "help users write clean code",
-			},
-			wantParts: []string{"Your goal is to help users write clean code."},
-		},
-		{
-			name: "backstory only",
-			persona: Persona{
-				Backstory: "You have 10 years of experience.",
-			},
-			wantParts: []string{"You have 10 years of experience."},
-		},
-		{
-			name: "traits only",
-			persona: Persona{
-				Traits: []string{"concise", "friendly"},
-			},
-			wantParts: []string{"Your traits: concise, friendly."},
-		},
-		{
-			name: "all fields",
-			persona: Persona{
-				Role:      "data scientist",
-				Goal:      "analyze data accurately",
-				Backstory: "Expert in ML and statistics.",
-				Traits:    []string{"analytical", "precise"},
-			},
-			wantParts: []string{
-				"You are a data scientist.",
-				"Your goal is to analyze data accurately.",
-				"Expert in ML and statistics.",
-				"Your traits: analytical, precise.",
-			},
-		},
-	}
+	t.Run("empty persona returns nil", func(t *testing.T) {
+		msg := (Persona{}).ToSystemMessage()
+		if msg != nil {
+			t.Fatalf("expected nil, got %v", msg)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			msg := tt.persona.ToSystemMessage()
+	t.Run("role only", func(t *testing.T) {
+		p := Persona{Role: "software engineer"}
+		msg := p.ToSystemMessage()
+		if msg == nil {
+			t.Fatal("expected non-nil SystemMessage")
+		}
+		assertPersonaMessage(t, msg, []string{"You are a software engineer."}, nil)
+	})
 
-			if tt.wantNil {
-				if msg != nil {
-					t.Fatalf("expected nil, got %v", msg)
-				}
-				return
-			}
+	t.Run("goal only", func(t *testing.T) {
+		p := Persona{Goal: "help users write clean code"}
+		msg := p.ToSystemMessage()
+		if msg == nil {
+			t.Fatal("expected non-nil SystemMessage")
+		}
+		assertPersonaMessage(t, msg, []string{"Your goal is to help users write clean code."}, nil)
+	})
 
-			if msg == nil {
-				t.Fatal("expected non-nil SystemMessage")
-			}
+	t.Run("backstory only", func(t *testing.T) {
+		p := Persona{Backstory: "You have 10 years of experience."}
+		msg := p.ToSystemMessage()
+		if msg == nil {
+			t.Fatal("expected non-nil SystemMessage")
+		}
+		assertPersonaMessage(t, msg, []string{"You have 10 years of experience."}, nil)
+	})
 
-			if msg.GetRole() != schema.RoleSystem {
-				t.Errorf("role = %s, want %s", msg.GetRole(), schema.RoleSystem)
-			}
+	t.Run("traits only", func(t *testing.T) {
+		p := Persona{Traits: []string{"concise", "friendly"}}
+		msg := p.ToSystemMessage()
+		if msg == nil {
+			t.Fatal("expected non-nil SystemMessage")
+		}
+		assertPersonaMessage(t, msg, []string{"Your traits: concise, friendly."}, nil)
+	})
 
-			text := msg.Text()
-			for _, part := range tt.wantParts {
-				if !strings.Contains(text, part) {
-					t.Errorf("text should contain %q, got:\n%s", part, text)
-				}
-			}
-			for _, part := range tt.dontWant {
-				if strings.Contains(text, part) {
-					t.Errorf("text should NOT contain %q, got:\n%s", part, text)
-				}
-			}
-		})
-	}
+	t.Run("all fields", func(t *testing.T) {
+		p := Persona{
+			Role:      "data scientist",
+			Goal:      "analyze data accurately",
+			Backstory: "Expert in ML and statistics.",
+			Traits:    []string{"analytical", "precise"},
+		}
+		msg := p.ToSystemMessage()
+		if msg == nil {
+			t.Fatal("expected non-nil SystemMessage")
+		}
+		wantParts := []string{
+			"You are a data scientist.",
+			"Your goal is to analyze data accurately.",
+			"Expert in ML and statistics.",
+			"Your traits: analytical, precise.",
+		}
+		assertPersonaMessage(t, msg, wantParts, nil)
+	})
 }
 
 func TestPersona_IsEmpty(t *testing.T) {

--- a/agent/reflection_test.go
+++ b/agent/reflection_test.go
@@ -473,7 +473,9 @@ func (m *reflexionTestLLM) Generate(ctx context.Context, msgs []schema.Message, 
 }
 
 func (m *reflexionTestLLM) Stream(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
-	return func(yield func(schema.StreamChunk, error) bool) {}
+	return func(yield func(schema.StreamChunk, error) bool) {
+		// no-op: satisfies llm.ChatModel for testing; streaming not exercised
+	}
 }
 
 func (m *reflexionTestLLM) BindTools(tools []schema.ToolDefinition) llm.ChatModel {

--- a/agent/selfdiscover_test.go
+++ b/agent/selfdiscover_test.go
@@ -114,33 +114,52 @@ func TestSelfDiscoverPlanner_Plan_ThreePhases(t *testing.T) {
 	}
 }
 
+// lastMsgText returns the text of the last message in msgs, or empty string if
+// it is not a *schema.HumanMessage.
+func lastMsgText(msgs []schema.Message) string {
+	if len(msgs) == 0 {
+		return ""
+	}
+	hm, ok := msgs[len(msgs)-1].(*schema.HumanMessage)
+	if !ok {
+		return ""
+	}
+	return hm.Text()
+}
+
+// collectModulesFromPrompt appends to dst any of the named modules whose name
+// appears in prompt, and returns the result.
+func collectModulesFromPrompt(dst []string, prompt string, names []string) []string {
+	for _, name := range names {
+		if strings.Contains(prompt, name) {
+			dst = append(dst, name)
+		}
+	}
+	return dst
+}
+
 func TestSelfDiscoverPlanner_Plan_SelectParsesModuleNames(t *testing.T) {
 	callCount := 0
 	var selectedModules []string
+	wantModules := []string{"decomposition", "critical_thinking", "abstraction"}
+
+	selectResponse := func() (*schema.AIMessage, error) {
+		return schema.NewAIMessage("1. decomposition\n- critical_thinking\nabstraction"), nil
+	}
+	adaptResponse := func(msgs []schema.Message) (*schema.AIMessage, error) {
+		prompt := lastMsgText(msgs)
+		selectedModules = collectModulesFromPrompt(selectedModules, prompt, wantModules)
+		return schema.NewAIMessage("Adapted structure"), nil
+	}
 
 	model := &testLLM{
 		generateFn: func(ctx context.Context, msgs []schema.Message) (*schema.AIMessage, error) {
 			callCount++
 			switch callCount {
 			case 1: // SELECT phase - return module names in various formats
-				return schema.NewAIMessage("1. decomposition\n- critical_thinking\nabstraction"), nil
+				return selectResponse()
 			case 2: // ADAPT phase - capture context to verify parsing
-				// Check that the selected modules are in the prompt
-				lastMsg := msgs[len(msgs)-1]
-				var prompt string
-				if hm, ok := lastMsg.(*schema.HumanMessage); ok {
-					prompt = hm.Text()
-				}
-				if strings.Contains(prompt, "decomposition") {
-					selectedModules = append(selectedModules, "decomposition")
-				}
-				if strings.Contains(prompt, "critical_thinking") {
-					selectedModules = append(selectedModules, "critical_thinking")
-				}
-				if strings.Contains(prompt, "abstraction") {
-					selectedModules = append(selectedModules, "abstraction")
-				}
-				return schema.NewAIMessage("Adapted structure"), nil
+				return adaptResponse(msgs)
 			case 3: // IMPLEMENT phase
 				return schema.NewAIMessage("Final answer"), nil
 			default:

--- a/cache/providers/inmemory/inmemory_test.go
+++ b/cache/providers/inmemory/inmemory_test.go
@@ -280,6 +280,26 @@ func TestInMemoryCache_Len(t *testing.T) {
 	}
 }
 
+func assertCachedValue(t *testing.T, c *InMemoryCache, ctx context.Context, key string, want any) {
+	t.Helper()
+	val, ok, err := c.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if want == nil {
+		if val != nil {
+			t.Errorf("Get() = %v, want nil", val)
+		}
+		return
+	}
+	if fmt.Sprintf("%v", val) != fmt.Sprintf("%v", want) {
+		t.Errorf("Get() = %v, want %v", val, want)
+	}
+}
+
 func TestInMemoryCache_DifferentValueTypes(t *testing.T) {
 	c := newTestCache(time.Minute, 100)
 	ctx := context.Background()
@@ -303,24 +323,7 @@ func TestInMemoryCache_DifferentValueTypes(t *testing.T) {
 			if err := c.Set(ctx, tt.key, tt.value, 0); err != nil {
 				t.Fatalf("Set() error = %v", err)
 			}
-			val, ok, err := c.Get(ctx, tt.key)
-			if err != nil {
-				t.Fatalf("Get() error = %v", err)
-			}
-			if !ok {
-				t.Fatal("Get() ok = false, want true")
-			}
-			// For nil, check directly.
-			if tt.value == nil {
-				if val != nil {
-					t.Errorf("Get() = %v, want nil", val)
-				}
-				return
-			}
-			// For others, use fmt comparison.
-			if fmt.Sprintf("%v", val) != fmt.Sprintf("%v", tt.value) {
-				t.Errorf("Get() = %v, want %v", val, tt.value)
-			}
+			assertCachedValue(t, c, ctx, tt.key, tt.value)
 		})
 	}
 }

--- a/cache/semantic_test.go
+++ b/cache/semantic_test.go
@@ -252,6 +252,26 @@ func TestSemanticCache_EmptyEmbedding(t *testing.T) {
 	}
 }
 
+func assertSemanticValue(t *testing.T, sc *SemanticCache, ctx context.Context, emb []float32, want any) {
+	t.Helper()
+	val, ok, err := sc.GetSemantic(ctx, emb, 0)
+	if err != nil {
+		t.Fatalf("GetSemantic() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetSemantic() ok = false, want true")
+	}
+	if want == nil {
+		if val != nil {
+			t.Errorf("GetSemantic() = %v, want nil", val)
+		}
+		return
+	}
+	if val != want {
+		t.Errorf("GetSemantic() = %v, want %v", val, want)
+	}
+}
+
 func TestSemanticCache_DifferentValueTypes(t *testing.T) {
 	mc := newMockCache()
 	sc := NewSemanticCache(mc, 0.9)
@@ -273,22 +293,7 @@ func TestSemanticCache_DifferentValueTypes(t *testing.T) {
 			if err := sc.SetSemantic(ctx, tt.embedding, tt.value); err != nil {
 				t.Fatalf("SetSemantic() error = %v", err)
 			}
-			val, ok, err := sc.GetSemantic(ctx, tt.embedding, 0)
-			if err != nil {
-				t.Fatalf("GetSemantic() error = %v", err)
-			}
-			if !ok {
-				t.Fatal("GetSemantic() ok = false, want true")
-			}
-			if tt.value == nil {
-				if val != nil {
-					t.Errorf("GetSemantic() = %v, want nil", val)
-				}
-				return
-			}
-			if val != tt.value {
-				t.Errorf("GetSemantic() = %v, want %v", val, tt.value)
-			}
+			assertSemanticValue(t, sc, ctx, tt.embedding, tt.value)
 		})
 	}
 }

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -42,6 +42,8 @@ const (
 	outputDir  = "docs/website/src/content/docs/api-reference"
 )
 
+const goCodeFence = "```go\n"
+
 func main() {
 	root, err := findModuleRoot()
 	if err != nil {
@@ -549,7 +551,7 @@ Every extensible package provides:
 ### Middleware Pattern
 
 Wrap interfaces to add cross-cutting behavior:
-` + "```go\n" + `model = llm.ApplyMiddleware(model,
+` + goCodeFence + `model = llm.ApplyMiddleware(model,
     llm.WithLogging(logger),
     llm.WithRetry(3),
 )
@@ -557,7 +559,7 @@ Wrap interfaces to add cross-cutting behavior:
 ### Hooks Pattern
 
 Inject lifecycle callbacks without middleware:
-` + "```go\n" + `hooks := llm.Hooks{
+` + goCodeFence + `hooks := llm.Hooks{
     BeforeGenerate: func(ctx, msgs) error { ... },
     AfterGenerate:  func(ctx, resp, err) { ... },
 }
@@ -566,7 +568,7 @@ model = llm.WithHooks(model, hooks)
 ### Streaming Pattern
 
 All streaming uses Go 1.23+ ` + "`iter.Seq2`" + `:
-` + "```go\n" + `for chunk, err := range model.Stream(ctx, msgs) {
+` + goCodeFence + `for chunk, err := range model.Stream(ctx, msgs) {
     if err != nil { break }
     fmt.Print(chunk.Delta)
 }

--- a/config/watch_test.go
+++ b/config/watch_test.go
@@ -128,7 +128,9 @@ func TestFileWatcher_Watch_NoChangeNoCallback(t *testing.T) {
 
 func TestFileWatcher_Watch_FileNotFound(t *testing.T) {
 	w := NewFileWatcher("/nonexistent/path/config.json", 100*time.Millisecond)
-	err := w.Watch(context.Background(), func(newConfig any) {})
+	err := w.Watch(context.Background(), func(newConfig any) {
+		// no-op: file not found, callback never invoked
+	})
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -148,7 +150,9 @@ func TestFileWatcher_Watch_ContextCancellation(t *testing.T) {
 
 	watchDone := make(chan error, 1)
 	go func() {
-		watchDone <- w.Watch(ctx, func(newConfig any) {})
+		watchDone <- w.Watch(ctx, func(newConfig any) {
+			// no-op: context cancelled before any config change occurs
+		})
 	}()
 
 	// Let Watch start up.
@@ -177,7 +181,9 @@ func TestFileWatcher_Close(t *testing.T) {
 
 	watchDone := make(chan error, 1)
 	go func() {
-		watchDone <- w.Watch(context.Background(), func(newConfig any) {})
+		watchDone <- w.Watch(context.Background(), func(newConfig any) {
+			// no-op: watcher closed before any config change occurs
+		})
 	}()
 
 	// Let Watch start.

--- a/core/option_test.go
+++ b/core/option_test.go
@@ -73,91 +73,102 @@ func TestOptionFunc_ImplementsOption(t *testing.T) {
 	})
 }
 
-func TestApplyOptions(t *testing.T) {
-	t.Run("multiple_options", func(t *testing.T) {
-		opts := []Option{
-			OptionFunc(func(target any) {
-				cfg := target.(*testConfig)
-				cfg.Name = "applied"
-			}),
-			OptionFunc(func(target any) {
-				cfg := target.(*testConfig)
-				cfg.Value = 99
-			}),
-			OptionFunc(func(target any) {
-				cfg := target.(*testConfig)
-				cfg.Enabled = true
-			}),
-		}
-
-		cfg := testConfig{}
-		ApplyOptions(&cfg, opts...)
-
-		if cfg.Name != "applied" {
-			t.Errorf("Name = %q, want %q", cfg.Name, "applied")
-		}
-		if cfg.Value != 99 {
-			t.Errorf("Value = %d, want 99", cfg.Value)
-		}
-		if !cfg.Enabled {
-			t.Error("Enabled = false, want true")
-		}
-	})
-
-	t.Run("no_options", func(t *testing.T) {
-		cfg := testConfig{Name: "unchanged", Value: 7, Enabled: true}
-		ApplyOptions(&cfg)
-
-		if cfg.Name != "unchanged" {
-			t.Errorf("Name = %q, want %q", cfg.Name, "unchanged")
-		}
-		if cfg.Value != 7 {
-			t.Errorf("Value = %d, want 7", cfg.Value)
-		}
-		if !cfg.Enabled {
-			t.Error("Enabled = false, want true")
-		}
-	})
-
-	t.Run("order_matters", func(t *testing.T) {
-		opts := []Option{
-			OptionFunc(func(target any) {
-				cfg := target.(*testConfig)
-				cfg.Name = "first"
-			}),
-			OptionFunc(func(target any) {
-				cfg := target.(*testConfig)
-				cfg.Name = "second"
-			}),
-		}
-
-		cfg := testConfig{}
-		ApplyOptions(&cfg, opts...)
-
-		if cfg.Name != "second" {
-			t.Errorf("Name = %q, want %q (last option wins)", cfg.Name, "second")
-		}
-	})
-
-	t.Run("nil_target_no_panic_with_nil_safe_option", func(t *testing.T) {
-		// An option that doesn't dereference target should work with nil.
-		opt := OptionFunc(func(_ any) {
-			// no-op
-		})
-		ApplyOptions(nil, opt)
-	})
-
-	t.Run("single_option", func(t *testing.T) {
-		cfg := testConfig{}
-		ApplyOptions(&cfg, OptionFunc(func(target any) {
+func testApplyOptionsMultipleOptions(t *testing.T) {
+	t.Helper()
+	opts := []Option{
+		OptionFunc(func(target any) {
 			cfg := target.(*testConfig)
-			cfg.Value = 1
-		}))
+			cfg.Name = "applied"
+		}),
+		OptionFunc(func(target any) {
+			cfg := target.(*testConfig)
+			cfg.Value = 99
+		}),
+		OptionFunc(func(target any) {
+			cfg := target.(*testConfig)
+			cfg.Enabled = true
+		}),
+	}
 
-		if cfg.Value != 1 {
-			t.Errorf("Value = %d, want 1", cfg.Value)
-		}
+	cfg := testConfig{}
+	ApplyOptions(&cfg, opts...)
+
+	if cfg.Name != "applied" {
+		t.Errorf("Name = %q, want %q", cfg.Name, "applied")
+	}
+	if cfg.Value != 99 {
+		t.Errorf("Value = %d, want 99", cfg.Value)
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+}
+
+func testApplyOptionsNoOptions(t *testing.T) {
+	t.Helper()
+	cfg := testConfig{Name: "unchanged", Value: 7, Enabled: true}
+	ApplyOptions(&cfg)
+
+	if cfg.Name != "unchanged" {
+		t.Errorf("Name = %q, want %q", cfg.Name, "unchanged")
+	}
+	if cfg.Value != 7 {
+		t.Errorf("Value = %d, want 7", cfg.Value)
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+}
+
+func testApplyOptionsOrderMatters(t *testing.T) {
+	t.Helper()
+	opts := []Option{
+		OptionFunc(func(target any) {
+			cfg := target.(*testConfig)
+			cfg.Name = "first"
+		}),
+		OptionFunc(func(target any) {
+			cfg := target.(*testConfig)
+			cfg.Name = "second"
+		}),
+	}
+
+	cfg := testConfig{}
+	ApplyOptions(&cfg, opts...)
+
+	if cfg.Name != "second" {
+		t.Errorf("Name = %q, want %q (last option wins)", cfg.Name, "second")
+	}
+}
+
+func testApplyOptionsNilTargetNoParicWithNilSafeOption(t *testing.T) {
+	t.Helper()
+	// An option that doesn't dereference target should work with nil.
+	opt := OptionFunc(func(_ any) {
+		// no-op
 	})
+	ApplyOptions(nil, opt)
+}
+
+func testApplyOptionsSingleOption(t *testing.T) {
+	t.Helper()
+	cfg := testConfig{}
+	ApplyOptions(&cfg, OptionFunc(func(target any) {
+		cfg := target.(*testConfig)
+		cfg.Value = 1
+	}))
+
+	if cfg.Value != 1 {
+		t.Errorf("Value = %d, want 1", cfg.Value)
+	}
+}
+
+func TestApplyOptions(t *testing.T) {
+	t.Run("multiple_options", testApplyOptionsMultipleOptions)
+	t.Run("no_options", testApplyOptionsNoOptions)
+	t.Run("order_matters", testApplyOptionsOrderMatters)
+	t.Run("nil_target_no_panic_with_nil_safe_option", testApplyOptionsNilTargetNoParicWithNilSafeOption)
+	t.Run("single_option", testApplyOptionsSingleOption)
 }
 
 func TestApplyOptions_Empty_Slice(t *testing.T) {

--- a/core/option_test.go
+++ b/core/option_test.go
@@ -69,7 +69,8 @@ func TestOptionFunc_Apply(t *testing.T) {
 
 func TestOptionFunc_ImplementsOption(t *testing.T) {
 	// Verify OptionFunc satisfies the Option interface at compile time.
-	var _ Option = OptionFunc(func(_ any) {})
+	var _ Option = OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
+	})
 }
 
 func TestApplyOptions(t *testing.T) {

--- a/core/option_test.go
+++ b/core/option_test.go
@@ -74,7 +74,6 @@ func TestOptionFunc_ImplementsOption(t *testing.T) {
 }
 
 func testApplyOptionsMultipleOptions(t *testing.T) {
-	t.Helper()
 	opts := []Option{
 		OptionFunc(func(target any) {
 			cfg := target.(*testConfig)
@@ -105,7 +104,6 @@ func testApplyOptionsMultipleOptions(t *testing.T) {
 }
 
 func testApplyOptionsNoOptions(t *testing.T) {
-	t.Helper()
 	cfg := testConfig{Name: "unchanged", Value: 7, Enabled: true}
 	ApplyOptions(&cfg)
 
@@ -121,7 +119,6 @@ func testApplyOptionsNoOptions(t *testing.T) {
 }
 
 func testApplyOptionsOrderMatters(t *testing.T) {
-	t.Helper()
 	opts := []Option{
 		OptionFunc(func(target any) {
 			cfg := target.(*testConfig)
@@ -142,7 +139,6 @@ func testApplyOptionsOrderMatters(t *testing.T) {
 }
 
 func testApplyOptionsNilTargetNoParicWithNilSafeOption(t *testing.T) {
-	t.Helper()
 	// An option that doesn't dereference target should work with nil.
 	opt := OptionFunc(func(_ any) {
 		// no-op
@@ -151,7 +147,6 @@ func testApplyOptionsNilTargetNoParicWithNilSafeOption(t *testing.T) {
 }
 
 func testApplyOptionsSingleOption(t *testing.T) {
-	t.Helper()
 	cfg := testConfig{}
 	ApplyOptions(&cfg, OptionFunc(func(target any) {
 		cfg := target.(*testConfig)

--- a/core/runnable_test.go
+++ b/core/runnable_test.go
@@ -57,7 +57,8 @@ func errorRunnable(err error) *mockRunnable {
 	}
 }
 
-func TestPipe_Invoke(t *testing.T) {
+func testPipeInvokeTableCases(t *testing.T) {
+	t.Helper()
 	tests := []struct {
 		name    string
 		a       Runnable
@@ -131,6 +132,10 @@ func TestPipe_Invoke(t *testing.T) {
 	}
 }
 
+func TestPipe_Invoke(t *testing.T) {
+	testPipeInvokeTableCases(t)
+}
+
 func TestPipe_Invoke_OptionsPassthrough(t *testing.T) {
 	var aOpts, bOpts []Option
 
@@ -187,117 +192,126 @@ func TestPipe_Invoke_ContextCancellation(t *testing.T) {
 	}
 }
 
-func TestPipe_Stream(t *testing.T) {
-	t.Run("streams_from_second", func(t *testing.T) {
-		a := transformRunnable("-A")
-		b := &mockRunnable{
-			streamFunc: func(_ context.Context, input any, _ ...Option) iter.Seq2[any, error] {
-				return func(yield func(any, error) bool) {
-					yield(fmt.Sprintf("%v-1", input), nil)
-					yield(fmt.Sprintf("%v-2", input), nil)
-				}
-			},
-		}
-
-		p := Pipe(a, b)
-		var results []any
-		for val, err := range p.Stream(context.Background(), "start") {
-			if err != nil {
-				t.Fatalf("Stream() unexpected error: %v", err)
+func testPipeStreamFromSecond(t *testing.T) {
+	t.Helper()
+	a := transformRunnable("-A")
+	b := &mockRunnable{
+		streamFunc: func(_ context.Context, input any, _ ...Option) iter.Seq2[any, error] {
+			return func(yield func(any, error) bool) {
+				yield(fmt.Sprintf("%v-1", input), nil)
+				yield(fmt.Sprintf("%v-2", input), nil)
 			}
-			results = append(results, val)
-		}
+		},
+	}
 
-		if len(results) != 2 {
-			t.Fatalf("len(results) = %d, want 2", len(results))
+	p := Pipe(a, b)
+	var results []any
+	for val, err := range p.Stream(context.Background(), "start") {
+		if err != nil {
+			t.Fatalf("Stream() unexpected error: %v", err)
 		}
-		if results[0] != "start-A-1" {
-			t.Errorf("results[0] = %v, want %q", results[0], "start-A-1")
-		}
-		if results[1] != "start-A-2" {
-			t.Errorf("results[1] = %v, want %q", results[1], "start-A-2")
-		}
-	})
+		results = append(results, val)
+	}
 
-	t.Run("first_invoke_error_yields_error", func(t *testing.T) {
-		a := errorRunnable(fmt.Errorf("a failed"))
-		b := transformRunnable("-B")
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0] != "start-A-1" {
+		t.Errorf("results[0] = %v, want %q", results[0], "start-A-1")
+	}
+	if results[1] != "start-A-2" {
+		t.Errorf("results[1] = %v, want %q", results[1], "start-A-2")
+	}
+}
 
-		p := Pipe(a, b)
-		var gotErr error
-		for _, err := range p.Stream(context.Background(), "x") {
-			if err != nil {
-				gotErr = err
-				break
+func testPipeStreamFirstInvokeError(t *testing.T) {
+	t.Helper()
+	a := errorRunnable(fmt.Errorf("a failed"))
+	b := transformRunnable("-B")
+
+	p := Pipe(a, b)
+	var gotErr error
+	for _, err := range p.Stream(context.Background(), "x") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("Stream() expected error from first runnable, got nil")
+	}
+	if gotErr.Error() != "a failed" {
+		t.Errorf("error = %q, want %q", gotErr.Error(), "a failed")
+	}
+}
+
+func testPipeStreamSecondStreamError(t *testing.T) {
+	t.Helper()
+	a := &mockRunnable{}
+	b := &mockRunnable{
+		streamFunc: func(_ context.Context, _ any, _ ...Option) iter.Seq2[any, error] {
+			return func(yield func(any, error) bool) {
+				yield("ok", nil)
+				yield(nil, fmt.Errorf("stream err"))
 			}
-		}
-		if gotErr == nil {
-			t.Fatal("Stream() expected error from first runnable, got nil")
-		}
-		if gotErr.Error() != "a failed" {
-			t.Errorf("error = %q, want %q", gotErr.Error(), "a failed")
-		}
-	})
+		},
+	}
 
-	t.Run("second_stream_error", func(t *testing.T) {
-		a := &mockRunnable{}
-		b := &mockRunnable{
-			streamFunc: func(_ context.Context, _ any, _ ...Option) iter.Seq2[any, error] {
-				return func(yield func(any, error) bool) {
-					yield("ok", nil)
-					yield(nil, fmt.Errorf("stream err"))
-				}
-			},
+	p := Pipe(a, b)
+	var vals []any
+	var gotErr error
+	for val, err := range p.Stream(context.Background(), "in") {
+		if err != nil {
+			gotErr = err
+			break
 		}
+		vals = append(vals, val)
+	}
 
-		p := Pipe(a, b)
-		var vals []any
-		var gotErr error
-		for val, err := range p.Stream(context.Background(), "in") {
-			if err != nil {
-				gotErr = err
-				break
-			}
-			vals = append(vals, val)
-		}
+	if len(vals) != 1 {
+		t.Errorf("received %d values before error, want 1", len(vals))
+	}
+	if gotErr == nil || gotErr.Error() != "stream err" {
+		t.Errorf("error = %v, want %q", gotErr, "stream err")
+	}
+}
 
-		if len(vals) != 1 {
-			t.Errorf("received %d values before error, want 1", len(vals))
-		}
-		if gotErr == nil || gotErr.Error() != "stream err" {
-			t.Errorf("error = %v, want %q", gotErr, "stream err")
-		}
-	})
-
-	t.Run("early_break_stops_stream", func(t *testing.T) {
-		count := 0
-		a := &mockRunnable{}
-		b := &mockRunnable{
-			streamFunc: func(_ context.Context, _ any, _ ...Option) iter.Seq2[any, error] {
-				return func(yield func(any, error) bool) {
-					for i := 0; i < 100; i++ {
-						count++
-						if !yield(i, nil) {
-							return
-						}
+func testPipeStreamEarlyBreak(t *testing.T) {
+	t.Helper()
+	count := 0
+	a := &mockRunnable{}
+	b := &mockRunnable{
+		streamFunc: func(_ context.Context, _ any, _ ...Option) iter.Seq2[any, error] {
+			return func(yield func(any, error) bool) {
+				for i := 0; i < 100; i++ {
+					count++
+					if !yield(i, nil) {
+						return
 					}
 				}
-			},
-		}
-
-		p := Pipe(a, b)
-		for _, err := range p.Stream(context.Background(), "in") {
-			if err != nil {
-				break
 			}
-			break // Stop after first value.
-		}
+		},
+	}
 
-		// The stream should have stopped early.
-		if count >= 100 {
-			t.Errorf("stream produced %d values, expected early stop", count)
+	p := Pipe(a, b)
+	for _, err := range p.Stream(context.Background(), "in") {
+		if err != nil {
+			break
 		}
-	})
+		break // Stop after first value.
+	}
+
+	// The stream should have stopped early.
+	if count >= 100 {
+		t.Errorf("stream produced %d values, expected early stop", count)
+	}
+}
+
+func TestPipe_Stream(t *testing.T) {
+	t.Run("streams_from_second", testPipeStreamFromSecond)
+	t.Run("first_invoke_error_yields_error", testPipeStreamFirstInvokeError)
+	t.Run("second_stream_error", testPipeStreamSecondStreamError)
+	t.Run("early_break_stops_stream", testPipeStreamEarlyBreak)
 }
 
 func TestPipe_Chaining(t *testing.T) {
@@ -316,130 +330,145 @@ func TestPipe_Chaining(t *testing.T) {
 	}
 }
 
+func testParallelInvokeAllSucceed(t *testing.T) {
+	t.Helper()
+	r1 := transformRunnable("-1")
+	r2 := transformRunnable("-2")
+	r3 := transformRunnable("-3")
+
+	p := Parallel(r1, r2, r3)
+	got, err := p.Invoke(context.Background(), "in")
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+
+	results, ok := got.([]any)
+	if !ok {
+		t.Fatalf("Invoke() result type = %T, want []any", got)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	if results[0] != "in-1" {
+		t.Errorf("results[0] = %v, want %q", results[0], "in-1")
+	}
+	if results[1] != "in-2" {
+		t.Errorf("results[1] = %v, want %q", results[1], "in-2")
+	}
+	if results[2] != "in-3" {
+		t.Errorf("results[2] = %v, want %q", results[2], "in-3")
+	}
+}
+
+func testParallelInvokeOneError(t *testing.T) {
+	t.Helper()
+	r1 := transformRunnable("-ok")
+	r2 := errorRunnable(fmt.Errorf("r2 failed"))
+	r3 := transformRunnable("-ok")
+
+	p := Parallel(r1, r2, r3)
+	_, err := p.Invoke(context.Background(), "in")
+	if err == nil {
+		t.Fatal("Invoke() expected error, got nil")
+	}
+	if err.Error() != "r2 failed" {
+		t.Errorf("error = %q, want %q", err.Error(), "r2 failed")
+	}
+}
+
+func testParallelInvokeAllErrors(t *testing.T) {
+	t.Helper()
+	r1 := errorRunnable(fmt.Errorf("err1"))
+	r2 := errorRunnable(fmt.Errorf("err2"))
+
+	p := Parallel(r1, r2)
+	_, err := p.Invoke(context.Background(), "in")
+	if err == nil {
+		t.Fatal("Invoke() expected error, got nil")
+	}
+	// Should return the first error in order.
+	if err.Error() != "err1" {
+		t.Errorf("error = %q, want %q", err.Error(), "err1")
+	}
+}
+
+func testParallelInvokeNoRunnables(t *testing.T) {
+	t.Helper()
+	p := Parallel()
+	got, err := p.Invoke(context.Background(), "in")
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	results, ok := got.([]any)
+	if !ok {
+		t.Fatalf("result type = %T, want []any", got)
+	}
+	if len(results) != 0 {
+		t.Errorf("len(results) = %d, want 0", len(results))
+	}
+}
+
+func testParallelInvokeSingleRunnable(t *testing.T) {
+	t.Helper()
+	r := transformRunnable("-solo")
+	p := Parallel(r)
+	got, err := p.Invoke(context.Background(), "in")
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	results := got.([]any)
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0] != "in-solo" {
+		t.Errorf("results[0] = %v, want %q", results[0], "in-solo")
+	}
+}
+
+func testParallelInvokeNilInput(t *testing.T) {
+	t.Helper()
+	r := &mockRunnable{}
+	p := Parallel(r)
+	got, err := p.Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	results := got.([]any)
+	if results[0] != nil {
+		t.Errorf("results[0] = %v, want nil", results[0])
+	}
+}
+
+func testParallelInvokeOptionsPassthrough(t *testing.T) {
+	t.Helper()
+	var received []Option
+	r := &mockRunnable{
+		invokeFunc: func(_ context.Context, input any, opts ...Option) (any, error) {
+			received = opts
+			return input, nil
+		},
+	}
+
+	opt := OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
+	})
+	p := Parallel(r)
+	_, err := p.Invoke(context.Background(), "in", opt)
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if len(received) != 1 {
+		t.Errorf("runnable received %d opts, want 1", len(received))
+	}
+}
+
 func TestParallel_Invoke(t *testing.T) {
-	t.Run("all_succeed", func(t *testing.T) {
-		r1 := transformRunnable("-1")
-		r2 := transformRunnable("-2")
-		r3 := transformRunnable("-3")
-
-		p := Parallel(r1, r2, r3)
-		got, err := p.Invoke(context.Background(), "in")
-		if err != nil {
-			t.Fatalf("Invoke() error = %v", err)
-		}
-
-		results, ok := got.([]any)
-		if !ok {
-			t.Fatalf("Invoke() result type = %T, want []any", got)
-		}
-		if len(results) != 3 {
-			t.Fatalf("len(results) = %d, want 3", len(results))
-		}
-		if results[0] != "in-1" {
-			t.Errorf("results[0] = %v, want %q", results[0], "in-1")
-		}
-		if results[1] != "in-2" {
-			t.Errorf("results[1] = %v, want %q", results[1], "in-2")
-		}
-		if results[2] != "in-3" {
-			t.Errorf("results[2] = %v, want %q", results[2], "in-3")
-		}
-	})
-
-	t.Run("one_error_returns_error", func(t *testing.T) {
-		r1 := transformRunnable("-ok")
-		r2 := errorRunnable(fmt.Errorf("r2 failed"))
-		r3 := transformRunnable("-ok")
-
-		p := Parallel(r1, r2, r3)
-		_, err := p.Invoke(context.Background(), "in")
-		if err == nil {
-			t.Fatal("Invoke() expected error, got nil")
-		}
-		if err.Error() != "r2 failed" {
-			t.Errorf("error = %q, want %q", err.Error(), "r2 failed")
-		}
-	})
-
-	t.Run("all_errors_returns_first", func(t *testing.T) {
-		r1 := errorRunnable(fmt.Errorf("err1"))
-		r2 := errorRunnable(fmt.Errorf("err2"))
-
-		p := Parallel(r1, r2)
-		_, err := p.Invoke(context.Background(), "in")
-		if err == nil {
-			t.Fatal("Invoke() expected error, got nil")
-		}
-		// Should return the first error in order.
-		if err.Error() != "err1" {
-			t.Errorf("error = %q, want %q", err.Error(), "err1")
-		}
-	})
-
-	t.Run("no_runnables", func(t *testing.T) {
-		p := Parallel()
-		got, err := p.Invoke(context.Background(), "in")
-		if err != nil {
-			t.Fatalf("Invoke() error = %v", err)
-		}
-		results, ok := got.([]any)
-		if !ok {
-			t.Fatalf("result type = %T, want []any", got)
-		}
-		if len(results) != 0 {
-			t.Errorf("len(results) = %d, want 0", len(results))
-		}
-	})
-
-	t.Run("single_runnable", func(t *testing.T) {
-		r := transformRunnable("-solo")
-		p := Parallel(r)
-		got, err := p.Invoke(context.Background(), "in")
-		if err != nil {
-			t.Fatalf("Invoke() error = %v", err)
-		}
-		results := got.([]any)
-		if len(results) != 1 {
-			t.Fatalf("len(results) = %d, want 1", len(results))
-		}
-		if results[0] != "in-solo" {
-			t.Errorf("results[0] = %v, want %q", results[0], "in-solo")
-		}
-	})
-
-	t.Run("nil_input", func(t *testing.T) {
-		r := &mockRunnable{}
-		p := Parallel(r)
-		got, err := p.Invoke(context.Background(), nil)
-		if err != nil {
-			t.Fatalf("Invoke() error = %v", err)
-		}
-		results := got.([]any)
-		if results[0] != nil {
-			t.Errorf("results[0] = %v, want nil", results[0])
-		}
-	})
-
-	t.Run("options_passthrough", func(t *testing.T) {
-		var received []Option
-		r := &mockRunnable{
-			invokeFunc: func(_ context.Context, input any, opts ...Option) (any, error) {
-				received = opts
-				return input, nil
-			},
-		}
-
-		opt := OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
-		})
-		p := Parallel(r)
-		_, err := p.Invoke(context.Background(), "in", opt)
-		if err != nil {
-			t.Fatalf("Invoke() error = %v", err)
-		}
-		if len(received) != 1 {
-			t.Errorf("runnable received %d opts, want 1", len(received))
-		}
-	})
+	t.Run("all_succeed", testParallelInvokeAllSucceed)
+	t.Run("one_error_returns_error", testParallelInvokeOneError)
+	t.Run("all_errors_returns_first", testParallelInvokeAllErrors)
+	t.Run("no_runnables", testParallelInvokeNoRunnables)
+	t.Run("single_runnable", testParallelInvokeSingleRunnable)
+	t.Run("nil_input", testParallelInvokeNilInput)
+	t.Run("options_passthrough", testParallelInvokeOptionsPassthrough)
 }
 
 func TestParallel_Invoke_ContextCancellation(t *testing.T) {
@@ -462,60 +491,65 @@ func TestParallel_Invoke_ContextCancellation(t *testing.T) {
 	}
 }
 
+func testParallelStreamYieldsResultSlice(t *testing.T) {
+	t.Helper()
+	r1 := transformRunnable("-1")
+	r2 := transformRunnable("-2")
+
+	p := Parallel(r1, r2)
+	var results []any
+	var gotErr error
+	for val, err := range p.Stream(context.Background(), "in") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		results = append(results, val)
+	}
+
+	if gotErr != nil {
+		t.Fatalf("Stream() error = %v", gotErr)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Stream yielded %d values, want 1", len(results))
+	}
+
+	slice, ok := results[0].([]any)
+	if !ok {
+		t.Fatalf("result type = %T, want []any", results[0])
+	}
+	if len(slice) != 2 {
+		t.Fatalf("len(slice) = %d, want 2", len(slice))
+	}
+	if slice[0] != "in-1" {
+		t.Errorf("slice[0] = %v, want %q", slice[0], "in-1")
+	}
+	if slice[1] != "in-2" {
+		t.Errorf("slice[1] = %v, want %q", slice[1], "in-2")
+	}
+}
+
+func testParallelStreamErrorPropagates(t *testing.T) {
+	t.Helper()
+	r1 := transformRunnable("-ok")
+	r2 := errorRunnable(fmt.Errorf("parallel err"))
+
+	p := Parallel(r1, r2)
+	var gotErr error
+	for _, err := range p.Stream(context.Background(), "in") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	if gotErr == nil || gotErr.Error() != "parallel err" {
+		t.Errorf("error = %v, want %q", gotErr, "parallel err")
+	}
+}
+
 func TestParallel_Stream(t *testing.T) {
-	t.Run("yields_result_slice", func(t *testing.T) {
-		r1 := transformRunnable("-1")
-		r2 := transformRunnable("-2")
-
-		p := Parallel(r1, r2)
-		var results []any
-		var gotErr error
-		for val, err := range p.Stream(context.Background(), "in") {
-			if err != nil {
-				gotErr = err
-				break
-			}
-			results = append(results, val)
-		}
-
-		if gotErr != nil {
-			t.Fatalf("Stream() error = %v", gotErr)
-		}
-		if len(results) != 1 {
-			t.Fatalf("Stream yielded %d values, want 1", len(results))
-		}
-
-		slice, ok := results[0].([]any)
-		if !ok {
-			t.Fatalf("result type = %T, want []any", results[0])
-		}
-		if len(slice) != 2 {
-			t.Fatalf("len(slice) = %d, want 2", len(slice))
-		}
-		if slice[0] != "in-1" {
-			t.Errorf("slice[0] = %v, want %q", slice[0], "in-1")
-		}
-		if slice[1] != "in-2" {
-			t.Errorf("slice[1] = %v, want %q", slice[1], "in-2")
-		}
-	})
-
-	t.Run("error_propagates", func(t *testing.T) {
-		r1 := transformRunnable("-ok")
-		r2 := errorRunnable(fmt.Errorf("parallel err"))
-
-		p := Parallel(r1, r2)
-		var gotErr error
-		for _, err := range p.Stream(context.Background(), "in") {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		if gotErr == nil || gotErr.Error() != "parallel err" {
-			t.Errorf("error = %v, want %q", gotErr, "parallel err")
-		}
-	})
+	t.Run("yields_result_slice", testParallelStreamYieldsResultSlice)
+	t.Run("error_propagates", testParallelStreamErrorPropagates)
 }
 
 func TestParallel_Concurrent_Execution(t *testing.T) {

--- a/core/runnable_test.go
+++ b/core/runnable_test.go
@@ -147,8 +147,10 @@ func TestPipe_Invoke_OptionsPassthrough(t *testing.T) {
 		},
 	}
 
-	opt1 := OptionFunc(func(_ any) {})
-	opt2 := OptionFunc(func(_ any) {})
+	opt1 := OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
+	})
+	opt2 := OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
+	})
 
 	p := Pipe(a, b)
 	_, err := p.Invoke(context.Background(), "test", opt1, opt2)
@@ -427,7 +429,8 @@ func TestParallel_Invoke(t *testing.T) {
 			},
 		}
 
-		opt := OptionFunc(func(_ any) {})
+		opt := OptionFunc(func(_ any) { // no-op: tests option passthrough, not behavior
+		})
 		p := Parallel(r)
 		_, err := p.Invoke(context.Background(), "in", opt)
 		if err != nil {

--- a/core/runnable_test.go
+++ b/core/runnable_test.go
@@ -193,7 +193,6 @@ func TestPipe_Invoke_ContextCancellation(t *testing.T) {
 }
 
 func testPipeStreamFromSecond(t *testing.T) {
-	t.Helper()
 	a := transformRunnable("-A")
 	b := &mockRunnable{
 		streamFunc: func(_ context.Context, input any, _ ...Option) iter.Seq2[any, error] {
@@ -225,7 +224,6 @@ func testPipeStreamFromSecond(t *testing.T) {
 }
 
 func testPipeStreamFirstInvokeError(t *testing.T) {
-	t.Helper()
 	a := errorRunnable(fmt.Errorf("a failed"))
 	b := transformRunnable("-B")
 
@@ -246,7 +244,6 @@ func testPipeStreamFirstInvokeError(t *testing.T) {
 }
 
 func testPipeStreamSecondStreamError(t *testing.T) {
-	t.Helper()
 	a := &mockRunnable{}
 	b := &mockRunnable{
 		streamFunc: func(_ context.Context, _ any, _ ...Option) iter.Seq2[any, error] {
@@ -277,7 +274,6 @@ func testPipeStreamSecondStreamError(t *testing.T) {
 }
 
 func testPipeStreamEarlyBreak(t *testing.T) {
-	t.Helper()
 	count := 0
 	a := &mockRunnable{}
 	b := &mockRunnable{
@@ -331,7 +327,6 @@ func TestPipe_Chaining(t *testing.T) {
 }
 
 func testParallelInvokeAllSucceed(t *testing.T) {
-	t.Helper()
 	r1 := transformRunnable("-1")
 	r2 := transformRunnable("-2")
 	r3 := transformRunnable("-3")
@@ -361,7 +356,6 @@ func testParallelInvokeAllSucceed(t *testing.T) {
 }
 
 func testParallelInvokeOneError(t *testing.T) {
-	t.Helper()
 	r1 := transformRunnable("-ok")
 	r2 := errorRunnable(fmt.Errorf("r2 failed"))
 	r3 := transformRunnable("-ok")
@@ -377,7 +371,6 @@ func testParallelInvokeOneError(t *testing.T) {
 }
 
 func testParallelInvokeAllErrors(t *testing.T) {
-	t.Helper()
 	r1 := errorRunnable(fmt.Errorf("err1"))
 	r2 := errorRunnable(fmt.Errorf("err2"))
 
@@ -393,7 +386,6 @@ func testParallelInvokeAllErrors(t *testing.T) {
 }
 
 func testParallelInvokeNoRunnables(t *testing.T) {
-	t.Helper()
 	p := Parallel()
 	got, err := p.Invoke(context.Background(), "in")
 	if err != nil {
@@ -409,7 +401,6 @@ func testParallelInvokeNoRunnables(t *testing.T) {
 }
 
 func testParallelInvokeSingleRunnable(t *testing.T) {
-	t.Helper()
 	r := transformRunnable("-solo")
 	p := Parallel(r)
 	got, err := p.Invoke(context.Background(), "in")
@@ -426,7 +417,6 @@ func testParallelInvokeSingleRunnable(t *testing.T) {
 }
 
 func testParallelInvokeNilInput(t *testing.T) {
-	t.Helper()
 	r := &mockRunnable{}
 	p := Parallel(r)
 	got, err := p.Invoke(context.Background(), nil)
@@ -440,7 +430,6 @@ func testParallelInvokeNilInput(t *testing.T) {
 }
 
 func testParallelInvokeOptionsPassthrough(t *testing.T) {
-	t.Helper()
 	var received []Option
 	r := &mockRunnable{
 		invokeFunc: func(_ context.Context, input any, opts ...Option) (any, error) {
@@ -492,7 +481,6 @@ func TestParallel_Invoke_ContextCancellation(t *testing.T) {
 }
 
 func testParallelStreamYieldsResultSlice(t *testing.T) {
-	t.Helper()
 	r1 := transformRunnable("-1")
 	r2 := transformRunnable("-2")
 
@@ -530,7 +518,6 @@ func testParallelStreamYieldsResultSlice(t *testing.T) {
 }
 
 func testParallelStreamErrorPropagates(t *testing.T) {
-	t.Helper()
 	r1 := transformRunnable("-ok")
 	r2 := errorRunnable(fmt.Errorf("parallel err"))
 

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -29,131 +29,145 @@ func makeErrorStream[T any](events []Event[T], err error) Stream[T] {
 	}
 }
 
+func testCollectStreamEmpty(t *testing.T) {
+	t.Helper()
+	stream := makeStream[string](nil)
+	events, err := CollectStream(stream)
+	if err != nil {
+		t.Fatalf("CollectStream() error = %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("len(events) = %d, want 0", len(events))
+	}
+}
+
+func testCollectStreamMultipleEvents(t *testing.T) {
+	t.Helper()
+	input := []Event[string]{
+		{Type: EventData, Payload: "hello"},
+		{Type: EventData, Payload: "world"},
+		{Type: EventDone, Payload: ""},
+	}
+	stream := makeStream(input)
+	events, err := CollectStream(stream)
+	if err != nil {
+		t.Fatalf("CollectStream() error = %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want 3", len(events))
+	}
+	if events[0].Payload != "hello" {
+		t.Errorf("events[0].Payload = %q, want %q", events[0].Payload, "hello")
+	}
+	if events[1].Payload != "world" {
+		t.Errorf("events[1].Payload = %q, want %q", events[1].Payload, "world")
+	}
+}
+
+func testCollectStreamStopsOnError(t *testing.T) {
+	t.Helper()
+	input := []Event[string]{
+		{Type: EventData, Payload: "ok"},
+	}
+	stream := makeErrorStream(input, fmt.Errorf("stream failed"))
+	events, err := CollectStream(stream)
+	if err == nil {
+		t.Fatal("CollectStream() expected error, got nil")
+	}
+	if err.Error() != "stream failed" {
+		t.Errorf("error = %q, want %q", err.Error(), "stream failed")
+	}
+	if len(events) != 1 {
+		t.Errorf("len(events) = %d, want 1 (events before error)", len(events))
+	}
+}
+
 func TestCollectStream(t *testing.T) {
-	t.Run("empty_stream", func(t *testing.T) {
-		stream := makeStream[string](nil)
-		events, err := CollectStream(stream)
-		if err != nil {
-			t.Fatalf("CollectStream() error = %v", err)
-		}
-		if len(events) != 0 {
-			t.Errorf("len(events) = %d, want 0", len(events))
-		}
+	t.Run("empty_stream", testCollectStreamEmpty)
+	t.Run("multiple_events", testCollectStreamMultipleEvents)
+	t.Run("stops_on_error", testCollectStreamStopsOnError)
+}
+
+func testMapStreamTransformPayload(t *testing.T) {
+	t.Helper()
+	input := []Event[int]{
+		{Type: EventData, Payload: 1},
+		{Type: EventData, Payload: 2},
+		{Type: EventData, Payload: 3},
+	}
+	stream := makeStream(input)
+
+	mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
+		return Event[string]{
+			Type:    e.Type,
+			Payload: fmt.Sprintf("num-%d", e.Payload),
+		}, nil
 	})
 
-	t.Run("multiple_events", func(t *testing.T) {
-		input := []Event[string]{
-			{Type: EventData, Payload: "hello"},
-			{Type: EventData, Payload: "world"},
-			{Type: EventDone, Payload: ""},
+	events, err := CollectStream(mapped)
+	if err != nil {
+		t.Fatalf("CollectStream() error = %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want 3", len(events))
+	}
+	if events[0].Payload != "num-1" {
+		t.Errorf("events[0].Payload = %q, want %q", events[0].Payload, "num-1")
+	}
+	if events[2].Payload != "num-3" {
+		t.Errorf("events[2].Payload = %q, want %q", events[2].Payload, "num-3")
+	}
+}
+
+func testMapStreamMapErrorStopsStream(t *testing.T) {
+	t.Helper()
+	input := []Event[int]{
+		{Type: EventData, Payload: 1},
+		{Type: EventData, Payload: 2},
+	}
+	stream := makeStream(input)
+
+	mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
+		if e.Payload == 2 {
+			return Event[string]{}, fmt.Errorf("bad value")
 		}
-		stream := makeStream(input)
-		events, err := CollectStream(stream)
-		if err != nil {
-			t.Fatalf("CollectStream() error = %v", err)
-		}
-		if len(events) != 3 {
-			t.Fatalf("len(events) = %d, want 3", len(events))
-		}
-		if events[0].Payload != "hello" {
-			t.Errorf("events[0].Payload = %q, want %q", events[0].Payload, "hello")
-		}
-		if events[1].Payload != "world" {
-			t.Errorf("events[1].Payload = %q, want %q", events[1].Payload, "world")
-		}
+		return Event[string]{Payload: "ok"}, nil
 	})
 
-	t.Run("stops_on_error", func(t *testing.T) {
-		input := []Event[string]{
-			{Type: EventData, Payload: "ok"},
-		}
-		stream := makeErrorStream(input, fmt.Errorf("stream failed"))
-		events, err := CollectStream(stream)
-		if err == nil {
-			t.Fatal("CollectStream() expected error, got nil")
-		}
-		if err.Error() != "stream failed" {
-			t.Errorf("error = %q, want %q", err.Error(), "stream failed")
-		}
-		if len(events) != 1 {
-			t.Errorf("len(events) = %d, want 1 (events before error)", len(events))
-		}
+	events, err := CollectStream(mapped)
+	if err == nil {
+		t.Fatal("expected error from map function")
+	}
+	if len(events) != 1 {
+		t.Errorf("len(events) = %d, want 1", len(events))
+	}
+}
+
+func testMapStreamSourceErrorPropagates(t *testing.T) {
+	t.Helper()
+	input := []Event[int]{{Type: EventData, Payload: 1}}
+	stream := makeErrorStream(input, fmt.Errorf("source error"))
+
+	mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
+		return Event[string]{Payload: "ok"}, nil
 	})
+
+	events, err := CollectStream(mapped)
+	if err == nil {
+		t.Fatal("expected source error to propagate")
+	}
+	if err.Error() != "source error" {
+		t.Errorf("error = %q, want %q", err.Error(), "source error")
+	}
+	if len(events) != 1 {
+		t.Errorf("len(events) = %d, want 1", len(events))
+	}
 }
 
 func TestMapStream(t *testing.T) {
-	t.Run("transform_payload", func(t *testing.T) {
-		input := []Event[int]{
-			{Type: EventData, Payload: 1},
-			{Type: EventData, Payload: 2},
-			{Type: EventData, Payload: 3},
-		}
-		stream := makeStream(input)
-
-		mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
-			return Event[string]{
-				Type:    e.Type,
-				Payload: fmt.Sprintf("num-%d", e.Payload),
-			}, nil
-		})
-
-		events, err := CollectStream(mapped)
-		if err != nil {
-			t.Fatalf("CollectStream() error = %v", err)
-		}
-		if len(events) != 3 {
-			t.Fatalf("len(events) = %d, want 3", len(events))
-		}
-		if events[0].Payload != "num-1" {
-			t.Errorf("events[0].Payload = %q, want %q", events[0].Payload, "num-1")
-		}
-		if events[2].Payload != "num-3" {
-			t.Errorf("events[2].Payload = %q, want %q", events[2].Payload, "num-3")
-		}
-	})
-
-	t.Run("map_error_stops_stream", func(t *testing.T) {
-		input := []Event[int]{
-			{Type: EventData, Payload: 1},
-			{Type: EventData, Payload: 2},
-		}
-		stream := makeStream(input)
-
-		mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
-			if e.Payload == 2 {
-				return Event[string]{}, fmt.Errorf("bad value")
-			}
-			return Event[string]{Payload: "ok"}, nil
-		})
-
-		events, err := CollectStream(mapped)
-		if err == nil {
-			t.Fatal("expected error from map function")
-		}
-		if len(events) != 1 {
-			t.Errorf("len(events) = %d, want 1", len(events))
-		}
-	})
-
-	t.Run("source_error_propagates", func(t *testing.T) {
-		input := []Event[int]{{Type: EventData, Payload: 1}}
-		stream := makeErrorStream(input, fmt.Errorf("source error"))
-
-		mapped := MapStream(stream, func(e Event[int]) (Event[string], error) {
-			return Event[string]{Payload: "ok"}, nil
-		})
-
-		events, err := CollectStream(mapped)
-		if err == nil {
-			t.Fatal("expected source error to propagate")
-		}
-		if err.Error() != "source error" {
-			t.Errorf("error = %q, want %q", err.Error(), "source error")
-		}
-		if len(events) != 1 {
-			t.Errorf("len(events) = %d, want 1", len(events))
-		}
-	})
+	t.Run("transform_payload", testMapStreamTransformPayload)
+	t.Run("map_error_stops_stream", testMapStreamMapErrorStopsStream)
+	t.Run("source_error_propagates", testMapStreamSourceErrorPropagates)
 }
 
 func TestFilterStream(t *testing.T) {
@@ -412,155 +426,170 @@ func TestFanOut(t *testing.T) {
 	}
 }
 
-func TestFlowController(t *testing.T) {
-	t.Run("basic_acquire_release", func(t *testing.T) {
-		fc := NewFlowController(2)
-		ctx := context.Background()
+func testFlowControllerBasicAcquireRelease(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(2)
+	ctx := context.Background()
 
-		// Acquire twice should succeed.
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("first Acquire() error = %v", err)
-		}
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("second Acquire() error = %v", err)
-		}
+	// Acquire twice should succeed.
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("first Acquire() error = %v", err)
+	}
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("second Acquire() error = %v", err)
+	}
 
-		// Release twice to free capacity.
-		fc.Release()
-		fc.Release()
+	// Release twice to free capacity.
+	fc.Release()
+	fc.Release()
 
-		// Acquire again should work.
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("third Acquire() error = %v", err)
-		}
-		fc.Release()
-	})
+	// Acquire again should work.
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("third Acquire() error = %v", err)
+	}
+	fc.Release()
+}
 
-	t.Run("try_acquire_when_full", func(t *testing.T) {
-		fc := NewFlowController(1)
-		ctx := context.Background()
+func testFlowControllerTryAcquireWhenFull(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(1)
+	ctx := context.Background()
 
-		// First acquire should succeed.
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("Acquire() error = %v", err)
-		}
+	// First acquire should succeed.
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
 
-		// TryAcquire should fail when full.
-		if ok := fc.TryAcquire(); ok {
-			t.Error("TryAcquire() = true, want false (flow controller is full)")
-		}
+	// TryAcquire should fail when full.
+	if ok := fc.TryAcquire(); ok {
+		t.Error("TryAcquire() = true, want false (flow controller is full)")
+	}
 
-		// After release, TryAcquire should succeed.
-		fc.Release()
-		if ok := fc.TryAcquire(); !ok {
-			t.Error("TryAcquire() = false, want true (capacity available)")
-		}
+	// After release, TryAcquire should succeed.
+	fc.Release()
+	if ok := fc.TryAcquire(); !ok {
+		t.Error("TryAcquire() = false, want true (capacity available)")
+	}
 
-		fc.Release()
-	})
+	fc.Release()
+}
 
-	t.Run("try_acquire_when_available", func(t *testing.T) {
-		fc := NewFlowController(3)
+func testFlowControllerTryAcquireWhenAvailable(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(3)
 
-		// TryAcquire should succeed when capacity is available.
-		if ok := fc.TryAcquire(); !ok {
-			t.Error("TryAcquire() = false, want true")
-		}
-		if ok := fc.TryAcquire(); !ok {
-			t.Error("TryAcquire() = false, want true")
-		}
+	// TryAcquire should succeed when capacity is available.
+	if ok := fc.TryAcquire(); !ok {
+		t.Error("TryAcquire() = false, want true")
+	}
+	if ok := fc.TryAcquire(); !ok {
+		t.Error("TryAcquire() = false, want true")
+	}
 
-		fc.Release()
-		fc.Release()
-	})
+	fc.Release()
+	fc.Release()
+}
 
-	t.Run("context_cancellation_during_acquire", func(t *testing.T) {
-		fc := NewFlowController(1)
-		ctx, cancel := context.WithCancel(context.Background())
+func testFlowControllerContextCancellationDuringAcquire(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(1)
+	ctx, cancel := context.WithCancel(context.Background())
 
-		// Fill the controller.
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("Acquire() error = %v", err)
-		}
+	// Fill the controller.
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
 
-		// Start a goroutine that tries to acquire (will block).
-		errCh := make(chan error, 1)
+	// Start a goroutine that tries to acquire (will block).
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fc.Acquire(ctx)
+	}()
+
+	// Cancel the context.
+	cancel()
+
+	// The blocked acquire should return context.Canceled.
+	err := <-errCh
+	if err != context.Canceled {
+		t.Errorf("Acquire() error = %v, want context.Canceled", err)
+	}
+
+	fc.Release()
+}
+
+func testFlowControllerConcurrencySafety(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(10)
+	ctx := context.Background()
+
+	const goroutines = 20
+	const opsPerGoroutine = 50
+
+	// Launch multiple goroutines that acquire and release concurrently.
+	errCh := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
 		go func() {
-			errCh <- fc.Acquire(ctx)
-		}()
-
-		// Cancel the context.
-		cancel()
-
-		// The blocked acquire should return context.Canceled.
-		err := <-errCh
-		if err != context.Canceled {
-			t.Errorf("Acquire() error = %v, want context.Canceled", err)
-		}
-
-		fc.Release()
-	})
-
-	t.Run("concurrency_safety", func(t *testing.T) {
-		fc := NewFlowController(10)
-		ctx := context.Background()
-
-		const goroutines = 20
-		const opsPerGoroutine = 50
-
-		// Launch multiple goroutines that acquire and release concurrently.
-		errCh := make(chan error, goroutines)
-		for i := 0; i < goroutines; i++ {
-			go func() {
-				for j := 0; j < opsPerGoroutine; j++ {
-					if err := fc.Acquire(ctx); err != nil {
-						errCh <- err
-						return
-					}
-					// Simulate some work.
-					fc.Release()
+			for j := 0; j < opsPerGoroutine; j++ {
+				if err := fc.Acquire(ctx); err != nil {
+					errCh <- err
+					return
 				}
-				errCh <- nil
-			}()
-		}
-
-		// Wait for all goroutines to complete.
-		for i := 0; i < goroutines; i++ {
-			if err := <-errCh; err != nil {
-				t.Errorf("goroutine error: %v", err)
+				// Simulate some work.
+				fc.Release()
 			}
-		}
-	})
-
-	t.Run("max_concurrency_clamped_to_1", func(t *testing.T) {
-		fc := NewFlowController(0)
-		ctx := context.Background()
-
-		// Should allow at least 1 acquisition.
-		if err := fc.Acquire(ctx); err != nil {
-			t.Fatalf("Acquire() error = %v (maxConcurrency should be clamped to 1)", err)
-		}
-
-		// Second acquire should block (but we use TryAcquire to test).
-		if fc.TryAcquire() {
-			t.Error("TryAcquire() = true, want false (maxConcurrency=1)")
-			fc.Release()
-		}
-
-		fc.Release()
-	})
-
-	t.Run("multiple_release_doesnt_panic", func(t *testing.T) {
-		fc := NewFlowController(1)
-
-		// Release without acquire should not panic (graceful handling).
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Release() panicked: %v", r)
-			}
+			errCh <- nil
 		}()
+	}
 
+	// Wait for all goroutines to complete.
+	for i := 0; i < goroutines; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("goroutine error: %v", err)
+		}
+	}
+}
+
+func testFlowControllerMaxConcurrencyClampedTo1(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(0)
+	ctx := context.Background()
+
+	// Should allow at least 1 acquisition.
+	if err := fc.Acquire(ctx); err != nil {
+		t.Fatalf("Acquire() error = %v (maxConcurrency should be clamped to 1)", err)
+	}
+
+	// Second acquire should block (but we use TryAcquire to test).
+	if fc.TryAcquire() {
+		t.Error("TryAcquire() = true, want false (maxConcurrency=1)")
 		fc.Release()
-		fc.Release()
-	})
+	}
+
+	fc.Release()
+}
+
+func testFlowControllerMultipleReleaseDoesntPanic(t *testing.T) {
+	t.Helper()
+	fc := NewFlowController(1)
+
+	// Release without acquire should not panic (graceful handling).
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Release() panicked: %v", r)
+		}
+	}()
+
+	fc.Release()
+	fc.Release()
+}
+
+func TestFlowController(t *testing.T) {
+	t.Run("basic_acquire_release", testFlowControllerBasicAcquireRelease)
+	t.Run("try_acquire_when_full", testFlowControllerTryAcquireWhenFull)
+	t.Run("try_acquire_when_available", testFlowControllerTryAcquireWhenAvailable)
+	t.Run("context_cancellation_during_acquire", testFlowControllerContextCancellationDuringAcquire)
+	t.Run("concurrency_safety", testFlowControllerConcurrencySafety)
+	t.Run("max_concurrency_clamped_to_1", testFlowControllerMaxConcurrencyClampedTo1)
+	t.Run("multiple_release_doesnt_panic", testFlowControllerMultipleReleaseDoesntPanic)
 }

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -30,7 +30,6 @@ func makeErrorStream[T any](events []Event[T], err error) Stream[T] {
 }
 
 func testCollectStreamEmpty(t *testing.T) {
-	t.Helper()
 	stream := makeStream[string](nil)
 	events, err := CollectStream(stream)
 	if err != nil {
@@ -42,7 +41,6 @@ func testCollectStreamEmpty(t *testing.T) {
 }
 
 func testCollectStreamMultipleEvents(t *testing.T) {
-	t.Helper()
 	input := []Event[string]{
 		{Type: EventData, Payload: "hello"},
 		{Type: EventData, Payload: "world"},
@@ -65,7 +63,6 @@ func testCollectStreamMultipleEvents(t *testing.T) {
 }
 
 func testCollectStreamStopsOnError(t *testing.T) {
-	t.Helper()
 	input := []Event[string]{
 		{Type: EventData, Payload: "ok"},
 	}
@@ -89,7 +86,6 @@ func TestCollectStream(t *testing.T) {
 }
 
 func testMapStreamTransformPayload(t *testing.T) {
-	t.Helper()
 	input := []Event[int]{
 		{Type: EventData, Payload: 1},
 		{Type: EventData, Payload: 2},
@@ -120,7 +116,6 @@ func testMapStreamTransformPayload(t *testing.T) {
 }
 
 func testMapStreamMapErrorStopsStream(t *testing.T) {
-	t.Helper()
 	input := []Event[int]{
 		{Type: EventData, Payload: 1},
 		{Type: EventData, Payload: 2},
@@ -144,7 +139,6 @@ func testMapStreamMapErrorStopsStream(t *testing.T) {
 }
 
 func testMapStreamSourceErrorPropagates(t *testing.T) {
-	t.Helper()
 	input := []Event[int]{{Type: EventData, Payload: 1}}
 	stream := makeErrorStream(input, fmt.Errorf("source error"))
 
@@ -427,7 +421,6 @@ func TestFanOut(t *testing.T) {
 }
 
 func testFlowControllerBasicAcquireRelease(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(2)
 	ctx := context.Background()
 
@@ -451,7 +444,6 @@ func testFlowControllerBasicAcquireRelease(t *testing.T) {
 }
 
 func testFlowControllerTryAcquireWhenFull(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(1)
 	ctx := context.Background()
 
@@ -475,7 +467,6 @@ func testFlowControllerTryAcquireWhenFull(t *testing.T) {
 }
 
 func testFlowControllerTryAcquireWhenAvailable(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(3)
 
 	// TryAcquire should succeed when capacity is available.
@@ -491,7 +482,6 @@ func testFlowControllerTryAcquireWhenAvailable(t *testing.T) {
 }
 
 func testFlowControllerContextCancellationDuringAcquire(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(1)
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -519,7 +509,6 @@ func testFlowControllerContextCancellationDuringAcquire(t *testing.T) {
 }
 
 func testFlowControllerConcurrencySafety(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(10)
 	ctx := context.Background()
 
@@ -551,7 +540,6 @@ func testFlowControllerConcurrencySafety(t *testing.T) {
 }
 
 func testFlowControllerMaxConcurrencyClampedTo1(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(0)
 	ctx := context.Background()
 
@@ -570,7 +558,6 @@ func testFlowControllerMaxConcurrencyClampedTo1(t *testing.T) {
 }
 
 func testFlowControllerMultipleReleaseDoesntPanic(t *testing.T) {
-	t.Helper()
 	fc := NewFlowController(1)
 
 	// Release without acquire should not panic (graceful handling).

--- a/docs/superpowers/plans/2026-04-07-sonarcloud-integration-and-fixes.md
+++ b/docs/superpowers/plans/2026-04-07-sonarcloud-integration-and-fixes.md
@@ -1,0 +1,827 @@
+# SonarCloud Integration Fix & Issue Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix SonarCloud CI integration for dependabot PRs, resolve all SonarCloud issues in production and test code, and configure SonarCloud to exclude test files from string duplication checks.
+
+**Architecture:** Four workstreams executed sequentially: (1) CI workflow fixes, (2) SonarCloud config, (3) production code string constant extraction, (4) test file quality fixes (empty functions + cognitive complexity). Each workstream is committed independently.
+
+**Tech Stack:** GitHub Actions YAML, Go, SonarCloud configuration
+
+**Spec:** `docs/superpowers/specs/2026-04-07-sonarcloud-integration-and-fixes-design.md`
+
+---
+
+## Task 1: Fix `pr.yml` — Skip SonarCloud for Dependabot PRs
+
+**Files:**
+- Modify: `.github/workflows/pr.yml`
+
+- [ ] **Step 1: Update the `if` condition on the sonarcloud job**
+
+In `.github/workflows/pr.yml`, change the `sonarcloud` job's `if` from:
+
+```yaml
+if: github.event.pull_request.head.repo.full_name == github.repository
+```
+
+to:
+
+```yaml
+if: |
+  github.event.pull_request.head.repo.full_name == github.repository &&
+  github.actor != 'dependabot[bot]'
+```
+
+This skips SonarCloud for dependabot PRs (which can't access `SONAR_TOKEN`). SonarCloud still runs on main after merge via `main.yml`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/pr.yml
+git commit -m "fix(ci): skip SonarCloud analysis for dependabot PRs
+
+Dependabot PRs cannot access repo secrets, causing SonarCloud to
+fail with 'Project not found'. Skip the job for dependabot and
+rely on the main branch analysis after merge."
+```
+
+---
+
+## Task 2: Fix `release.yml` — Move Permissions to Job Level
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Remove workflow-level permissions**
+
+In `.github/workflows/release.yml`, remove the top-level `permissions` block:
+
+```yaml
+# REMOVE this block (currently at line ~22):
+permissions:
+  contents: write
+```
+
+- [ ] **Step 2: Add job-level permissions to each job that needs them**
+
+Add `permissions` to the jobs that need write access:
+
+```yaml
+  create-tag:
+    name: Create and push tag (manual only)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # ... existing steps unchanged
+
+  changes:
+    name: Check Release-Relevant Changes
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # ... rest unchanged
+
+  changelog:
+    name: Generate Changelog
+    needs: changes
+    if: needs.changes.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # ... rest unchanged
+
+  release:
+    name: GoReleaser
+    needs: [changes, changelog]
+    if: needs.changes.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # ... rest unchanged
+
+  trigger-docs:
+    name: Trigger Docs Rebuild
+    needs: [changes, release]
+    if: needs.changes.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    # ... rest unchanged
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "fix(ci): move permissions from workflow to job level in release.yml
+
+Resolves SonarCloud vulnerability githubactions:S8233. Each job now
+declares only the permissions it needs rather than inheriting a
+broad workflow-level write permission."
+```
+
+---
+
+## Task 3: Update SonarCloud Configuration
+
+**Files:**
+- Modify: `sonar-project.properties`
+
+- [ ] **Step 1: Add S1192 exclusion for test files**
+
+Append to `sonar-project.properties`:
+
+```properties
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+```
+
+The full file should now be:
+
+```properties
+sonar.projectKey=lookatitude_beluga-ai
+sonar.organization=lookatitude
+sonar.projectName=Beluga AI
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/testutil/**,**/vendor/**,docs/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+
+sonar.go.coverage.reportPaths=coverage.out
+
+sonar.cpd.exclusions=**/providers/**
+
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add sonar-project.properties
+git commit -m "chore(sonar): exclude test files from string duplication rule
+
+Test files intentionally repeat string literals for readability.
+Suppressing go:S1192 in *_test.go eliminates ~870 false-positive
+code smell reports."
+```
+
+---
+
+## Task 4: Fix S1192 in `protocol/a2a/server.go`
+
+**Files:**
+- Modify: `protocol/a2a/server.go`
+
+- [ ] **Step 1: Add constants at the top of the file (after imports)**
+
+Add a const block after the import section:
+
+```go
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json"
+)
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace every `"Content-Type"` with `contentTypeHeader` and every `"application/json"` with `contentTypeJSON` in `w.Header().Set(...)` calls throughout the file. These appear at lines ~79, ~117, ~175, ~208.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./protocol/a2a/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add protocol/a2a/server.go
+git commit -m "refactor(a2a): extract HTTP header constants in server.go"
+```
+
+---
+
+## Task 5: Fix S1192 in `protocol/a2a/client.go`
+
+**Files:**
+- Modify: `protocol/a2a/client.go`
+
+- [ ] **Step 1: Identify the duplicated error prefix strings**
+
+The duplicated strings are the error format prefixes used 3+ times each:
+- `"a2a/get_card: %w"` — 3 occurrences
+- `"a2a/create_task: %w"` — 4 occurrences
+- `"a2a/get_task: %w"` — 3 occurrences
+
+Since these are error format strings with `%w`/`%s` verbs (not plain strings), and each occurrence has a slightly different context, the cleanest fix is to extract the operation name prefixes as constants:
+
+```go
+const (
+	opGetCard    = "a2a/get_card: "
+	opCreateTask = "a2a/create_task: "
+	opGetTask    = "a2a/get_task: "
+	opCancelTask = "a2a/cancel_task: "
+	opInvoke     = "a2a/invoke: "
+)
+```
+
+- [ ] **Step 2: Replace all error format strings**
+
+Replace usages like:
+```go
+fmt.Errorf("a2a/get_card: %w", err)
+```
+with:
+```go
+fmt.Errorf(opGetCard+"%w", err)
+```
+
+Apply this pattern to all `fmt.Errorf` calls in the file that use these prefixes.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./protocol/a2a/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add protocol/a2a/client.go
+git commit -m "refactor(a2a): extract error prefix constants in client.go"
+```
+
+---
+
+## Task 6: Fix S1192 in `voice/stt/providers/deepgram/deepgram.go`
+
+**Files:**
+- Modify: `voice/stt/providers/deepgram/deepgram.go`
+
+- [ ] **Step 1: Add constants**
+
+```go
+const (
+	authPrefix = "Token "
+	listenPath = "/listen?"
+)
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"Token "` with `authPrefix` (lines ~65, ~110, ~139) and `"/listen?"` with `listenPath` (lines ~106, ~132).
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./voice/stt/providers/deepgram/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add voice/stt/providers/deepgram/deepgram.go
+git commit -m "refactor(deepgram): extract auth and path constants"
+```
+
+---
+
+## Task 7: Fix S1192 in `agent/lats.go`
+
+**Files:**
+- Modify: `agent/lats.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const stepFmt = "Step %d: %s\n"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"Step %d: %s\n"` with `stepFmt` at lines ~238, ~276, ~385.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./agent/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/lats.go
+git commit -m "refactor(agent): extract step format constant in lats.go"
+```
+
+---
+
+## Task 8: Fix S1192 in `orchestration/chain.go`
+
+**Files:**
+- Modify: `orchestration/chain.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const chainStepErrFmt = "orchestration/chain: step %d: %w"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"orchestration/chain: step %d: %w"` with `chainStepErrFmt` at lines ~38, ~69, ~81.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./orchestration/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add orchestration/chain.go
+git commit -m "refactor(orchestration): extract error format constant in chain.go"
+```
+
+---
+
+## Task 9: Fix S1192 in `orchestration/supervisor.go`
+
+**Files:**
+- Modify: `orchestration/supervisor.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const supervisorAgentErrFmt = "orchestration/supervisor: agent %q: %w"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"orchestration/supervisor: agent %q: %w"` with `supervisorAgentErrFmt` at lines ~67, ~109, ~120.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./orchestration/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add orchestration/supervisor.go
+git commit -m "refactor(orchestration): extract error format constant in supervisor.go"
+```
+
+---
+
+## Task 10: Fix S1192 in `eval/metrics/cost.go`
+
+**Files:**
+- Modify: `eval/metrics/cost.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const missingMetaKeyFmt = "cost: missing metadata key %q"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"cost: missing metadata key %q"` with `missingMetaKeyFmt` at lines ~57, ~71, ~80.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./eval/metrics/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add eval/metrics/cost.go
+git commit -m "refactor(eval): extract error format constant in cost.go"
+```
+
+---
+
+## Task 11: Fix S1192 in `workflow/providers/inngest/inngest.go`
+
+**Files:**
+- Modify: `workflow/providers/inngest/inngest.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const workflowPathFmt = "/v1/workflows/%s"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace `"/v1/workflows/%s"` with `workflowPathFmt` in the `fmt.Sprintf` calls at lines ~71, ~101, ~151.
+
+Example:
+```go
+// Before:
+u := fmt.Sprintf("%s/v1/workflows/%s", s.baseURL, state.WorkflowID)
+// After:
+u := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, state.WorkflowID)
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./workflow/providers/inngest/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add workflow/providers/inngest/inngest.go
+git commit -m "refactor(inngest): extract workflow path constant"
+```
+
+---
+
+## Task 12: Fix S1192 in `cmd/docgen/main.go`
+
+**Files:**
+- Modify: `cmd/docgen/main.go`
+
+- [ ] **Step 1: Add constant**
+
+```go
+const goCodeFence = "```go\n"
+```
+
+- [ ] **Step 2: Replace all occurrences**
+
+Replace the 3 occurrences of the go code fence string literal with `goCodeFence`.
+
+- [ ] **Step 3: Run build**
+
+```bash
+go build ./cmd/docgen/...
+```
+
+Expected: BUILD OK (docgen is a CLI tool, may not have separate tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/docgen/main.go
+git commit -m "refactor(docgen): extract code fence constant"
+```
+
+---
+
+## Task 13: Fix S1186 — Empty Functions in Test Files
+
+**Files (34 empty functions across 18 files):**
+- Modify: `core/runnable_test.go` (lines 150, 151, 430)
+- Modify: `core/option_test.go` (line 72)
+- Modify: `protocol/a2a/a2a_test.go` (line 623)
+- Modify: `protocol/rest/rest_test.go` (lines 486, 493, 498, 550, 672)
+- Modify: `server/sse_test.go` (lines 125, 143, 145)
+- Modify: `voice/stt/providers/assemblyai/assemblyai_test.go` (lines 632, 706)
+- Modify: `voice/stt/providers/gladia/gladia_test.go` (lines 411, 438, 468, 660, 1051)
+- Modify: `voice/stt/providers/groq/groq_test.go` (line 211)
+- Modify: `agent/bus_test.go` (line 115)
+- Modify: `agent/reflection_test.go` (line 476)
+- Modify: `config/watch_test.go` (lines 131, 151, 180)
+- Modify: `internal/syncutil/pool_test.go` (line 84)
+- Modify: `internal/testutil/helpers_test.go` (lines 16, 128)
+- Modify: `orchestration/hooks_test.go` (line 159)
+- Modify: `rag/retriever/mocks_test.go` (line 29)
+- Modify: `rag/retriever/retriever_test.go` (line 89)
+- Modify: `state/hooks_test.go` (line 200)
+- Modify: `voice/pipeline_test.go` (line 225)
+
+- [ ] **Step 1: Add explanatory comments to all empty functions**
+
+For each empty function, read the surrounding context to understand its purpose, then add an appropriate comment inside the function body. The patterns are:
+
+**Pattern A — Interface stub (most common):**
+```go
+func (m *mockThing) Method() {
+	// no-op: stub satisfies InterfaceName for testing
+}
+```
+
+**Pattern B — No-op callback/handler:**
+```go
+bus.Subscribe(func(event AgentEvent) {
+	// no-op: subscription is immediately cancelled by context
+})
+```
+
+**Pattern C — No-op option func:**
+```go
+OptionFunc(func(_ any) {
+	// no-op: tests option passthrough, not behavior
+})
+```
+
+Read each file at the specified line, determine which pattern applies, and add the appropriate comment. The comment must explain *why* the function is empty.
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+go test ./... -count=1 -timeout 120s 2>&1 | tail -5
+```
+
+Expected: PASS (comments don't change behavior)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A '*.go'
+git commit -m "refactor(tests): add explanatory comments to empty test functions
+
+Resolves SonarCloud go:S1186 across 18 test files. Each empty
+function now documents why it is intentionally empty."
+```
+
+---
+
+## Task 14: Fix S3776 — Cognitive Complexity in `core/` Test Files
+
+**Files:**
+- Modify: `core/runnable_test.go` (lines 60, 188, 317, 462 — complexities 18, 46, 40, 25)
+- Modify: `core/stream_test.go` (lines 32, 84, 415 — complexities 18, 17, 43)
+- Modify: `core/option_test.go` (line 75 — complexity 16)
+
+- [ ] **Step 1: Refactor complex test functions**
+
+For each flagged function:
+1. Read the function at the specified line
+2. Identify logical subtest boundaries (different test scenarios, error paths, edge cases)
+3. Extract each scenario into a `t.Run("descriptive_name", func(t *testing.T) { ... })` subtest
+4. Extract repeated setup logic into `t.Helper()` functions where it reduces complexity
+5. For table-driven tests, ensure assertions inside the loop body are flat (no nested if/else)
+
+**Key principle:** Each `t.Run` creates a new function scope that resets cognitive complexity. Moving test cases into subtests naturally reduces per-function complexity.
+
+**Example transformation for table-driven tests with nested assertions:**
+
+Before (high complexity):
+```go
+func TestFoo(t *testing.T) {
+    tests := []struct{ ... }{...}
+    for _, tt := range tests {
+        result, err := Foo(tt.input)
+        if tt.wantErr {
+            if err == nil {
+                t.Errorf("expected error")
+            }
+        } else {
+            if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+            if result != tt.want {
+                t.Errorf("got %v, want %v", result, tt.want)
+            }
+        }
+    }
+}
+```
+
+After (lower complexity):
+```go
+func TestFoo(t *testing.T) {
+    tests := []struct{ ... }{...}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result, err := Foo(tt.input)
+            if tt.wantErr {
+                require.Error(t, err)
+                return
+            }
+            require.NoError(t, err)
+            assert.Equal(t, tt.want, result)
+        })
+    }
+}
+```
+
+If the project doesn't use testify, use the same pattern with standard library assertions but keep the `t.Run` wrapping.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+go test ./core/... -count=1 -v 2>&1 | tail -20
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/runnable_test.go core/stream_test.go core/option_test.go
+git commit -m "refactor(core): reduce cognitive complexity in test files
+
+Break complex test functions into subtests using t.Run() to bring
+cognitive complexity below the 15-point threshold."
+```
+
+---
+
+## Task 15: Fix S3776 — Cognitive Complexity in `agent/` Test Files
+
+**Files:**
+- Modify: `agent/persona_test.go` (line 10 — complexity 28)
+- Modify: `agent/selfdiscover_test.go` (line 117 — complexity 16)
+
+- [ ] **Step 1: Refactor `TestPersona_ToSystemMessage` in `agent/persona_test.go`**
+
+This is a table-driven test with 6 cases. Wrap the loop body in `t.Run(tt.name, ...)` and flatten assertions using early returns.
+
+- [ ] **Step 2: Refactor the function at line 117 in `agent/selfdiscover_test.go`**
+
+Complexity is 16 (threshold 15). Wrap test cases in `t.Run` subtests to bring below threshold.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./agent/... -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/persona_test.go agent/selfdiscover_test.go
+git commit -m "refactor(agent): reduce cognitive complexity in test files"
+```
+
+---
+
+## Task 16: Fix S3776 — Cognitive Complexity in `voice/stt/` Test Files
+
+**Files:**
+- Modify: `voice/stt/providers/assemblyai/assemblyai_test.go` (lines 50, 382 — complexities 50, 104)
+- Modify: `voice/stt/providers/gladia/gladia_test.go` (lines 327, 930 — complexities 89, 22)
+- Modify: `voice/stt/providers/groq/groq_test.go` (line 171 — complexity 24)
+- Modify: `voice/stt/providers/whisper/whisper_test.go` (line 185 — complexity 29)
+- Modify: `voice/stt/providers/elevenlabs/elevenlabs_test.go` (line 190 — complexity 29)
+
+- [ ] **Step 1: Refactor each flagged function**
+
+These are the highest-complexity functions in the codebase (up to 104). For each:
+1. Read the function
+2. Identify distinct test scenarios (success path, error cases, edge cases, streaming behavior)
+3. Extract each scenario into `t.Run("name", func(t *testing.T) { ... })`
+4. For functions with complexity >40, also extract shared setup into helper functions
+
+- [ ] **Step 2: Run tests**
+
+```bash
+go test ./voice/stt/... -count=1 -timeout 60s
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add voice/stt/
+git commit -m "refactor(voice/stt): reduce cognitive complexity in test files
+
+Break high-complexity test functions (up to 104) into focused
+subtests using t.Run()."
+```
+
+---
+
+## Task 17: Fix S3776 — Cognitive Complexity in `voice/tts/` Test Files
+
+**Files:**
+- Modify: `voice/tts/providers/cartesia/cartesia_test.go` (line 168 — complexity 21)
+- Modify: `voice/tts/providers/elevenlabs/elevenlabs_test.go` (line 177 — complexity 23)
+- Modify: `voice/tts/providers/fish/fish_test.go` (line 174 — complexity 21)
+- Modify: `voice/tts/providers/groq/groq_test.go` (line 162 — complexity 21)
+- Modify: `voice/tts/providers/lmnt/lmnt_test.go` (line 190 — complexity 21)
+- Modify: `voice/tts/providers/playht/playht_test.go` (line 167 — complexity 21)
+- Modify: `voice/tts/providers/smallest/smallest_test.go` (line 153 — complexity 21)
+
+- [ ] **Step 1: Refactor each flagged function**
+
+These TTS provider tests likely follow a similar pattern (complexity 21 across 6 of 7 files). For each:
+1. Read the function at the specified line
+2. Wrap test cases in `t.Run` subtests
+3. Flatten nested conditionals with early returns
+
+- [ ] **Step 2: Run tests**
+
+```bash
+go test ./voice/tts/... -count=1 -timeout 60s
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add voice/tts/
+git commit -m "refactor(voice/tts): reduce cognitive complexity in test files"
+```
+
+---
+
+## Task 18: Fix S3776 — Cognitive Complexity in Remaining Test Files
+
+**Files:**
+- Modify: `voice/processor_test.go` (line 199 — complexity 20)
+- Modify: `voice/s2s/providers/gemini/gemini_test.go` (line 495 — complexity 16)
+- Modify: `voice/pipeline_test.go` (if flagged)
+- Modify: `rag/embedding/embedding_test.go` (line 247 — complexity 20)
+- Modify: `rag/loader/providers/notion/notion_test.go` (line 44 — complexity 24)
+- Modify: `rag/loader/providers/unstructured/unstructured_test.go` (line 441 — complexity 34)
+- Modify: `server/handler_test.go` (line 99 — complexity 22)
+- Modify: `cache/providers/inmemory/inmemory_test.go` (line 283 — complexity 20)
+- Modify: `cache/semantic_test.go` (line 255 — complexity 20)
+
+- [ ] **Step 1: Refactor each flagged function**
+
+Same approach as previous tasks: wrap test cases in `t.Run` subtests, flatten assertions, extract helpers where needed.
+
+- [ ] **Step 2: Run all tests to verify nothing is broken**
+
+```bash
+go test ./... -count=1 -timeout 120s 2>&1 | tail -10
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add voice/ rag/ server/ cache/
+git commit -m "refactor: reduce cognitive complexity in remaining test files
+
+Fix S3776 issues in voice, rag, server, and cache test files."
+```
+
+---
+
+## Task 19: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+go test ./... -count=1 -timeout 180s
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Run linter**
+
+```bash
+go vet ./...
+```
+
+Expected: no issues
+
+- [ ] **Step 3: Verify build**
+
+```bash
+go build ./...
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Review the change summary**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected output should show commits for each task.

--- a/docs/superpowers/specs/2026-04-07-sonarcloud-integration-and-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-07-sonarcloud-integration-and-fixes-design.md
@@ -1,0 +1,178 @@
+# SonarCloud Integration Fix & Issue Resolution
+
+## Summary
+
+Fix SonarCloud's GitHub PR integration for dependabot PRs, resolve the single security vulnerability, fix all production code smells and test file quality issues, and configure SonarCloud to exclude test files from the string duplication rule (`go:S1192`).
+
+## Problem
+
+1. **SonarCloud fails on dependabot PRs** — The `pr.yml` workflow's `if` guard (`github.event.pull_request.head.repo.full_name == github.repository`) passes for dependabot (same-repo), but dependabot can't access repo secrets. The `SONAR_TOKEN` is empty, causing the scan to fail with "Project not found."
+
+2. **962 open SonarCloud issues** across the codebase:
+   - 1 vulnerability (`githubactions:S8233`) in `release.yml`
+   - ~14 critical code smells (`go:S1192`) in production code
+   - 54 critical code smells (`go:S3776` — cognitive complexity) in test files
+   - 34 critical code smells (`go:S1186` — empty functions) in test files
+   - ~870+ critical code smells (`go:S1192`) in test files (to be handled by config exclusion)
+
+## Design
+
+### Workstream 1: CI Integration Fix
+
+#### 1a. Fix `pr.yml` — Dependabot SonarCloud Handling
+
+The `if` guard needs to also check that `SONAR_TOKEN` is actually available. Dependabot PRs are same-repo so they pass the fork check, but secrets are not exposed to dependabot.
+
+**Fix:** Add a secret availability check to the `if` condition:
+
+```yaml
+sonarcloud:
+  name: SonarCloud Analysis
+  needs: ci
+  runs-on: ubuntu-latest
+  if: |
+    github.event.pull_request.head.repo.full_name == github.repository &&
+    github.actor != 'dependabot[bot]'
+  steps:
+    # ... existing steps
+```
+
+This explicitly skips SonarCloud for dependabot PRs. SonarCloud will still run on main pushes (via `main.yml`) after dependabot PRs are merged, so coverage is not lost.
+
+#### 1b. Fix `release.yml` — Vulnerability `githubactions:S8233`
+
+Move write permissions from workflow level to job level at line 22.
+
+**Current:** Permissions declared at workflow level.
+**Fix:** Move `contents: write` to the specific job that needs it.
+
+### Workstream 2: Production Code Fixes (`go:S1192`)
+
+Extract per-file constants for duplicated string literals in these production files:
+
+| File | Duplicated Strings | Count |
+|------|-------------------|-------|
+| `workflow/providers/inngest/inngest.go` | `"Bearer "`, header literal | 2 |
+| `eval/metrics/cost.go` | `"cost: missing metadata key %q"` | 1 |
+| `protocol/a2a/server.go` | `"application/json"`, `"Content-Type"` | 2 |
+| `protocol/a2a/client.go` | error format strings | 3 |
+| `agent/lats.go` | `"Step %d: %s\n"` | 1 |
+| `voice/stt/providers/deepgram/deepgram.go` | `"Token "`, `"/listen?"` | 2 |
+| `orchestration/chain.go` | error format string | 1 |
+| `orchestration/supervisor.go` | error format string | 1 |
+| `cmd/docgen/main.go` | `` "```go\n" `` | 1 |
+
+**Approach:** Add `const` blocks at the top of each file (or near usage) with descriptive names. Keep scope file-local (unexported).
+
+### Workstream 3: Test File Fixes
+
+#### 3a. Cognitive Complexity (`go:S3776`) — 54 issues
+
+Break complex test functions into subtests using `t.Run()` where natural boundaries exist. Priority by complexity excess:
+
+| File | Line | Complexity | Threshold |
+|------|------|-----------|-----------|
+| `voice/stt/providers/assemblyai/assemblyai_test.go` | 382 | 104 | 15 |
+| `voice/stt/providers/gladia/gladia_test.go` | 327 | 89 | 15 |
+| `voice/stt/providers/assemblyai/assemblyai_test.go` | 50 | 50 | 15 |
+| `core/runnable_test.go` | 188 | 46 | 15 |
+| `core/stream_test.go` | 415 | 43 | 15 |
+| `core/runnable_test.go` | 317 | 40 | 15 |
+| `rag/loader/providers/unstructured/unstructured_test.go` | 441 | 34 | 15 |
+| `voice/stt/providers/elevenlabs/elevenlabs_test.go` | 190 | 29 | 15 |
+| `voice/stt/providers/whisper/whisper_test.go` | 185 | 29 | 15 |
+| `agent/persona_test.go` | 10 | 28 | 15 |
+| `core/runnable_test.go` | 462 | 25 | 15 |
+| `rag/loader/providers/notion/notion_test.go` | 44 | 24 | 15 |
+| `voice/stt/providers/groq/groq_test.go` | 171 | 24 | 15 |
+| `voice/tts/providers/elevenlabs/elevenlabs_test.go` | 177 | 23 | 15 |
+| `server/handler_test.go` | 99 | 22 | 15 |
+| `voice/stt/providers/gladia/gladia_test.go` | 930 | 22 | 15 |
+| `voice/tts/providers/cartesia/cartesia_test.go` | 168 | 21 | 15 |
+| `voice/tts/providers/fish/fish_test.go` | 174 | 21 | 15 |
+| `voice/tts/providers/groq/groq_test.go` | 162 | 21 | 15 |
+| `voice/tts/providers/lmnt/lmnt_test.go` | 190 | 21 | 15 |
+| `voice/tts/providers/playht/playht_test.go` | 167 | 21 | 15 |
+| `voice/tts/providers/smallest/smallest_test.go` | 153 | 21 | 15 |
+| `rag/embedding/embedding_test.go` | 247 | 20 | 15 |
+| `voice/processor_test.go` | 199 | 20 | 15 |
+| `cache/providers/inmemory/inmemory_test.go` | 283 | 20 | 15 |
+| `cache/semantic_test.go` | 255 | 20 | 15 |
+| `core/stream_test.go` | 32 | 18 | 15 |
+| `core/runnable_test.go` | 60 | 18 | 15 |
+| `core/stream_test.go` | 84 | 17 | 15 |
+| `voice/s2s/providers/gemini/gemini_test.go` | 495 | 16 | 15 |
+| `agent/selfdiscover_test.go` | 117 | 16 | 15 |
+| `core/option_test.go` | 75 | 16 | 15 |
+
+**Strategy:** For each function:
+- Identify logical test case groupings
+- Extract into `t.Run("descriptive name", func(t *testing.T) { ... })` subtests
+- Extract shared setup into helper functions where it reduces complexity
+- For very high complexity (>40), consider extracting test helper functions
+
+#### 3b. Empty Functions (`go:S1186`) — 34 issues
+
+All are in test files — likely interface stub implementations or callback placeholders.
+
+| File | Lines |
+|------|-------|
+| `protocol/a2a/a2a_test.go` | 623 |
+| `protocol/rest/rest_test.go` | 486, 493, 498, 550, 672 |
+| `server/sse_test.go` | 125, 143, 145 |
+| `voice/stt/providers/assemblyai/assemblyai_test.go` | 632, 706 |
+| `voice/stt/providers/gladia/gladia_test.go` | 411, 438, 468, 660, 1051 |
+| `voice/stt/providers/groq/groq_test.go` | 211 |
+| `agent/bus_test.go` | 115 |
+| `agent/reflection_test.go` | 476 |
+| `config/watch_test.go` | 131, 151, 180 |
+| `core/option_test.go` | 72 |
+| `core/runnable_test.go` | 150, 151, 430 |
+| `internal/syncutil/pool_test.go` | 84 |
+| `internal/testutil/helpers_test.go` | 16, 128 |
+| `orchestration/hooks_test.go` | 159 |
+| `rag/retriever/mocks_test.go` | 29 |
+| `rag/retriever/retriever_test.go` | 89 |
+| `state/hooks_test.go` | 200 |
+| `voice/pipeline_test.go` | 225 |
+
+**Strategy:** For each empty function, read the context to determine:
+- If it's an interface stub → add `// no-op: satisfies <InterfaceName> for testing`
+- If it's unused → remove it
+
+### Workstream 4: SonarCloud Configuration
+
+Update `sonar-project.properties` to exclude test files from the `S1192` (string duplication) rule:
+
+```properties
+# Existing config
+sonar.projectKey=lookatitude_beluga-ai
+sonar.organization=lookatitude
+sonar.projectName=Beluga AI
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/testutil/**,**/vendor/**,docs/**
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+
+sonar.go.coverage.reportPaths=coverage.out
+
+sonar.cpd.exclusions=**/providers/**
+
+# NEW: Exclude test files from string duplication rule
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+```
+
+## Testing
+
+- All existing tests must continue to pass (`go test ./...`)
+- After merge to main, verify SonarCloud dashboard shows reduced issue count
+- Create a test dependabot-like PR or verify next dependabot PR doesn't fail SonarCloud
+
+## Out of Scope
+
+- Fixing `S1192` in test files (handled by SonarCloud config exclusion)
+- Changing SonarCloud quality gates or other rules
+- Adding new CI checks or workflows

--- a/eval/metrics/cost.go
+++ b/eval/metrics/cost.go
@@ -7,6 +7,8 @@ import (
 	"github.com/lookatitude/beluga-ai/eval"
 )
 
+const missingMetaKeyFmt = "cost: missing metadata key %q"
+
 // ModelPricing defines per-token pricing for a model.
 type ModelPricing struct {
 	// InputTokenPrice is the price per 1 million input tokens in dollars.
@@ -54,7 +56,7 @@ func (c *Cost) Name() string { return "cost" }
 func (c *Cost) Score(_ context.Context, sample eval.EvalSample) (float64, error) {
 	modelRaw, ok := sample.Metadata["model"]
 	if !ok {
-		return 0, fmt.Errorf("cost: missing metadata key %q", "model")
+		return 0, fmt.Errorf(missingMetaKeyFmt, "model")
 	}
 	model, ok := modelRaw.(string)
 	if !ok {
@@ -68,7 +70,7 @@ func (c *Cost) Score(_ context.Context, sample eval.EvalSample) (float64, error)
 
 	inputRaw, ok := sample.Metadata["input_tokens"]
 	if !ok {
-		return 0, fmt.Errorf("cost: missing metadata key %q", "input_tokens")
+		return 0, fmt.Errorf(missingMetaKeyFmt, "input_tokens")
 	}
 	inputTokens, err := toFloat64(inputRaw)
 	if err != nil {
@@ -77,7 +79,7 @@ func (c *Cost) Score(_ context.Context, sample eval.EvalSample) (float64, error)
 
 	outputRaw, ok := sample.Metadata["output_tokens"]
 	if !ok {
-		return 0, fmt.Errorf("cost: missing metadata key %q", "output_tokens")
+		return 0, fmt.Errorf(missingMetaKeyFmt, "output_tokens")
 	}
 	outputTokens, err := toFloat64(outputRaw)
 	if err != nil {

--- a/internal/syncutil/pool_test.go
+++ b/internal/syncutil/pool_test.go
@@ -81,7 +81,9 @@ func TestWorkerPoolClosePreventsSubmit(t *testing.T) {
 	pool := NewWorkerPool(2)
 	pool.Close()
 
-	err := pool.Submit(func() {})
+	err := pool.Submit(func() {
+		// no-op: pool is closed; task body is never executed
+	})
 	if err != ErrPoolClosed {
 		t.Errorf("expected ErrPoolClosed, got %v", err)
 	}

--- a/internal/testutil/helpers_test.go
+++ b/internal/testutil/helpers_test.go
@@ -13,7 +13,8 @@ type mockT struct {
 	message string
 }
 
-func (m *mockT) Helper()                          {}
+func (m *mockT) Helper() { // no-op: satisfies testing.TB for testing
+}
 func (m *mockT) Fatalf(format string, args ...any) { m.failed = true }
 func (m *mockT) Fatal(args ...any)                 { m.failed = true }
 
@@ -125,7 +126,9 @@ func TestCollectStream(t *testing.T) {
 	})
 
 	t.Run("empty stream", func(t *testing.T) {
-		seq := func(yield func(string, error) bool) {}
+		seq := func(yield func(string, error) bool) {
+			// no-op: simulates an empty iterator to verify zero results are collected
+		}
 
 		results, err := CollectStream[string](iter.Seq2[string, error](seq))
 		if err != nil {

--- a/orchestration/chain.go
+++ b/orchestration/chain.go
@@ -8,6 +8,8 @@ import (
 	"github.com/lookatitude/beluga-ai/core"
 )
 
+const chainStepErrFmt = "orchestration/chain: step %d: %w"
+
 // Chain composes steps sequentially: the output of step N becomes the input
 // of step N+1. The resulting Runnable supports both Invoke and Stream.
 //
@@ -35,7 +37,7 @@ func (c *chainRunnable) Invoke(ctx context.Context, input any, opts ...core.Opti
 	for i, step := range c.steps {
 		result, err := step.Invoke(ctx, current, opts...)
 		if err != nil {
-			return nil, fmt.Errorf("orchestration/chain: step %d: %w", i, err)
+			return nil, fmt.Errorf(chainStepErrFmt, i, err)
 		}
 		current = result
 	}
@@ -66,7 +68,7 @@ func (c *chainRunnable) invokeLeadingSteps(ctx context.Context, input any, opts 
 	for i, step := range c.steps[:len(c.steps)-1] {
 		result, err := step.Invoke(ctx, current, opts...)
 		if err != nil {
-			return nil, fmt.Errorf("orchestration/chain: step %d: %w", i, err)
+			return nil, fmt.Errorf(chainStepErrFmt, i, err)
 		}
 		current = result
 	}
@@ -78,7 +80,7 @@ func (c *chainRunnable) streamLastStep(ctx context.Context, input any, yield fun
 	last := c.steps[len(c.steps)-1]
 	for val, err := range last.Stream(ctx, input, opts...) {
 		if err != nil {
-			yield(nil, fmt.Errorf("orchestration/chain: step %d: %w", len(c.steps)-1, err))
+			yield(nil, fmt.Errorf(chainStepErrFmt, len(c.steps)-1, err))
 			return
 		}
 		if !yield(val, nil) {

--- a/orchestration/hooks_test.go
+++ b/orchestration/hooks_test.go
@@ -156,7 +156,9 @@ func TestComposeHooks_NilHooksSkipped(t *testing.T) {
 	h1 := Hooks{} // All nil.
 	h2 := Hooks{
 		BeforeStep: func(_ context.Context, _ string, _ any) error { return nil },
-		AfterStep:  func(_ context.Context, _ string, _ any, _ error) {},
+		AfterStep: func(_ context.Context, _ string, _ any, _ error) {
+			// no-op: satisfies Hooks for testing; AfterStep behaviour not under test
+		},
 		OnBranch:   func(_ context.Context, _, _ string) error { return nil },
 		OnError:    func(_ context.Context, err error) error { return err },
 	}

--- a/orchestration/supervisor.go
+++ b/orchestration/supervisor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/lookatitude/beluga-ai/core"
 )
 
+const supervisorAgentErrFmt = "orchestration/supervisor: agent %q: %w"
+
 // StrategyFunc selects an agent from the available agents for the given input.
 // Returning a nil agent signals that execution should stop.
 type StrategyFunc func(ctx context.Context, input any, agents []agent.Agent) (agent.Agent, error)
@@ -64,7 +66,7 @@ func (s *Supervisor) Invoke(ctx context.Context, input any, opts ...core.Option)
 		inputStr := fmt.Sprintf("%v", current)
 		result, err := selected.Invoke(ctx, inputStr)
 		if err != nil {
-			return nil, fmt.Errorf("orchestration/supervisor: agent %q: %w", selected.ID(), err)
+			return nil, fmt.Errorf(supervisorAgentErrFmt, selected.ID(), err)
 		}
 		current = result
 	}
@@ -106,7 +108,7 @@ func (s *Supervisor) streamRounds(ctx context.Context, input any, yield func(any
 
 		result, err := selected.Invoke(ctx, inputStr)
 		if err != nil {
-			yield(nil, fmt.Errorf("orchestration/supervisor: agent %q: %w", selected.ID(), err))
+			yield(nil, fmt.Errorf(supervisorAgentErrFmt, selected.ID(), err))
 			return
 		}
 		current = result
@@ -117,7 +119,7 @@ func (s *Supervisor) streamRounds(ctx context.Context, input any, yield func(any
 func streamAgent(ctx context.Context, a agent.Agent, input string, yield func(any, error) bool) {
 	for event, err := range a.Stream(ctx, input) {
 		if err != nil {
-			yield(nil, fmt.Errorf("orchestration/supervisor: agent %q: %w", a.ID(), err))
+			yield(nil, fmt.Errorf(supervisorAgentErrFmt, a.ID(), err))
 			return
 		}
 		if !yield(event, nil) {

--- a/protocol/a2a/a2a_test.go
+++ b/protocol/a2a/a2a_test.go
@@ -620,7 +620,9 @@ func TestServer_Serve_BusyPort(t *testing.T) {
 	srv := NewServer(a, card)
 
 	// Listen on a port to make it busy.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// no-op: mock implementation not needed for this test
+	}))
 	defer ts.Close()
 
 	// Try to serve on the same address - the port extraction is tricky,

--- a/protocol/a2a/client.go
+++ b/protocol/a2a/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"net/http"
@@ -19,6 +20,8 @@ const (
 	opGetTask    = "a2a/get_task: "
 	opCancelTask = "a2a/cancel_task: "
 	opInvoke     = "a2a/invoke: "
+
+	unexpectedStatusFmt = "unexpected status %d"
 )
 
 // A2AClient connects to a remote A2A agent over HTTP.
@@ -49,7 +52,7 @@ func (c *A2AClient) GetCard(ctx context.Context) (*AgentCard, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(opGetCard+"unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf(opGetCard+unexpectedStatusFmt, resp.StatusCode)
 	}
 
 	var card AgentCard
@@ -105,10 +108,10 @@ func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*Task, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf(opGetTask + "task not found")
+		return nil, errors.New(opGetTask + "task not found")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(opGetTask+"unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf(opGetTask+unexpectedStatusFmt, resp.StatusCode)
 	}
 
 	var taskResp TaskResponse
@@ -132,10 +135,10 @@ func (c *A2AClient) CancelTask(ctx context.Context, taskID string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf(opCancelTask + "task not found")
+		return errors.New(opCancelTask + "task not found")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf(opCancelTask+"unexpected status %d", resp.StatusCode)
+		return fmt.Errorf(opCancelTask+unexpectedStatusFmt, resp.StatusCode)
 	}
 
 	return nil
@@ -204,7 +207,7 @@ func (a *remoteAgent) Invoke(ctx context.Context, input string, _ ...agent.Optio
 		case StatusFailed:
 			return "", fmt.Errorf(opInvoke+"task failed: %s", task.Error)
 		case StatusCanceled:
-			return "", fmt.Errorf(opInvoke + "task canceled")
+			return "", errors.New(opInvoke + "task canceled")
 		}
 
 		// Exponential backoff, capped at maxDelay.

--- a/protocol/a2a/client.go
+++ b/protocol/a2a/client.go
@@ -13,6 +13,14 @@ import (
 	"github.com/lookatitude/beluga-ai/tool"
 )
 
+const (
+	opGetCard    = "a2a/get_card: "
+	opCreateTask = "a2a/create_task: "
+	opGetTask    = "a2a/get_task: "
+	opCancelTask = "a2a/cancel_task: "
+	opInvoke     = "a2a/invoke: "
+)
+
 // A2AClient connects to a remote A2A agent over HTTP.
 type A2AClient struct {
 	baseURL    string
@@ -31,22 +39,22 @@ func NewClient(baseURL string) *A2AClient {
 func (c *A2AClient) GetCard(ctx context.Context) (*AgentCard, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/.well-known/agent.json", nil)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/get_card: %w", err)
+		return nil, fmt.Errorf(opGetCard+"%w", err)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/get_card: %w", err)
+		return nil, fmt.Errorf(opGetCard+"%w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("a2a/get_card: unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf(opGetCard+"unexpected status %d", resp.StatusCode)
 	}
 
 	var card AgentCard
 	if err := json.NewDecoder(resp.Body).Decode(&card); err != nil {
-		return nil, fmt.Errorf("a2a/get_card: %w", err)
+		return nil, fmt.Errorf(opGetCard+"%w", err)
 	}
 	return &card, nil
 }
@@ -55,30 +63,30 @@ func (c *A2AClient) GetCard(ctx context.Context) (*AgentCard, error) {
 func (c *A2AClient) CreateTask(ctx context.Context, req TaskRequest) (*Task, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/create_task: %w", err)
+		return nil, fmt.Errorf(opCreateTask+"%w", err)
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/tasks", bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("a2a/create_task: %w", err)
+		return nil, fmt.Errorf(opCreateTask+"%w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(contentTypeHeader, contentTypeJSON)
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/create_task: %w", err)
+		return nil, fmt.Errorf(opCreateTask+"%w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		var errResp ErrorResponse
 		json.NewDecoder(resp.Body).Decode(&errResp)
-		return nil, fmt.Errorf("a2a/create_task: %s", errResp.Error)
+		return nil, fmt.Errorf(opCreateTask+"%s", errResp.Error)
 	}
 
 	var taskResp TaskResponse
 	if err := json.NewDecoder(resp.Body).Decode(&taskResp); err != nil {
-		return nil, fmt.Errorf("a2a/create_task: %w", err)
+		return nil, fmt.Errorf(opCreateTask+"%w", err)
 	}
 	return &taskResp.Task, nil
 }
@@ -87,25 +95,25 @@ func (c *A2AClient) CreateTask(ctx context.Context, req TaskRequest) (*Task, err
 func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*Task, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/tasks/"+taskID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/get_task: %w", err)
+		return nil, fmt.Errorf(opGetTask+"%w", err)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("a2a/get_task: %w", err)
+		return nil, fmt.Errorf(opGetTask+"%w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("a2a/get_task: task not found")
+		return nil, fmt.Errorf(opGetTask + "task not found")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("a2a/get_task: unexpected status %d", resp.StatusCode)
+		return nil, fmt.Errorf(opGetTask+"unexpected status %d", resp.StatusCode)
 	}
 
 	var taskResp TaskResponse
 	if err := json.NewDecoder(resp.Body).Decode(&taskResp); err != nil {
-		return nil, fmt.Errorf("a2a/get_task: %w", err)
+		return nil, fmt.Errorf(opGetTask+"%w", err)
 	}
 	return &taskResp.Task, nil
 }
@@ -114,20 +122,20 @@ func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*Task, error) {
 func (c *A2AClient) CancelTask(ctx context.Context, taskID string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/tasks/"+taskID+"/cancel", nil)
 	if err != nil {
-		return fmt.Errorf("a2a/cancel_task: %w", err)
+		return fmt.Errorf(opCancelTask+"%w", err)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("a2a/cancel_task: %w", err)
+		return fmt.Errorf(opCancelTask+"%w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("a2a/cancel_task: task not found")
+		return fmt.Errorf(opCancelTask + "task not found")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("a2a/cancel_task: unexpected status %d", resp.StatusCode)
+		return fmt.Errorf(opCancelTask+"unexpected status %d", resp.StatusCode)
 	}
 
 	return nil
@@ -171,7 +179,7 @@ func (a *remoteAgent) Children() []agent.Agent { return nil }
 func (a *remoteAgent) Invoke(ctx context.Context, input string, _ ...agent.Option) (string, error) {
 	task, err := a.client.CreateTask(ctx, TaskRequest{Input: input})
 	if err != nil {
-		return "", fmt.Errorf("a2a/invoke: %w", err)
+		return "", fmt.Errorf(opInvoke+"%w", err)
 	}
 
 	// Poll until terminal state with exponential backoff.
@@ -187,16 +195,16 @@ func (a *remoteAgent) Invoke(ctx context.Context, input string, _ ...agent.Optio
 
 		task, err = a.client.GetTask(ctx, task.ID)
 		if err != nil {
-			return "", fmt.Errorf("a2a/invoke: %w", err)
+			return "", fmt.Errorf(opInvoke+"%w", err)
 		}
 
 		switch task.Status {
 		case StatusCompleted:
 			return task.Output, nil
 		case StatusFailed:
-			return "", fmt.Errorf("a2a/invoke: task failed: %s", task.Error)
+			return "", fmt.Errorf(opInvoke+"task failed: %s", task.Error)
 		case StatusCanceled:
-			return "", fmt.Errorf("a2a/invoke: task canceled")
+			return "", fmt.Errorf(opInvoke + "task canceled")
 		}
 
 		// Exponential backoff, capped at maxDelay.

--- a/protocol/a2a/server.go
+++ b/protocol/a2a/server.go
@@ -13,6 +13,11 @@ import (
 	"github.com/lookatitude/beluga-ai/agent"
 )
 
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json"
+)
+
 // A2AServer exposes a Beluga agent as an A2A remote agent via HTTP.
 // It provides endpoints for the Agent Card, task creation, status, and cancellation.
 type A2AServer struct {
@@ -76,7 +81,7 @@ func (s *A2AServer) Serve(ctx context.Context, addr string) error {
 }
 
 func (s *A2AServer) handleCard(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	json.NewEncoder(w).Encode(s.card)
 }
 
@@ -114,7 +119,7 @@ func (s *A2AServer) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	// Run the agent asynchronously.
 	go s.runTask(ctx, task)
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(TaskResponse{Task: snapshot})
 }
@@ -172,7 +177,7 @@ func (s *A2AServer) handleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	json.NewEncoder(w).Encode(TaskResponse{Task: snapshot})
 }
 
@@ -205,7 +210,7 @@ func (s *A2AServer) handleTaskAction(w http.ResponseWriter, r *http.Request) {
 	snapshot := *task
 	s.mu.Unlock()
 
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	json.NewEncoder(w).Encode(TaskResponse{Task: snapshot})
 }
 
@@ -216,7 +221,7 @@ func extractTaskID(path string) string {
 }
 
 func writeJSONError(w http.ResponseWriter, statusCode int, message string) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(ErrorResponse{Error: message})
 }

--- a/protocol/rest/rest_test.go
+++ b/protocol/rest/rest_test.go
@@ -483,19 +483,22 @@ type nonFlushWriter struct{}
 
 func (w *nonFlushWriter) Header() http.Header        { return http.Header{} }
 func (w *nonFlushWriter) Write(b []byte) (int, error) { return len(b), nil }
-func (w *nonFlushWriter) WriteHeader(int)             {}
+func (w *nonFlushWriter) WriteHeader(int) { // no-op: stub writer/flusher for testing error paths
+}
 
 // errorWriter implements http.ResponseWriter but always returns errors on Write.
 type errorWriter struct{}
 
 func (w *errorWriter) Header() http.Header        { return http.Header{} }
 func (w *errorWriter) Write(b []byte) (int, error) { return 0, fmt.Errorf("write error") }
-func (w *errorWriter) WriteHeader(int)             {}
+func (w *errorWriter) WriteHeader(int) { // no-op: stub writer/flusher for testing error paths
+}
 
 // noopFlusher implements http.Flusher but does nothing.
 type noopFlusher struct{}
 
-func (f *noopFlusher) Flush() {}
+func (f *noopFlusher) Flush() { // no-op: stub writer/flusher for testing error paths
+}
 
 // parseSSEEvents reads SSE events from the response body.
 func parseSSEEvents(t *testing.T, resp *http.Response) []sseTestEvent {
@@ -547,7 +550,8 @@ func (w *countingErrorWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func (w *countingErrorWriter) WriteHeader(int) {}
+func (w *countingErrorWriter) WriteHeader(int) { // no-op: stub writer/flusher for testing error paths
+}
 
 // TestSSEWriter_WriteEvent_EventLineError tests the error path when writing the event line fails.
 // This covers sse.go:47-49.
@@ -669,7 +673,9 @@ func TestRESTServer_Serve_AddressInUse(t *testing.T) {
 	srv.RegisterAgent("test", &mockAgent{id: "test"})
 
 	// Start a server to occupy a port.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// no-op: mock implementation not needed for this test
+	}))
 	defer ts.Close()
 
 	// Extract the address from the test server.

--- a/rag/embedding/embedding_test.go
+++ b/rag/embedding/embedding_test.go
@@ -244,112 +244,90 @@ func TestMiddleware_HooksAbort(t *testing.T) {
 	}
 }
 
-func TestMiddleware_AfterEmbedHook(t *testing.T) {
-	emb, _ := embedding.New("inmemory", config.ProviderConfig{})
-	ctx := context.Background()
-
-	var afterCalled bool
-	var capturedEmbeddings [][]float32
+func newAfterEmbedCapture() (embedding.Hooks, *bool, *[][]float32, *error) {
+	called := false
+	var captured [][]float32
 	var capturedErr error
-
 	hooks := embedding.Hooks{
 		AfterEmbed: func(_ context.Context, embeddings [][]float32, err error) {
-			afterCalled = true
-			capturedEmbeddings = embeddings
+			called = true
+			captured = embeddings
 			capturedErr = err
 		},
 	}
+	return hooks, &called, &captured, &capturedErr
+}
 
+func TestMiddleware_AfterEmbedHook_Embed(t *testing.T) {
+	emb, _ := embedding.New("inmemory", config.ProviderConfig{})
+	ctx := context.Background()
+	hooks, afterCalled, capturedEmbeddings, capturedErr := newAfterEmbedCapture()
 	wrapped := embedding.ApplyMiddleware(emb, embedding.WithHooks(hooks))
 
-	t.Run("Embed calls AfterEmbed hook", func(t *testing.T) {
-		afterCalled = false
-		capturedEmbeddings = nil
-		capturedErr = nil
+	vecs, err := wrapped.Embed(ctx, []string{"test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*afterCalled {
+		t.Fatal("AfterEmbed hook not called")
+	}
+	if len(*capturedEmbeddings) != 1 {
+		t.Fatalf("expected 1 embedding in hook, got %d", len(*capturedEmbeddings))
+	}
+	if len((*capturedEmbeddings)[0]) != len(vecs[0]) {
+		t.Fatalf("embedding dimension mismatch in hook: %d != %d", len((*capturedEmbeddings)[0]), len(vecs[0]))
+	}
+	if *capturedErr != nil {
+		t.Fatalf("expected nil error in hook, got %v", *capturedErr)
+	}
+}
 
-		vecs, err := wrapped.Embed(ctx, []string{"test"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !afterCalled {
-			t.Fatal("AfterEmbed hook not called")
-		}
-		if len(capturedEmbeddings) != 1 {
-			t.Fatalf("expected 1 embedding in hook, got %d", len(capturedEmbeddings))
-		}
-		if len(capturedEmbeddings[0]) != len(vecs[0]) {
-			t.Fatalf("embedding dimension mismatch in hook: %d != %d", len(capturedEmbeddings[0]), len(vecs[0]))
-		}
-		if capturedErr != nil {
-			t.Fatalf("expected nil error in hook, got %v", capturedErr)
-		}
-	})
+func TestMiddleware_AfterEmbedHook_EmbedSingle(t *testing.T) {
+	emb, _ := embedding.New("inmemory", config.ProviderConfig{})
+	ctx := context.Background()
+	hooks, afterCalled, capturedEmbeddings, capturedErr := newAfterEmbedCapture()
+	wrapped := embedding.ApplyMiddleware(emb, embedding.WithHooks(hooks))
 
-	t.Run("EmbedSingle calls AfterEmbed with non-nil vec", func(t *testing.T) {
-		afterCalled = false
-		capturedEmbeddings = nil
-		capturedErr = nil
-
-		vec, err := wrapped.EmbedSingle(ctx, "test")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !afterCalled {
-			t.Fatal("AfterEmbed hook not called")
-		}
-		if len(capturedEmbeddings) != 1 {
-			t.Fatalf("expected 1 embedding in hook, got %d", len(capturedEmbeddings))
-		}
-		if len(capturedEmbeddings[0]) != len(vec) {
-			t.Fatalf("embedding dimension mismatch in hook: %d != %d", len(capturedEmbeddings[0]), len(vec))
-		}
-		if capturedErr != nil {
-			t.Fatalf("expected nil error in hook, got %v", capturedErr)
-		}
-	})
+	vec, err := wrapped.EmbedSingle(ctx, "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*afterCalled {
+		t.Fatal("AfterEmbed hook not called")
+	}
+	if len(*capturedEmbeddings) != 1 {
+		t.Fatalf("expected 1 embedding in hook, got %d", len(*capturedEmbeddings))
+	}
+	if len((*capturedEmbeddings)[0]) != len(vec) {
+		t.Fatalf("embedding dimension mismatch in hook: %d != %d", len((*capturedEmbeddings)[0]), len(vec))
+	}
+	if *capturedErr != nil {
+		t.Fatalf("expected nil error in hook, got %v", *capturedErr)
+	}
 }
 
 func TestMiddleware_EmbedSingleAfterEmbedWithError(t *testing.T) {
-	// Create a mock embedder that returns an error
 	mockEmb := &errorEmbedder{err: errors.New("embed error"), dims: 128}
 	ctx := context.Background()
-
-	var afterCalled bool
-	var capturedEmbeddings [][]float32
-	var capturedErr error
-
-	hooks := embedding.Hooks{
-		AfterEmbed: func(_ context.Context, embeddings [][]float32, err error) {
-			afterCalled = true
-			capturedEmbeddings = embeddings
-			capturedErr = err
-		},
-	}
-
+	hooks, afterCalled, capturedEmbeddings, capturedErr := newAfterEmbedCapture()
 	wrapped := embedding.ApplyMiddleware(mockEmb, embedding.WithHooks(hooks))
 
-	t.Run("EmbedSingle calls AfterEmbed with nil vec on error", func(t *testing.T) {
-		afterCalled = false
-		capturedEmbeddings = nil
-		capturedErr = nil
-
-		vec, err := wrapped.EmbedSingle(ctx, "test")
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if vec != nil {
-			t.Fatalf("expected nil vec, got %v", vec)
-		}
-		if !afterCalled {
-			t.Fatal("AfterEmbed hook not called")
-		}
-		if capturedEmbeddings != nil {
-			t.Fatalf("expected nil embeddings in hook, got %v", capturedEmbeddings)
-		}
-		if capturedErr == nil {
-			t.Fatal("expected non-nil error in hook")
-		}
-	})
+	vec, err := wrapped.EmbedSingle(ctx, "test")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if vec != nil {
+		t.Fatalf("expected nil vec, got %v", vec)
+	}
+	if !*afterCalled {
+		t.Fatal("AfterEmbed hook not called")
+	}
+	if *capturedEmbeddings != nil {
+		t.Fatalf("expected nil embeddings in hook, got %v", *capturedEmbeddings)
+	}
+	if *capturedErr == nil {
+		t.Fatal("expected non-nil error in hook")
+	}
 }
 
 // errorEmbedder is a mock embedder that always returns an error.

--- a/rag/loader/providers/notion/notion_test.go
+++ b/rag/loader/providers/notion/notion_test.go
@@ -41,231 +41,203 @@ func TestNew(t *testing.T) {
 	})
 }
 
-func TestLoad(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "2022-06-28", r.Header.Get("Notion-Version"))
-			assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+func TestLoad_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "2022-06-28", r.Header.Get("Notion-Version"))
+		assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
 
-			w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
 
-			if r.URL.Path == "/v1/pages/abc123" {
-				page := pageResponse{
-					ID: "abc123",
-					Properties: map[string]property{
-						"Name": {Type: "title", Title: []richText{{PlainText: "Test Page"}}},
-					},
-				}
-				json.NewEncoder(w).Encode(page)
-				return
-			}
-
-			if r.URL.Path == "/v1/blocks/abc123/children" {
-				blocks := blockChildren{
-					Results: []block{
-						{
-							ID:   "b1",
-							Type: "heading_1",
-							Heading1: &richTextBlock{
-								RichText: []richText{{PlainText: "Title"}},
-							},
-						},
-						{
-							ID:   "b2",
-							Type: "paragraph",
-							Paragraph: &richTextBlock{
-								RichText: []richText{{PlainText: "Hello World"}},
-							},
-						},
-					},
-				}
-				json.NewEncoder(w).Encode(blocks)
-				return
-			}
-
+		switch r.URL.Path {
+		case "/v1/pages/abc123":
+			json.NewEncoder(w).Encode(pageResponse{
+				ID: "abc123",
+				Properties: map[string]property{
+					"Name": {Type: "title", Title: []richText{{PlainText: "Test Page"}}},
+				},
+			})
+		case "/v1/blocks/abc123/children":
+			json.NewEncoder(w).Encode(blockChildren{
+				Results: []block{
+					{ID: "b1", Type: "heading_1", Heading1: &richTextBlock{RichText: []richText{{PlainText: "Title"}}}},
+					{ID: "b2", Type: "paragraph", Paragraph: &richTextBlock{RichText: []richText{{PlainText: "Hello World"}}}},
+				},
+			})
+		default:
 			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer srv.Close()
+		}
+	}))
+	defer srv.Close()
 
-		l, err := New(config.ProviderConfig{
-			APIKey:  "ntn-test",
-			BaseURL: srv.URL,
+	l, err := New(config.ProviderConfig{APIKey: "ntn-test", BaseURL: srv.URL})
+	require.NoError(t, err)
+
+	docs, err := l.Load(context.Background(), "abc123")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, "abc123", docs[0].ID)
+	assert.Contains(t, docs[0].Content, "Title")
+	assert.Contains(t, docs[0].Content, "Hello World")
+	assert.Equal(t, "notion", docs[0].Metadata["loader"])
+	assert.Equal(t, "Test Page", docs[0].Metadata["title"])
+}
+
+func TestLoad_EmptySource(t *testing.T) {
+	l, err := New(config.ProviderConfig{APIKey: "test"})
+	require.NoError(t, err)
+
+	_, err = l.Load(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestLoad_EmptyBlocks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/pages/empty" {
+			json.NewEncoder(w).Encode(pageResponse{ID: "empty"})
+			return
+		}
+		json.NewEncoder(w).Encode(blockChildren{})
+	}))
+	defer srv.Close()
+
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
+
+	docs, err := l.Load(context.Background(), "empty")
+	require.NoError(t, err)
+	assert.Nil(t, docs)
+}
+
+func TestLoad_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"failed"}`))
+	}))
+	defer srv.Close()
+
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
+
+	_, err = l.Load(context.Background(), "abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "notion")
+}
+
+func TestLoad_CodeBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/pages/code1" {
+			json.NewEncoder(w).Encode(pageResponse{ID: "code1"})
+			return
+		}
+		json.NewEncoder(w).Encode(blockChildren{
+			Results: []block{
+				{
+					ID:   "c1",
+					Type: "code",
+					Code: &codeBlock{
+						RichText: []richText{{PlainText: "fmt.Println(\"hello\")"}},
+						Language: "go",
+					},
+				},
+			},
 		})
-		require.NoError(t, err)
+	}))
+	defer srv.Close()
 
-		docs, err := l.Load(context.Background(), "abc123")
-		require.NoError(t, err)
-		require.Len(t, docs, 1)
-		assert.Equal(t, "abc123", docs[0].ID)
-		assert.Contains(t, docs[0].Content, "Title")
-		assert.Contains(t, docs[0].Content, "Hello World")
-		assert.Equal(t, "notion", docs[0].Metadata["loader"])
-		assert.Equal(t, "Test Page", docs[0].Metadata["title"])
-	})
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
 
-	t.Run("empty source", func(t *testing.T) {
-		l, err := New(config.ProviderConfig{APIKey: "test"})
-		require.NoError(t, err)
+	docs, err := l.Load(context.Background(), "code1")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Contains(t, docs[0].Content, "fmt.Println")
+}
 
-		_, err = l.Load(context.Background(), "")
-		assert.Error(t, err)
-	})
+func TestLoad_AllBlockTypes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/pages/alltypes" {
+			json.NewEncoder(w).Encode(pageResponse{ID: "alltypes"})
+			return
+		}
+		json.NewEncoder(w).Encode(blockChildren{
+			Results: []block{
+				{ID: "h2", Type: "heading_2", Heading2: &richTextBlock{RichText: []richText{{PlainText: "H2 Title"}}}},
+				{ID: "h3", Type: "heading_3", Heading3: &richTextBlock{RichText: []richText{{PlainText: "H3 Title"}}}},
+				{ID: "bullet", Type: "bulleted_list_item", BulletedList: &richTextBlock{RichText: []richText{{PlainText: "Bullet point"}}}},
+				{ID: "number", Type: "numbered_list_item", NumberedList: &richTextBlock{RichText: []richText{{PlainText: "Numbered item"}}}},
+				{ID: "toggle", Type: "toggle", Toggle: &richTextBlock{RichText: []richText{{PlainText: "Toggle content"}}}},
+				{ID: "quote", Type: "quote", Quote: &richTextBlock{RichText: []richText{{PlainText: "Quote text"}}}},
+				{ID: "callout", Type: "callout", Callout: &richTextBlock{RichText: []richText{{PlainText: "Callout info"}}}},
+				{ID: "unknown", Type: "unsupported_type"},
+			},
+		})
+	}))
+	defer srv.Close()
 
-	t.Run("empty blocks", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/v1/pages/empty" {
-				json.NewEncoder(w).Encode(pageResponse{ID: "empty"})
-				return
-			}
-			json.NewEncoder(w).Encode(blockChildren{})
-		}))
-		defer srv.Close()
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
 
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
+	docs, err := l.Load(context.Background(), "alltypes")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Contains(t, docs[0].Content, "H2 Title")
+	assert.Contains(t, docs[0].Content, "H3 Title")
+	assert.Contains(t, docs[0].Content, "Bullet point")
+	assert.Contains(t, docs[0].Content, "Numbered item")
+	assert.Contains(t, docs[0].Content, "Toggle content")
+	assert.Contains(t, docs[0].Content, "Quote text")
+	assert.Contains(t, docs[0].Content, "Callout info")
+	assert.NotContains(t, docs[0].Content, "unsupported_type")
+}
 
-		docs, err := l.Load(context.Background(), "empty")
-		require.NoError(t, err)
-		assert.Nil(t, docs)
-	})
-
-	t.Run("server error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"error":"failed"}`))
-		}))
-		defer srv.Close()
-
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
-
-		_, err = l.Load(context.Background(), "abc")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "notion")
-	})
-
-	t.Run("code block", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/v1/pages/code1" {
-				json.NewEncoder(w).Encode(pageResponse{ID: "code1"})
-				return
-			}
-			blocks := blockChildren{
+func TestLoad_PageIDWithDashes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/pages/abc123def456":
+			json.NewEncoder(w).Encode(pageResponse{ID: "abc123def456"})
+		case "/v1/blocks/abc123def456/children":
+			json.NewEncoder(w).Encode(blockChildren{
 				Results: []block{
-					{
-						ID:   "c1",
-						Type: "code",
-						Code: &codeBlock{
-							RichText: []richText{{PlainText: "fmt.Println(\"hello\")"}},
-							Language: "go",
-						},
-					},
+					{ID: "p1", Type: "paragraph", Paragraph: &richTextBlock{RichText: []richText{{PlainText: "Test"}}}},
 				},
-			}
-			json.NewEncoder(w).Encode(blocks)
-		}))
-		defer srv.Close()
-
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
-
-		docs, err := l.Load(context.Background(), "code1")
-		require.NoError(t, err)
-		require.Len(t, docs, 1)
-		assert.Contains(t, docs[0].Content, "fmt.Println")
-	})
-
-	t.Run("all block types", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/v1/pages/alltypes" {
-				json.NewEncoder(w).Encode(pageResponse{ID: "alltypes"})
-				return
-			}
-			blocks := blockChildren{
-				Results: []block{
-					{ID: "h2", Type: "heading_2", Heading2: &richTextBlock{RichText: []richText{{PlainText: "H2 Title"}}}},
-					{ID: "h3", Type: "heading_3", Heading3: &richTextBlock{RichText: []richText{{PlainText: "H3 Title"}}}},
-					{ID: "bullet", Type: "bulleted_list_item", BulletedList: &richTextBlock{RichText: []richText{{PlainText: "Bullet point"}}}},
-					{ID: "number", Type: "numbered_list_item", NumberedList: &richTextBlock{RichText: []richText{{PlainText: "Numbered item"}}}},
-					{ID: "toggle", Type: "toggle", Toggle: &richTextBlock{RichText: []richText{{PlainText: "Toggle content"}}}},
-					{ID: "quote", Type: "quote", Quote: &richTextBlock{RichText: []richText{{PlainText: "Quote text"}}}},
-					{ID: "callout", Type: "callout", Callout: &richTextBlock{RichText: []richText{{PlainText: "Callout info"}}}},
-					{ID: "unknown", Type: "unsupported_type"},
-				},
-			}
-			json.NewEncoder(w).Encode(blocks)
-		}))
-		defer srv.Close()
-
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
-
-		docs, err := l.Load(context.Background(), "alltypes")
-		require.NoError(t, err)
-		require.Len(t, docs, 1)
-		assert.Contains(t, docs[0].Content, "H2 Title")
-		assert.Contains(t, docs[0].Content, "H3 Title")
-		assert.Contains(t, docs[0].Content, "Bullet point")
-		assert.Contains(t, docs[0].Content, "Numbered item")
-		assert.Contains(t, docs[0].Content, "Toggle content")
-		assert.Contains(t, docs[0].Content, "Quote text")
-		assert.Contains(t, docs[0].Content, "Callout info")
-		assert.NotContains(t, docs[0].Content, "unsupported_type")
-	})
-
-	t.Run("page id with dashes", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			// Verify dashes are stripped
-			if r.URL.Path == "/v1/pages/abc123def456" {
-				json.NewEncoder(w).Encode(pageResponse{ID: "abc123def456"})
-				return
-			}
-			if r.URL.Path == "/v1/blocks/abc123def456/children" {
-				json.NewEncoder(w).Encode(blockChildren{
-					Results: []block{
-						{ID: "p1", Type: "paragraph", Paragraph: &richTextBlock{RichText: []richText{{PlainText: "Test"}}}},
-					},
-				})
-				return
-			}
+			})
+		default:
 			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer srv.Close()
+		}
+	}))
+	defer srv.Close()
 
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
 
-		// Load with dashed page ID
-		docs, err := l.Load(context.Background(), "abc123-def456")
-		require.NoError(t, err)
-		require.Len(t, docs, 1)
-		assert.Equal(t, "abc123def456", docs[0].ID)
-	})
+	docs, err := l.Load(context.Background(), "abc123-def456")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.Equal(t, "abc123def456", docs[0].ID)
+}
 
-	t.Run("blocks fetch error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			if r.URL.Path == "/v1/pages/test123" {
-				json.NewEncoder(w).Encode(pageResponse{ID: "test123"})
-				return
-			}
-			// Fail on blocks fetch
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"error":"failed to fetch blocks"}`))
-		}))
-		defer srv.Close()
+func TestLoad_BlocksFetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/pages/test123" {
+			json.NewEncoder(w).Encode(pageResponse{ID: "test123"})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"failed to fetch blocks"}`))
+	}))
+	defer srv.Close()
 
-		l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
-		require.NoError(t, err)
+	l, err := New(config.ProviderConfig{APIKey: "test", BaseURL: srv.URL})
+	require.NoError(t, err)
 
-		_, err = l.Load(context.Background(), "test123")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "fetch blocks")
-	})
+	_, err = l.Load(context.Background(), "test123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch blocks")
 }
 
 func TestRegistryNew(t *testing.T) {

--- a/rag/loader/providers/unstructured/unstructured_test.go
+++ b/rag/loader/providers/unstructured/unstructured_test.go
@@ -438,6 +438,24 @@ func TestLoad_APIErrorMessageFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), errorMsg)
 }
 
+func resolveTestSource(t *testing.T, source string, wantErr bool) string {
+	t.Helper()
+	const nonexistentFile = "/tmp/nonexistent-file-xyz-12345.pdf"
+	if source == "" && !wantErr {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "test.txt")
+		require.NoError(t, os.WriteFile(p, []byte("content"), 0644))
+		return p
+	}
+	if source != "" && source != nonexistentFile {
+		dir := t.TempDir()
+		p := filepath.Join(dir, filepath.Base(source))
+		require.NoError(t, os.WriteFile(p, []byte("content"), 0644))
+		return p
+	}
+	return source
+}
+
 func TestLoad_TableDriven(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -450,15 +468,15 @@ func TestLoad_TableDriven(t *testing.T) {
 		checkDoc    func(t *testing.T, doc schema.Document)
 	}{
 		{
-			name:   "empty source path",
-			source: "",
-			wantErr: true,
+			name:        "empty source path",
+			source:      "",
+			wantErr:     true,
 			errContains: "source file path is required",
 		},
 		{
-			name:   "nonexistent file",
-			source: "/tmp/nonexistent-file-xyz-12345.pdf",
-			wantErr: true,
+			name:        "nonexistent file",
+			source:      "/tmp/nonexistent-file-xyz-12345.pdf",
+			wantErr:     true,
 			errContains: "open file",
 		},
 		{
@@ -500,18 +518,7 @@ func TestLoad_TableDriven(t *testing.T) {
 			l, err := New(config.ProviderConfig{BaseURL: ts.URL})
 			require.NoError(t, err)
 
-			// Create temp file if source is not provided
-			source := tt.source
-			if source == "" && !tt.wantErr {
-				dir := t.TempDir()
-				source = filepath.Join(dir, "test.txt")
-				require.NoError(t, os.WriteFile(source, []byte("content"), 0644))
-			} else if source != "" && source != "/tmp/nonexistent-file-xyz-12345.pdf" {
-				dir := t.TempDir()
-				actualPath := filepath.Join(dir, filepath.Base(source))
-				require.NoError(t, os.WriteFile(actualPath, []byte("content"), 0644))
-				source = actualPath
-			}
+			source := resolveTestSource(t, tt.source, tt.wantErr)
 
 			docs, err := l.Load(context.Background(), source)
 			if tt.wantErr {

--- a/rag/retriever/mocks_test.go
+++ b/rag/retriever/mocks_test.go
@@ -26,7 +26,9 @@ func (m *mockChatModel) Generate(ctx context.Context, msgs []schema.Message, opt
 }
 
 func (m *mockChatModel) Stream(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
-	return func(yield func(schema.StreamChunk, error) bool) {}
+	return func(yield func(schema.StreamChunk, error) bool) {
+		// no-op: satisfies llm.ChatModel for testing; streaming not exercised
+	}
 }
 
 func (m *mockChatModel) BindTools(_ []schema.ToolDefinition) llm.ChatModel {

--- a/rag/retriever/retriever_test.go
+++ b/rag/retriever/retriever_test.go
@@ -86,7 +86,9 @@ func (m *mockChatModel) Generate(_ context.Context, msgs []schema.Message, _ ...
 }
 
 func (m *mockChatModel) Stream(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
-	return func(yield func(schema.StreamChunk, error) bool) {}
+	return func(yield func(schema.StreamChunk, error) bool) {
+		// no-op: satisfies llm.ChatModel for testing; streaming not exercised
+	}
 }
 
 func (m *mockChatModel) BindTools(_ []schema.ToolDefinition) llm.ChatModel {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -96,125 +96,99 @@ func TestHandleInvoke(t *testing.T) {
 	})
 }
 
-func TestHandleStream(t *testing.T) {
-	t.Run("success with events", func(t *testing.T) {
-		a := &mockAgent{
-			id: "test",
-			events: []agent.Event{
-				{Type: agent.EventText, Text: "Hello", AgentID: "test"},
-				{Type: agent.EventText, Text: " World", AgentID: "test"},
-				{Type: agent.EventDone, AgentID: "test"},
-			},
-		}
-		handler := NewAgentHandler(a)
+func doStreamRequest(t *testing.T, handler http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
 
-		body := `{"input":"hi"}`
-		req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
+func TestHandleStream_SuccessWithEvents(t *testing.T) {
+	a := &mockAgent{
+		id: "test",
+		events: []agent.Event{
+			{Type: agent.EventText, Text: "Hello", AgentID: "test"},
+			{Type: agent.EventText, Text: " World", AgentID: "test"},
+			{Type: agent.EventDone, AgentID: "test"},
+		},
+	}
+	handler := NewAgentHandler(a)
+	w := doStreamRequest(t, handler, `{"input":"hi"}`)
 
-		handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want %q", got, "text/event-stream")
+	}
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "event: text") {
+		t.Errorf("expected 'event: text' in response body, got:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, `"Hello"`) {
+		t.Errorf("expected 'Hello' in response body, got:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, "event: done") {
+		t.Errorf("expected 'event: done' in response body, got:\n%s", respBody)
+	}
+}
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-		}
+func TestHandleStream_StreamError(t *testing.T) {
+	a := &errorStreamAgent{id: "test", err: errors.New("stream failed")}
+	handler := NewAgentHandler(a)
+	w := doStreamRequest(t, handler, `{"input":"hi"}`)
 
-		if got := w.Header().Get("Content-Type"); got != "text/event-stream" {
-			t.Errorf("Content-Type = %q, want %q", got, "text/event-stream")
-		}
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "event: error") {
+		t.Errorf("expected 'event: error' in response body, got:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, "stream failed") {
+		t.Errorf("expected 'stream failed' in response body, got:\n%s", respBody)
+	}
+}
 
-		respBody := w.Body.String()
-		if !strings.Contains(respBody, "event: text") {
-			t.Errorf("expected 'event: text' in response body, got:\n%s", respBody)
-		}
-		if !strings.Contains(respBody, `"Hello"`) {
-			t.Errorf("expected 'Hello' in response body, got:\n%s", respBody)
-		}
-		if !strings.Contains(respBody, "event: done") {
-			t.Errorf("expected 'event: done' in response body, got:\n%s", respBody)
-		}
-	})
+func TestHandleStream_InvalidJSON(t *testing.T) {
+	a := &mockAgent{id: "test"}
+	handler := NewAgentHandler(a)
 
-	t.Run("stream error", func(t *testing.T) {
-		a := &errorStreamAgent{
-			id:  "test",
-			err: errors.New("stream failed"),
-		}
-		handler := NewAgentHandler(a)
+	req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader("{bad"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
 
-		body := `{"input":"hi"}`
-		req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
 
-		handler.ServeHTTP(w, req)
+func TestHandleStream_EmptyEventsSendsDone(t *testing.T) {
+	a := &mockAgent{id: "test", events: nil}
+	handler := NewAgentHandler(a)
+	w := doStreamRequest(t, handler, `{"input":"hi"}`)
 
-		respBody := w.Body.String()
-		if !strings.Contains(respBody, "event: error") {
-			t.Errorf("expected 'event: error' in response body, got:\n%s", respBody)
-		}
-		if !strings.Contains(respBody, "stream failed") {
-			t.Errorf("expected 'stream failed' in response body, got:\n%s", respBody)
-		}
-	})
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "event: done") {
+		t.Errorf("expected final 'event: done' in response body, got:\n%s", respBody)
+	}
+}
 
-	t.Run("invalid JSON", func(t *testing.T) {
-		a := &mockAgent{id: "test"}
-		handler := NewAgentHandler(a)
+func TestHandleStream_EmptyTypeDefaultsToMessage(t *testing.T) {
+	a := &mockAgent{
+		id:     "test",
+		events: []agent.Event{{Type: "", Text: "some text", AgentID: "test"}},
+	}
+	handler := NewAgentHandler(a)
+	w := doStreamRequest(t, handler, `{"input":"hi"}`)
 
-		req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader("{bad"))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-
-		handler.ServeHTTP(w, req)
-
-		if w.Code != http.StatusBadRequest {
-			t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
-		}
-	})
-
-	t.Run("empty events stream sends done", func(t *testing.T) {
-		a := &mockAgent{id: "test", events: nil}
-		handler := NewAgentHandler(a)
-
-		body := `{"input":"hi"}`
-		req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-
-		handler.ServeHTTP(w, req)
-
-		respBody := w.Body.String()
-		if !strings.Contains(respBody, "event: done") {
-			t.Errorf("expected final 'event: done' in response body, got:\n%s", respBody)
-		}
-	})
-
-	t.Run("event with empty type defaults to message", func(t *testing.T) {
-		a := &mockAgent{
-			id: "test",
-			events: []agent.Event{
-				{Type: "", Text: "some text", AgentID: "test"},
-			},
-		}
-		handler := NewAgentHandler(a)
-
-		body := `{"input":"hi"}`
-		req := httptest.NewRequest(http.MethodPost, "/stream", strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-
-		handler.ServeHTTP(w, req)
-
-		respBody := w.Body.String()
-		// Should have "event: message" due to default.
-		if !strings.Contains(respBody, "event: message") {
-			t.Errorf("expected 'event: message' for empty event type, got:\n%s", respBody)
-		}
-		if !strings.Contains(respBody, "some text") {
-			t.Errorf("expected 'some text' in response body, got:\n%s", respBody)
-		}
-	})
+	respBody := w.Body.String()
+	if !strings.Contains(respBody, "event: message") {
+		t.Errorf("expected 'event: message' for empty event type, got:\n%s", respBody)
+	}
+	if !strings.Contains(respBody, "some text") {
+		t.Errorf("expected 'some text' in response body, got:\n%s", respBody)
+	}
 }
 
 // errorStreamAgent emits a single error from Stream.

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -122,7 +122,8 @@ type noFlushWriter struct{}
 
 func (w *noFlushWriter) Header() http.Header         { return http.Header{} }
 func (w *noFlushWriter) Write(b []byte) (int, error)  { return len(b), nil }
-func (w *noFlushWriter) WriteHeader(statusCode int)    {}
+func (w *noFlushWriter) WriteHeader(statusCode int) { // no-op: stub writer/flusher for testing error paths
+}
 
 // errWriter implements http.ResponseWriter and http.Flusher but returns error on Write.
 type errWriter struct {
@@ -140,9 +141,11 @@ func (w *errWriter) Write(b []byte) (int, error) {
 	return 0, fmt.Errorf("write error")
 }
 
-func (w *errWriter) WriteHeader(statusCode int) {}
+func (w *errWriter) WriteHeader(statusCode int) { // no-op: stub writer/flusher for testing error paths
+}
 
-func (w *errWriter) Flush() {}
+func (w *errWriter) Flush() { // no-op: stub writer/flusher for testing error paths
+}
 
 func TestSSEWriter_WriteEvent_Error(t *testing.T) {
 	w := &errWriter{}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,7 @@ sonar.test.inclusions=**/*_test.go
 sonar.go.coverage.reportPaths=coverage.out
 
 sonar.cpd.exclusions=**/providers/**
+
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go

--- a/state/hooks_test.go
+++ b/state/hooks_test.go
@@ -197,7 +197,9 @@ func TestComposeHooks_OnError_NonNilShortCircuits(t *testing.T) {
 func TestComposeHooks_NilHooksSkipped(t *testing.T) {
 	// All nil hooks — should not panic.
 	h1 := Hooks{} // all nil
-	h2 := Hooks{AfterGet: func(ctx context.Context, key string, val any, err error) {}}
+	h2 := Hooks{AfterGet: func(ctx context.Context, key string, val any, err error) {
+		// no-op: satisfies Hooks for testing; AfterGet behaviour not under test
+	}}
 
 	composed := ComposeHooks(h1, h2)
 

--- a/voice/pipeline_test.go
+++ b/voice/pipeline_test.go
@@ -222,7 +222,9 @@ func TestComposeHooksOnError(t *testing.T) {
 func TestComposeHooksNilFields(t *testing.T) {
 	// Composing hooks with nil fields should not panic.
 	h1 := Hooks{} // all nil
-	h2 := Hooks{OnSpeechEnd: func(_ context.Context) {}}
+	h2 := Hooks{OnSpeechEnd: func(_ context.Context) {
+		// no-op: satisfies Hooks for testing; OnSpeechEnd behaviour not under test
+	}}
 
 	composed := ComposeHooks(h1, h2)
 	// Should not panic.

--- a/voice/processor_test.go
+++ b/voice/processor_test.go
@@ -196,43 +196,25 @@ func TestChainErrorInMiddleProcessor(t *testing.T) {
 	}
 }
 
+func makeSuffixProcessor(suffix string) FrameProcessorFunc {
+	return FrameProcessorFunc(func(_ context.Context, in <-chan Frame, out chan<- Frame) error {
+		defer close(out)
+		for f := range in {
+			if f.Type == FrameText {
+				out <- NewTextFrame(f.Text() + suffix)
+			} else {
+				out <- f
+			}
+		}
+		return nil
+	})
+}
+
 func TestChainThreeProcessors(t *testing.T) {
 	// Three-processor chain exercises the intermediate channel path (i > 0 && i < len-1).
-	addA := FrameProcessorFunc(func(_ context.Context, in <-chan Frame, out chan<- Frame) error {
-		defer close(out)
-		for f := range in {
-			if f.Type == FrameText {
-				out <- NewTextFrame(f.Text() + "A")
-			} else {
-				out <- f
-			}
-		}
-		return nil
-	})
-
-	addB := FrameProcessorFunc(func(_ context.Context, in <-chan Frame, out chan<- Frame) error {
-		defer close(out)
-		for f := range in {
-			if f.Type == FrameText {
-				out <- NewTextFrame(f.Text() + "B")
-			} else {
-				out <- f
-			}
-		}
-		return nil
-	})
-
-	addC := FrameProcessorFunc(func(_ context.Context, in <-chan Frame, out chan<- Frame) error {
-		defer close(out)
-		for f := range in {
-			if f.Type == FrameText {
-				out <- NewTextFrame(f.Text() + "C")
-			} else {
-				out <- f
-			}
-		}
-		return nil
-	})
+	addA := makeSuffixProcessor("A")
+	addB := makeSuffixProcessor("B")
+	addC := makeSuffixProcessor("C")
 
 	chain := Chain(addA, addB, addC)
 	in := make(chan Frame, 1)

--- a/voice/s2s/providers/gemini/gemini_test.go
+++ b/voice/s2s/providers/gemini/gemini_test.go
@@ -492,6 +492,27 @@ func TestStartWithOptions(t *testing.T) {
 	})
 }
 
+// collectEvents drains up to maxEvents from session.Recv() with a timeout.
+func collectEvents(t *testing.T, session s2s.Session, maxEvents int, timeout time.Duration) []s2s.SessionEvent {
+	t.Helper()
+	var events []s2s.SessionEvent
+	timer := time.After(timeout)
+	for {
+		select {
+		case event, ok := <-session.Recv():
+			if !ok {
+				return events
+			}
+			events = append(events, event)
+			if len(events) >= maxEvents {
+				return events
+			}
+		case <-timer:
+			return events
+		}
+	}
+}
+
 func TestReadLoopEvents(t *testing.T) {
 	t.Run("connection error emits error event", func(t *testing.T) {
 		srv := newWSServer(t, func(conn *websocket.Conn) {
@@ -580,23 +601,7 @@ func TestReadLoopEvents(t *testing.T) {
 		require.NoError(t, err)
 		defer session.Close()
 
-		var events []s2s.SessionEvent
-		timeout := time.After(3 * time.Second)
-		for {
-			select {
-			case event, ok := <-session.Recv():
-				if !ok {
-					goto done
-				}
-				events = append(events, event)
-				if len(events) >= 2 {
-					goto done
-				}
-			case <-timeout:
-				goto done
-			}
-		}
-	done:
+		events := collectEvents(t, session, 2, 3*time.Second)
 		require.Len(t, events, 2)
 		assert.Equal(t, s2s.EventTextOutput, events[0].Type)
 		assert.Equal(t, "caption text", events[0].Text)
@@ -651,23 +656,7 @@ func TestReadLoopEvents(t *testing.T) {
 		require.NoError(t, err)
 		defer session.Close()
 
-		var events []s2s.SessionEvent
-		timeout := time.After(3 * time.Second)
-		for {
-			select {
-			case event, ok := <-session.Recv():
-				if !ok {
-					goto done2
-				}
-				events = append(events, event)
-				if len(events) >= 2 {
-					goto done2
-				}
-			case <-timeout:
-				goto done2
-			}
-		}
-	done2:
+		events := collectEvents(t, session, 2, 3*time.Second)
 		require.Len(t, events, 2)
 		assert.Equal(t, s2s.EventToolCall, events[0].Type)
 		assert.Equal(t, "call_1", events[0].ToolCall.ID)

--- a/voice/stt/providers/assemblyai/assemblyai_test.go
+++ b/voice/stt/providers/assemblyai/assemblyai_test.go
@@ -47,754 +47,628 @@ func TestNew(t *testing.T) {
 	})
 }
 
-func TestTranscribe(t *testing.T) {
-	t.Run("successful transcription", func(t *testing.T) {
-		callCount := 0
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "test-key", r.Header.Get("Authorization"))
-
-			switch {
-			case r.URL.Path == "/upload":
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(uploadResponse{
-					UploadURL: "https://cdn.assemblyai.com/upload/test123",
-				})
-
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				var req transcriptRequest
-				json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, "https://cdn.assemblyai.com/upload/test123", req.AudioURL)
-
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(transcriptResponse{
-					ID:     "tx_123",
-					Status: "queued",
-				})
-
-			case r.URL.Path == "/transcript/tx_123" && r.Method == http.MethodGet:
-				callCount++
-				status := "processing"
-				text := ""
-				if callCount >= 2 {
-					status = "completed"
-					text = "hello world"
-				}
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(transcriptResponse{
-					ID:     "tx_123",
-					Status: status,
-					Text:   text,
-				})
+func TestTranscribe_SuccessfulTranscription(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-key", r.Header.Get("Authorization"))
+		switch {
+		case r.URL.Path == "/upload":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.assemblyai.com/upload/test123"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			var req transcriptRequest
+			json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+			assert.Equal(t, "https://cdn.assemblyai.com/upload/test123", req.AudioURL)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_123", Status: "queued"}) //nolint:errcheck
+		case r.URL.Path == "/transcript/tx_123" && r.Method == http.MethodGet:
+			callCount++
+			status, text := "processing", ""
+			if callCount >= 2 {
+				status, text = "completed", "hello world"
 			}
-		}))
-		defer srv.Close()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_123", Status: status, Text: text}) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
 
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
 
-		text, err := e.Transcribe(context.Background(), []byte("fake-audio"))
-		require.NoError(t, err)
-		assert.Equal(t, "hello world", text)
-	})
-
-	t.Run("transcription error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_err", Status: "error", Error: "bad audio"})
-			case r.URL.Path == "/transcript/tx_err":
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_err", Status: "error", Error: "bad audio"})
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		_, err = e.Transcribe(context.Background(), []byte("bad-audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bad audio")
-	})
-
-	t.Run("upload error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error":"unauthorized"}`))
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "bad-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		_, err = e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "401")
-	})
-
-	t.Run("context cancelled", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(100 * time.Millisecond)
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		_, err = e.Transcribe(ctx, []byte("audio"))
-		require.Error(t, err)
-	})
-
-	t.Run("with options", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				var req transcriptRequest
-				json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, "en", req.LanguageCode)
-				assert.NotNil(t, req.Punctuate)
-				assert.True(t, *req.Punctuate)
-				assert.NotNil(t, req.SpeakerLabels)
-				assert.True(t, *req.SpeakerLabels)
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_opt", Status: "completed", Text: "test"})
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		text, err := e.Transcribe(context.Background(), []byte("audio"),
-			stt.WithLanguage("en"),
-			stt.WithPunctuation(true),
-			stt.WithDiarization(true),
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "test", text)
-	})
-
-	t.Run("upload decode error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("not json"))
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "decode upload")
-	})
-
-	t.Run("create transcript HTTP error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(`{"error":"server error"}`))
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "500")
-	})
-
-	t.Run("create transcript decode error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript":
-				w.Write([]byte("not json"))
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "decode transcript")
-	})
-
-	t.Run("poll decode error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_dec", Status: "queued"})
-			case r.URL.Path == "/transcript/tx_dec":
-				w.Write([]byte("not json"))
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "decode poll")
-	})
-
-	t.Run("upload HTTP failed", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			hj, ok := w.(http.Hijacker)
-			if ok {
-				c, _, _ := hj.Hijack()
-				c.Close()
-				return
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "upload failed")
-	})
-
-	t.Run("create transcript HTTP failed", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript":
-				hj, ok := w.(http.Hijacker)
-				if ok {
-					c, _, _ := hj.Hijack()
-					c.Close()
-					return
-				}
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "create transcript failed")
-	})
-
-	t.Run("poll HTTP failed", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_pf", Status: "queued"})
-			case r.URL.Path == "/transcript/tx_pf":
-				hj, ok := w.(http.Hijacker)
-				if ok {
-					c, _, _ := hj.Hijack()
-					c.Close()
-					return
-				}
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		_, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "poll failed")
-	})
-
-	t.Run("context cancelled during poll", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"})
-			case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_cp", Status: "queued"})
-			case strings.HasPrefix(r.URL.Path, "/transcript/tx_cp"):
-				json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_cp", Status: "processing"})
-			}
-		}))
-		defer srv.Close()
-
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-
-		_, err := e.Transcribe(ctx, []byte("audio"))
-		require.Error(t, err)
-	})
+	text, err := e.Transcribe(context.Background(), []byte("fake-audio"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", text)
 }
 
-func TestTranscribeStream(t *testing.T) {
-	t.Run("successful streaming", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
+func TestTranscribe_TranscriptionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_err", Status: "error", Error: "bad audio"}) //nolint:errcheck
+		case r.URL.Path == "/transcript/tx_err":
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_err", Status: "error", Error: "bad audio"}) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	_, err = e.Transcribe(context.Background(), []byte("bad-audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad audio")
+}
+
+func TestTranscribe_UploadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized"}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "bad-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	_, err = e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestTranscribe_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = e.Transcribe(ctx, []byte("audio"))
+	require.Error(t, err)
+}
+
+func TestTranscribe_WithOptions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			var req transcriptRequest
+			json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+			assert.Equal(t, "en", req.LanguageCode)
+			assert.NotNil(t, req.Punctuate)
+			assert.True(t, *req.Punctuate)
+			assert.NotNil(t, req.SpeakerLabels)
+			assert.True(t, *req.SpeakerLabels)
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_opt", Status: "completed", Text: "test"}) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	text, err := e.Transcribe(context.Background(), []byte("audio"),
+		stt.WithLanguage("en"),
+		stt.WithPunctuation(true),
+		stt.WithDiarization(true),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "test", text)
+}
+
+func TestTranscribe_UploadDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode upload")
+}
+
+func TestTranscribe_CreateTranscriptHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"server error"}`)) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestTranscribe_CreateTranscriptDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript":
+			w.Write([]byte("not json")) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode transcript")
+}
+
+func TestTranscribe_PollDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_dec", Status: "queued"}) //nolint:errcheck
+		case r.URL.Path == "/transcript/tx_dec":
+			w.Write([]byte("not json")) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode poll")
+}
+
+func TestTranscribe_UploadHTTPFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		c, _, _ := hj.Hijack()
+		c.Close()
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upload failed")
+}
+
+func TestTranscribe_CreateTranscriptHTTPFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
 				return
 			}
-			ctx := r.Context()
+			c, _, _ := hj.Hijack()
+			c.Close()
+		}
+	}))
+	defer srv.Close()
 
-			// Read audio data from client
-			conn.Read(ctx)
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
 
-			// Send transcript with words
-			wsjson.Write(ctx, conn, realtimeMessage{
-				MessageType: "FinalTranscript",
-				Text:        "hello world",
-				Confidence:  0.98,
-				AudioStart:  0,
-				AudioEnd:    1500,
-				Words: []struct {
-					Text       string  `json:"text"`
-					Start      int     `json:"start"`
-					End        int     `json:"end"`
-					Confidence float64 `json:"confidence"`
-				}{
-					{Text: "hello", Start: 0, End: 500, Confidence: 0.99},
-					{Text: "world", Start: 600, End: 1500, Confidence: 0.97},
-				},
-			})
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create transcript failed")
+}
 
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
+func TestTranscribe_PollHTTPFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_pf", Status: "queued"}) //nolint:errcheck
+		case r.URL.Path == "/transcript/tx_pf":
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				return
+			}
+			c, _, _ := hj.Hijack()
+			c.Close()
+		}
+	}))
+	defer srv.Close()
 
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
 
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key": "test-key",
-				"ws_url":  wsURL,
+	_, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll failed")
+}
+
+func TestTranscribe_ContextCancelledDuringPoll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{UploadURL: "https://cdn.test/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcript" && r.Method == http.MethodPost:
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_cp", Status: "queued"}) //nolint:errcheck
+		case strings.HasPrefix(r.URL.Path, "/transcript/tx_cp"):
+			json.NewEncoder(w).Encode(transcriptResponse{ID: "tx_cp", Status: "processing"}) //nolint:errcheck
+		}
+	}))
+	defer srv.Close()
+
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := e.Transcribe(ctx, []byte("audio"))
+	require.Error(t, err)
+}
+
+func TestTranscribeStream_SuccessfulStreaming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Read(ctx) //nolint:errcheck
+		wsjson.Write(ctx, conn, realtimeMessage{ //nolint:errcheck
+			MessageType: "FinalTranscript",
+			Text:        "hello world",
+			Confidence:  0.98,
+			AudioStart:  0,
+			AudioEnd:    1500,
+			Words: []struct {
+				Text       string  `json:"text"`
+				Start      int     `json:"start"`
+				End        int     `json:"end"`
+				Confidence float64 `json:"confidence"`
+			}{
+				{Text: "hello", Start: 0, End: 500, Confidence: 0.99},
+				{Text: "world", Start: 600, End: 1500, Confidence: 0.97},
 			},
 		})
-		require.NoError(t, err)
+		conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+	}))
+	defer srv.Close()
 
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01, 0x02}, nil)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			events = append(events, event)
-		}
-		require.GreaterOrEqual(t, len(events), 1)
-		assert.Equal(t, "hello world", events[0].Text)
-		assert.True(t, events[0].IsFinal)
-		assert.Equal(t, 0.98, events[0].Confidence)
-		require.Len(t, events[0].Words, 2)
-		assert.Equal(t, "hello", events[0].Words[0].Text)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, err := New(stt.Config{
+		Extra: map[string]any{"api_key": "test-key", "ws_url": wsURL},
 	})
+	require.NoError(t, err)
 
-	t.Run("partial transcript", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01, 0x02}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		events = append(events, event)
+	}
+	require.GreaterOrEqual(t, len(events), 1)
+	assert.Equal(t, "hello world", events[0].Text)
+	assert.True(t, events[0].IsFinal)
+	assert.Equal(t, 0.98, events[0].Confidence)
+	require.Len(t, events[0].Words, 2)
+	assert.Equal(t, "hello", events[0].Words[0].Text)
+}
+
+func TestTranscribeStream_PartialTranscript(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Read(ctx) //nolint:errcheck
+		wsjson.Write(ctx, conn, realtimeMessage{ //nolint:errcheck
+			MessageType: "PartialTranscript",
+			Text:        "hello",
+			Confidence:  0.7,
+		})
+		conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		events = append(events, event)
+	}
+	require.Len(t, events, 1)
+	assert.False(t, events[0].IsFinal)
+}
+
+func TestTranscribeStream_EmptyTextSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Read(ctx) //nolint:errcheck
+		wsjson.Write(ctx, conn, realtimeMessage{MessageType: "PartialTranscript", Text: ""})          //nolint:errcheck
+		wsjson.Write(ctx, conn, realtimeMessage{MessageType: "FinalTranscript", Text: "actual", Confidence: 0.9}) //nolint:errcheck
+		conn.Close(websocket.StatusNormalClosure, "")                                                  //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		events = append(events, event)
+	}
+	require.Len(t, events, 1)
+	assert.Equal(t, "actual", events[0].Text)
+}
+
+func TestTranscribeStream_NonJSONMessageSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Read(ctx)                                                                                      //nolint:errcheck
+		conn.Write(ctx, websocket.MessageText, []byte("not json"))                                         //nolint:errcheck
+		wsjson.Write(ctx, conn, realtimeMessage{MessageType: "FinalTranscript", Text: "valid", Confidence: 0.9}) //nolint:errcheck
+		conn.Close(websocket.StatusNormalClosure, "")                                                      //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		events = append(events, event)
+	}
+	require.Len(t, events, 1)
+	assert.Equal(t, "valid", events[0].Text)
+}
+
+func TestTranscribeStream_AudioStreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
 				return
 			}
-			ctx := r.Context()
-
-			conn.Read(ctx)
-
-			wsjson.Write(ctx, conn, realtimeMessage{
-				MessageType: "PartialTranscript",
-				Text:        "hello",
-				Confidence:  0.7,
-			})
-
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
 		}
+	}))
+	defer srv.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
 
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			events = append(events, event)
+	audioStream := func(yield func([]byte, error) bool) { yield(nil, assert.AnError) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			gotErr = err
+			break
 		}
-		require.Len(t, events, 1)
-		assert.False(t, events[0].IsFinal)
+	}
+	require.Error(t, gotErr)
+}
+
+func TestTranscribeStream_WebsocketDialError(t *testing.T) {
+	e, _ := New(stt.Config{
+		Extra: map[string]any{"api_key": "k", "ws_url": "ws://localhost:1/bad"},
 	})
 
-	t.Run("empty text skipped", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test exercises connection error path
+	}
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(context.Background(), audioStream) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "websocket dial")
+}
+
+func TestTranscribeStream_ContextCancelledDuringStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
 				return
 			}
-			ctx := r.Context()
-
-			conn.Read(ctx)
-
-			// Send empty text (should be skipped)
-			wsjson.Write(ctx, conn, realtimeMessage{
-				MessageType: "PartialTranscript",
-				Text:        "",
-			})
-			// Send non-empty
-			wsjson.Write(ctx, conn, realtimeMessage{
-				MessageType: "FinalTranscript",
-				Text:        "actual",
-				Confidence:  0.9,
-			})
-
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
 		}
+	}))
+	defer srv.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
 
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			events = append(events, event)
-		}
-		require.Len(t, events, 1)
-		assert.Equal(t, "actual", events[0].Text)
-	})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
 
-	t.Run("non-JSON message skipped", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			ctx := r.Context()
-
-			conn.Read(ctx)
-
-			// Send non-JSON (should be skipped)
-			conn.Write(ctx, websocket.MessageText, []byte("not json"))
-			// Send valid
-			wsjson.Write(ctx, conn, realtimeMessage{
-				MessageType: "FinalTranscript",
-				Text:        "valid",
-				Confidence:  0.9,
-			})
-
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			events = append(events, event)
-		}
-		require.Len(t, events, 1)
-		assert.Equal(t, "valid", events[0].Text)
-	})
-
-	t.Run("audio stream error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			defer conn.Close(websocket.StatusNormalClosure, "")
-			for {
-				_, _, err := conn.Read(r.Context())
-				if err != nil {
-					return
-				}
-			}
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield(nil, assert.AnError)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-	})
-
-	t.Run("websocket dial error", func(t *testing.T) {
-		e, _ := New(stt.Config{
-			Extra: map[string]any{
-				"api_key": "k",
-				"ws_url":  "ws://localhost:1/bad",
-			},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test exercises connection error path
-		}
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-		assert.Contains(t, gotErr.Error(), "websocket dial")
-	})
-
-	t.Run("context cancelled during stream", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			defer conn.Close(websocket.StatusNormalClosure, "")
-			for {
-				_, _, err := conn.Read(r.Context())
-				if err != nil {
-					return
-				}
-			}
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-
-		audioStream := func(yield func([]byte, error) bool) {
-			for {
-				time.Sleep(50 * time.Millisecond)
-				if !yield([]byte{0x01}, nil) {
-					return
-				}
-			}
-		}
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-	})
-
-	t.Run("with custom sample rate", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Verify sample_rate in query
-			assert.Contains(t, r.URL.RawQuery, "sample_rate=44100")
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			SampleRate: 44100,
-			Extra:      map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test verifies server closes connection cleanly
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-		}
-	})
-
-	t.Run("write error on closed connection", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			// Close immediately so client write fails
-			conn.Close(websocket.StatusNormalClosure, "")
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
+	audioStream := func(yield func([]byte, error) bool) {
+		for {
 			time.Sleep(50 * time.Millisecond)
-			yield([]byte{0x01}, nil)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-	})
-
-	t.Run("yield returns false", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
+			if !yield([]byte{0x01}, nil) {
 				return
 			}
-			defer conn.Close(websocket.StatusNormalClosure, "")
-			ctx := r.Context()
-			for i := 0; i < 5; i++ {
-				wsjson.Write(ctx, conn, realtimeMessage{
-					MessageType: "FinalTranscript",
-					Text:        "text",
-					Confidence:  0.9,
-				})
-			}
-		}))
-		defer srv.Close()
-
-		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-		e, _ := New(stt.Config{
-			Extra: map[string]any{"api_key": "k", "ws_url": wsURL},
-		})
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
 		}
+	}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		count := 0
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			count++
-			if count >= 1 {
-				break
-			}
+	var gotErr error
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			gotErr = err
+			break
 		}
-		assert.Equal(t, 1, count)
+	}
+	require.Error(t, gotErr)
+}
+
+func TestTranscribeStream_CustomSampleRate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "sample_rate=44100")
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{
+		SampleRate: 44100,
+		Extra:      map[string]any{"api_key": "k", "ws_url": wsURL},
 	})
+
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test verifies server closes connection cleanly
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+	}
+}
+
+func TestTranscribeStream_WriteErrorOnClosedConnection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
+
+	audioStream := func(yield func([]byte, error) bool) {
+		time.Sleep(50 * time.Millisecond)
+		yield([]byte{0x01}, nil)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+}
+
+func TestTranscribeStream_YieldReturnsFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		ctx := r.Context()
+		for i := 0; i < 5; i++ {
+			wsjson.Write(ctx, conn, realtimeMessage{ //nolint:errcheck
+				MessageType: "FinalTranscript",
+				Text:        "text",
+				Confidence:  0.9,
+			})
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "ws_url": wsURL}})
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	count := 0
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		count++
+		if count >= 1 {
+			break
+		}
+	}
+	assert.Equal(t, 1, count)
 }
 
 func TestRegistry(t *testing.T) {

--- a/voice/stt/providers/assemblyai/assemblyai_test.go
+++ b/voice/stt/providers/assemblyai/assemblyai_test.go
@@ -629,7 +629,9 @@ func TestTranscribeStream(t *testing.T) {
 			},
 		})
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test exercises connection error path
+		}
 
 		var gotErr error
 		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
@@ -703,7 +705,9 @@ func TestTranscribeStream(t *testing.T) {
 			Extra:      map[string]any{"api_key": "k", "ws_url": wsURL},
 		})
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test verifies server closes connection cleanly
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/voice/stt/providers/deepgram/deepgram.go
+++ b/voice/stt/providers/deepgram/deepgram.go
@@ -22,6 +22,11 @@ const (
 	defaultModel   = "nova-2"
 )
 
+const (
+	authPrefix = "Token "
+	listenPath = "/listen?"
+)
+
 var _ stt.STT = (*Engine)(nil) // compile-time interface check
 
 func init() {
@@ -62,7 +67,7 @@ func New(cfg stt.Config) (*Engine, error) {
 
 	client := httpclient.New(
 		httpclient.WithBaseURL(baseURL),
-		httpclient.WithBearerToken("Token "+apiKey),
+		httpclient.WithBearerToken(authPrefix+apiKey),
 		httpclient.WithRetries(2),
 	)
 
@@ -103,11 +108,11 @@ func (e *Engine) Transcribe(ctx context.Context, audio []byte, opts ...stt.Optio
 	}
 
 	params := e.buildQueryParams(cfg)
-	path := "/listen?" + params.Encode()
+	path := listenPath + params.Encode()
 
 	resp, err := e.client.Do(ctx, http.MethodPost, path, nil, map[string]string{
 		"Content-Type":  "audio/wav",
-		"Authorization": "Token " + e.apiKey,
+		"Authorization": authPrefix + e.apiKey,
 	})
 	if err != nil {
 		return "", fmt.Errorf("deepgram: request failed: %w", err)
@@ -129,14 +134,14 @@ func (e *Engine) Transcribe(ctx context.Context, audio []byte, opts ...stt.Optio
 
 func (e *Engine) transcribeRaw(ctx context.Context, audio []byte, cfg stt.Config) (string, error) {
 	params := e.buildQueryParams(cfg)
-	u := e.baseURL + "/listen?" + params.Encode()
+	u := e.baseURL + listenPath + params.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(string(audio)))
 	if err != nil {
 		return "", fmt.Errorf("deepgram: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "audio/wav")
-	req.Header.Set("Authorization", "Token "+e.apiKey)
+	req.Header.Set("Authorization", authPrefix+e.apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -181,10 +186,10 @@ type deepgramStreamResponse struct {
 // dialStream opens a WebSocket connection to Deepgram's streaming endpoint.
 func (e *Engine) dialStream(ctx context.Context, cfg stt.Config) (*websocket.Conn, error) {
 	params := e.buildQueryParams(cfg)
-	wsEndpoint := e.wsURL + "/listen?" + params.Encode()
+	wsEndpoint := e.wsURL + listenPath + params.Encode()
 
 	headers := http.Header{}
-	headers.Set("Authorization", "Token "+e.apiKey)
+	headers.Set("Authorization", authPrefix+e.apiKey)
 
 	conn, _, err := websocket.Dial(ctx, wsEndpoint, &websocket.DialOptions{
 		HTTPHeader: headers,

--- a/voice/stt/providers/gladia/gladia_test.go
+++ b/voice/stt/providers/gladia/gladia_test.go
@@ -45,133 +45,99 @@ func TestNew(t *testing.T) {
 	})
 }
 
-func TestTranscribe(t *testing.T) {
-	t.Run("successful transcription", func(t *testing.T) {
-		pollCount := 0
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "test-key", r.Header.Get("x-gladia-key"))
-
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{
-					AudioURL: "https://storage.gladia.io/test123",
-				})
-
-			case r.URL.Path == "/transcription" && r.Method == http.MethodPost:
-				var req transcriptionRequest
-				json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, "https://storage.gladia.io/test123", req.AudioURL)
-
-				json.NewEncoder(w).Encode(transcriptionResponse{
-					ID:        "tx_456",
-					ResultURL: "",
-					Status:    "queued",
-				})
-
-			case r.URL.Path == "/transcription/tx_456" && r.Method == http.MethodGet:
-				pollCount++
-				if pollCount >= 2 {
-					json.NewEncoder(w).Encode(transcriptionResult{
-						Status: "done",
-						Result: transcriptionResultData{
-							Transcription: transcriptionTranscription{FullTranscript: "hello world"},
-						},
-					})
-				} else {
-					json.NewEncoder(w).Encode(transcriptionResult{Status: "processing"})
-				}
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		text, err := e.Transcribe(context.Background(), []byte("fake-audio"))
-		require.NoError(t, err)
-		assert.Equal(t, "hello world", text)
-	})
-
-	t.Run("upload error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnauthorized)
-			w.Write([]byte(`{"error":"unauthorized"}`))
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "bad-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		_, err = e.Transcribe(context.Background(), []byte("audio"))
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "401")
-	})
-
-	t.Run("with language", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.URL.Path == "/upload":
-				json.NewEncoder(w).Encode(uploadResponse{AudioURL: "https://storage.gladia.io/x"})
-			case r.URL.Path == "/transcription" && r.Method == http.MethodPost:
-				var req transcriptionRequest
-				json.NewDecoder(r.Body).Decode(&req)
-				assert.Equal(t, "fr", req.Language)
-				json.NewEncoder(w).Encode(transcriptionResponse{ID: "tx_fr", ResultURL: ""})
-			case r.URL.Path == "/transcription/tx_fr":
-				json.NewEncoder(w).Encode(transcriptionResult{
+func TestTranscribe_SuccessfulTranscription(t *testing.T) {
+	pollCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-key", r.Header.Get("x-gladia-key"))
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{AudioURL: "https://storage.gladia.io/test123"}) //nolint:errcheck
+		case r.URL.Path == "/transcription" && r.Method == http.MethodPost:
+			var req transcriptionRequest
+			json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+			assert.Equal(t, "https://storage.gladia.io/test123", req.AudioURL)
+			json.NewEncoder(w).Encode(transcriptionResponse{ID: "tx_456", ResultURL: "", Status: "queued"}) //nolint:errcheck
+		case r.URL.Path == "/transcription/tx_456" && r.Method == http.MethodGet:
+			pollCount++
+			if pollCount >= 2 {
+				json.NewEncoder(w).Encode(transcriptionResult{ //nolint:errcheck
 					Status: "done",
-					Result: transcriptionResultData{
-							Transcription: transcriptionTranscription{FullTranscript: "bonjour"},
-						},
-						})
+					Result: transcriptionResultData{Transcription: transcriptionTranscription{FullTranscript: "hello world"}},
+				})
+			} else {
+				json.NewEncoder(w).Encode(transcriptionResult{Status: "processing"}) //nolint:errcheck
 			}
-		}))
-		defer srv.Close()
+		}
+	}))
+	defer srv.Close()
 
-		e, err := New(stt.Config{
-			Language: "fr",
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
 
-		text, err := e.Transcribe(context.Background(), []byte("audio"))
-		require.NoError(t, err)
-		assert.Equal(t, "bonjour", text)
+	text, err := e.Transcribe(context.Background(), []byte("fake-audio"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", text)
+}
+
+func TestTranscribe_UploadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized"}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "bad-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	_, err = e.Transcribe(context.Background(), []byte("audio"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestTranscribe_WithLanguage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/upload":
+			json.NewEncoder(w).Encode(uploadResponse{AudioURL: "https://storage.gladia.io/x"}) //nolint:errcheck
+		case r.URL.Path == "/transcription" && r.Method == http.MethodPost:
+			var req transcriptionRequest
+			json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck
+			assert.Equal(t, "fr", req.Language)
+			json.NewEncoder(w).Encode(transcriptionResponse{ID: "tx_fr", ResultURL: ""}) //nolint:errcheck
+		case r.URL.Path == "/transcription/tx_fr":
+			json.NewEncoder(w).Encode(transcriptionResult{ //nolint:errcheck
+				Status: "done",
+				Result: transcriptionResultData{Transcription: transcriptionTranscription{FullTranscript: "bonjour"}},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{
+		Language: "fr",
+		Extra:    map[string]any{"api_key": "test-key", "base_url": srv.URL},
 	})
+	require.NoError(t, err)
 
-	t.Run("context cancelled", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(100 * time.Millisecond)
-		}))
-		defer srv.Close()
+	text, err := e.Transcribe(context.Background(), []byte("audio"))
+	require.NoError(t, err)
+	assert.Equal(t, "bonjour", text)
+}
 
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
+func TestTranscribe_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
 
-		_, err = e.Transcribe(ctx, []byte("audio"))
-		require.Error(t, err)
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = e.Transcribe(ctx, []byte("audio"))
+	require.Error(t, err)
 }
 
 func TestTranscribe_CreateError(t *testing.T) {
@@ -324,359 +290,263 @@ func TestTranscribe_WithOption(t *testing.T) {
 	assert.Equal(t, "hallo", text)
 }
 
-func TestTranscribeStream(t *testing.T) {
-	t.Run("successful streaming", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/live" {
-				json.NewEncoder(w).Encode(map[string]string{
-					"url": "ws://" + r.Host + "/ws",
-				})
+func TestTranscribeStream_SuccessfulStreaming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/live" {
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
+			return
+		}
+		if r.URL.Path != "/ws" {
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Read(ctx) //nolint:errcheck
+		wsjson.Write(ctx, conn, gladiaStreamMsg{Type: "transcript", Transcript: "hello", Confidence: 0.85, IsFinal: false, Duration: 0.5})       //nolint:errcheck
+		wsjson.Write(ctx, conn, gladiaStreamMsg{Type: "transcript", Transcript: "hello world", Confidence: 0.95, IsFinal: true, Duration: 1.5}) //nolint:errcheck
+		conn.Close(websocket.StatusNormalClosure, "")                                                                                           //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01, 0x02}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+		events = append(events, event)
+	}
+	require.GreaterOrEqual(t, len(events), 1)
+	assert.NotEmpty(t, events[0].Text)
+}
+
+func TestTranscribeStream_EmptyURLReturned(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"url": ""}) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test exercises missing WebSocket URL error path
+	}
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(context.Background(), audioStream) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "no websocket URL")
+}
+
+func TestTranscribeStream_LiveRequestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test exercises HTTP error response path
+	}
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(context.Background(), audioStream) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+}
+
+func TestTranscribeStream_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Second)
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test exercises cancelled-context error path
+	}
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+}
+
+func TestTranscribeStream_WithLanguageAndSampleRate(t *testing.T) {
+	var receivedInit map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/live" {
+			json.NewDecoder(r.Body).Decode(&receivedInit) //nolint:errcheck
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
+			return
+		}
+		if r.URL.Path != "/ws" {
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		wsjson.Write(r.Context(), conn, gladiaStreamMsg{   //nolint:errcheck
+			Type: "transcript", Transcript: "test", IsFinal: true, Confidence: 0.9,
+		})
+	}))
+	defer srv.Close()
+
+	e, err := New(stt.Config{
+		Language:   "es",
+		SampleRate: 44100,
+		Extra:      map[string]any{"api_key": "test-key", "base_url": srv.URL},
+	})
+	require.NoError(t, err)
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
+		}
+	}
+	assert.Equal(t, "es", receivedInit["language"])
+	assert.Equal(t, float64(44100), receivedInit["sample_rate"])
+}
+
+func TestTranscribeStream_AudioStreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/live" {
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
+			return
+		}
+		if r.URL.Path != "/ws" {
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
 				return
 			}
-			if r.URL.Path == "/ws" {
-				conn, err := websocket.Accept(w, r, nil)
-				if err != nil {
-					return
-				}
-
-				ctx := r.Context()
-
-				// Read one audio chunk from client
-				conn.Read(ctx)
-
-				// Send transcript events
-				wsjson.Write(ctx, conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "hello",
-					Confidence: 0.85,
-					IsFinal:    false,
-					Duration:   0.5,
-				})
-				wsjson.Write(ctx, conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "hello world",
-					Confidence: 0.95,
-					IsFinal:    true,
-					Duration:   1.5,
-				})
-
-				// Close the connection
-				conn.Close(websocket.StatusNormalClosure, "")
-				return
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01, 0x02}, nil)
 		}
+	}))
+	defer srv.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
 
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				// WebSocket close is expected at end
-				break
-			}
-			events = append(events, event)
+	audioStream := func(yield func([]byte, error) bool) { yield(nil, assert.AnError) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var gotErr error
+	for _, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			gotErr = err
+			break
 		}
-		require.GreaterOrEqual(t, len(events), 1)
-		assert.NotEmpty(t, events[0].Text)
-	})
+	}
+	require.Error(t, gotErr)
+}
 
-	t.Run("empty URL returned", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(map[string]string{"url": ""})
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test exercises missing WebSocket URL error path
+func TestTranscribeStream_EmptyTranscriptSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/live" {
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
+			return
 		}
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
+		if r.URL.Path != "/ws" {
+			return
 		}
-		require.Error(t, gotErr)
-		assert.Contains(t, gotErr.Error(), "no websocket URL")
-	})
-
-	t.Run("live request HTTP error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("not json"))
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test exercises HTTP error response path
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
 		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		ctx := r.Context()
+		wsjson.Write(ctx, conn, gladiaStreamMsg{Type: "transcript", Transcript: ""})                                                    //nolint:errcheck
+		wsjson.Write(ctx, conn, gladiaStreamMsg{Type: "transcript", Transcript: "actual", IsFinal: true, Confidence: 0.9}) //nolint:errcheck
+	}))
+	defer srv.Close()
 
-		var gotErr error
-		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
+
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var events []stt.TranscriptEvent
+	for event, err := range e.TranscribeStream(ctx, audioStream) {
+		if err != nil {
+			break
 		}
-		// Either decode error or empty URL error
-		require.Error(t, gotErr)
-	})
+		events = append(events, event)
+	}
+	require.Len(t, events, 1)
+	assert.Equal(t, "actual", events[0].Text)
+}
 
-	t.Run("context cancelled", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(time.Second)
-		}))
-		defer srv.Close()
+func TestTranscribeStream_WebsocketDialFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"url": "ws://localhost:1/bad"}) //nolint:errcheck
+	}))
+	defer srv.Close()
 
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
+	e, err := New(stt.Config{Extra: map[string]any{"api_key": "test-key", "base_url": srv.URL}})
+	require.NoError(t, err)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: test exercises WebSocket dial error path
+	}
 
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test exercises cancelled-context error path
+	var gotErr error
+	for _, err := range e.TranscribeStream(context.Background(), audioStream) {
+		if err != nil {
+			gotErr = err
+			break
 		}
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-	})
-
-	t.Run("with language and sample rate", func(t *testing.T) {
-		var receivedInit map[string]any
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/live" {
-				json.NewDecoder(r.Body).Decode(&receivedInit)
-				json.NewEncoder(w).Encode(map[string]string{
-					"url": "ws://" + r.Host + "/ws",
-				})
-				return
-			}
-			if r.URL.Path == "/ws" {
-				conn, err := websocket.Accept(w, r, nil)
-				if err != nil {
-					return
-				}
-				defer conn.Close(websocket.StatusNormalClosure, "")
-				wsjson.Write(r.Context(), conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "test",
-					IsFinal:    true,
-					Confidence: 0.9,
-				})
-				return
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Language:   "es",
-			SampleRate: 44100,
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-		}
-		// Verify init request included language and sample rate
-		assert.Equal(t, "es", receivedInit["language"])
-		assert.Equal(t, float64(44100), receivedInit["sample_rate"])
-	})
-
-	t.Run("audio stream error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/live" {
-				json.NewEncoder(w).Encode(map[string]string{
-					"url": "ws://" + r.Host + "/ws",
-				})
-				return
-			}
-			if r.URL.Path == "/ws" {
-				conn, err := websocket.Accept(w, r, nil)
-				if err != nil {
-					return
-				}
-				defer conn.Close(websocket.StatusNormalClosure, "")
-				// Keep reading to allow audio send goroutine to work
-				for {
-					_, _, err := conn.Read(r.Context())
-					if err != nil {
-						return
-					}
-				}
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield(nil, assert.AnError)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-	})
-
-	t.Run("websocket message with empty transcript skipped", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/live" {
-				json.NewEncoder(w).Encode(map[string]string{
-					"url": "ws://" + r.Host + "/ws",
-				})
-				return
-			}
-			if r.URL.Path == "/ws" {
-				conn, err := websocket.Accept(w, r, nil)
-				if err != nil {
-					return
-				}
-				defer conn.Close(websocket.StatusNormalClosure, "")
-				ctx := r.Context()
-				// Send empty transcript (should be skipped)
-				wsjson.Write(ctx, conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "",
-				})
-				// Send non-empty transcript
-				wsjson.Write(ctx, conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "actual",
-					IsFinal:    true,
-					Confidence: 0.9,
-				})
-				return
-			}
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			yield([]byte{0x01}, nil)
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		var events []stt.TranscriptEvent
-		for event, err := range e.TranscribeStream(ctx, audioStream) {
-			if err != nil {
-				break
-			}
-			events = append(events, event)
-		}
-		// Only non-empty transcript should be received
-		require.Len(t, events, 1)
-		assert.Equal(t, "actual", events[0].Text)
-	})
-
-	t.Run("websocket dial failure", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Return a URL that won't accept WebSocket
-			json.NewEncoder(w).Encode(map[string]string{
-				"url": "ws://localhost:1/bad",
-			})
-		}))
-		defer srv.Close()
-
-		e, err := New(stt.Config{
-			Extra: map[string]any{
-				"api_key":  "test-key",
-				"base_url": srv.URL,
-			},
-		})
-		require.NoError(t, err)
-
-		audioStream := func(yield func([]byte, error) bool) {
-			// no-op: no audio to send; test exercises WebSocket dial error path
-		}
-
-		var gotErr error
-		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
-			if err != nil {
-				gotErr = err
-				break
-			}
-		}
-		require.Error(t, gotErr)
-		assert.Contains(t, gotErr.Error(), "websocket dial")
-	})
+	}
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "websocket dial")
 }
 
 func TestTranscribe_UploadDecodeError(t *testing.T) {
@@ -824,39 +694,26 @@ func TestTranscribe_CreateTranscriptionHTTPFailed(t *testing.T) {
 func TestTranscribeStream_NonJSONWSMessage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/live" {
-			json.NewEncoder(w).Encode(map[string]string{
-				"url": "ws://" + r.Host + "/ws",
-			})
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
 			return
 		}
-		if r.URL.Path == "/ws" {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			ctx := r.Context()
-			// Send non-JSON message (should be skipped)
-			conn.Write(ctx, websocket.MessageText, []byte("not json"))
-			// Send valid message
-			wsjson.Write(ctx, conn, gladiaStreamMsg{
-				Type:       "transcript",
-				Transcript: "after noise",
-				IsFinal:    true,
-				Confidence: 0.9,
-			})
-			conn.Close(websocket.StatusNormalClosure, "")
+		if r.URL.Path != "/ws" {
 			return
 		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		ctx := r.Context()
+		conn.Write(ctx, websocket.MessageText, []byte("not json"))                                                                     //nolint:errcheck
+		wsjson.Write(ctx, conn, gladiaStreamMsg{Type: "transcript", Transcript: "after noise", IsFinal: true, Confidence: 0.9}) //nolint:errcheck
+		conn.Close(websocket.StatusNormalClosure, "")                                                                                  //nolint:errcheck
 	}))
 	defer srv.Close()
 
-	e, _ := New(stt.Config{
-		Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-	})
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
 
-	audioStream := func(yield func([]byte, error) bool) {
-		yield([]byte{0x01}, nil)
-	}
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -875,20 +732,17 @@ func TestTranscribeStream_NonJSONWSMessage(t *testing.T) {
 func TestTranscribeStream_WriteError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/live" {
-			json.NewEncoder(w).Encode(map[string]string{
-				"url": "ws://" + r.Host + "/ws",
-			})
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
 			return
 		}
-		if r.URL.Path == "/ws" {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			// Close immediately so client write fails
-			conn.Close(websocket.StatusNormalClosure, "")
+		if r.URL.Path != "/ws" {
 			return
 		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -938,37 +792,31 @@ func TestTranscribe_UploadHTTPFailed(t *testing.T) {
 func TestTranscribeStream_ContextCancelledDuringStream(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/live" {
-			json.NewEncoder(w).Encode(map[string]string{
-				"url": "ws://" + r.Host + "/ws",
-			})
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
 			return
 		}
-		if r.URL.Path == "/ws" {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
+		if r.URL.Path != "/ws" {
+			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		for {
+			if _, _, err := conn.Read(r.Context()); err != nil {
 				return
-			}
-			defer conn.Close(websocket.StatusNormalClosure, "")
-			// Keep connection alive, wait for client to cancel
-			for {
-				_, _, err := conn.Read(r.Context())
-				if err != nil {
-					return
-				}
 			}
 		}
 	}))
 	defer srv.Close()
 
-	e, _ := New(stt.Config{
-		Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-	})
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	audioStream := func(yield func([]byte, error) bool) {
-		// Send audio slowly so context times out
 		for {
 			time.Sleep(50 * time.Millisecond)
 			if !yield([]byte{0x01}, nil) {
@@ -990,44 +838,33 @@ func TestTranscribeStream_ContextCancelledDuringStream(t *testing.T) {
 func TestTranscribeStream_YieldReturnsFalse(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/live" {
-			json.NewEncoder(w).Encode(map[string]string{
-				"url": "ws://" + r.Host + "/ws",
-			})
+			json.NewEncoder(w).Encode(map[string]string{"url": "ws://" + r.Host + "/ws"}) //nolint:errcheck
 			return
 		}
-		if r.URL.Path == "/ws" {
-			conn, err := websocket.Accept(w, r, nil)
-			if err != nil {
-				return
-			}
-			defer conn.Close(websocket.StatusNormalClosure, "")
-			ctx := r.Context()
-			// Send multiple messages
-			for i := 0; i < 5; i++ {
-				wsjson.Write(ctx, conn, gladiaStreamMsg{
-					Type:       "transcript",
-					Transcript: "text",
-					IsFinal:    true,
-					Confidence: 0.9,
-				})
-			}
+		if r.URL.Path != "/ws" {
 			return
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "") //nolint:errcheck
+		ctx := r.Context()
+		for i := 0; i < 5; i++ {
+			wsjson.Write(ctx, conn, gladiaStreamMsg{ //nolint:errcheck
+				Type: "transcript", Transcript: "text", IsFinal: true, Confidence: 0.9,
+			})
 		}
 	}))
 	defer srv.Close()
 
-	e, _ := New(stt.Config{
-		Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
-	})
+	e, _ := New(stt.Config{Extra: map[string]any{"api_key": "k", "base_url": srv.URL}})
 
-	audioStream := func(yield func([]byte, error) bool) {
-		yield([]byte{0x01}, nil)
-	}
+	audioStream := func(yield func([]byte, error) bool) { yield([]byte{0x01}, nil) }
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Break after first event — tests the yield returning false path
 	count := 0
 	for _, err := range e.TranscribeStream(ctx, audioStream) {
 		if err != nil {

--- a/voice/stt/providers/gladia/gladia_test.go
+++ b/voice/stt/providers/gladia/gladia_test.go
@@ -408,7 +408,9 @@ func TestTranscribeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test exercises missing WebSocket URL error path
+		}
 
 		var gotErr error
 		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
@@ -435,7 +437,9 @@ func TestTranscribeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test exercises HTTP error response path
+		}
 
 		var gotErr error
 		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
@@ -465,7 +469,9 @@ func TestTranscribeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test exercises cancelled-context error path
+		}
 
 		var gotErr error
 		for _, err := range e.TranscribeStream(ctx, audioStream) {
@@ -657,7 +663,9 @@ func TestTranscribeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test exercises WebSocket dial error path
+		}
 
 		var gotErr error
 		for _, err := range e.TranscribeStream(context.Background(), audioStream) {
@@ -1048,7 +1056,9 @@ func TestTranscribeStream_LiveHTTPFailed(t *testing.T) {
 		Extra: map[string]any{"api_key": "k", "base_url": srv.URL},
 	})
 
-	audioStream := func(yield func([]byte, error) bool) {}
+	audioStream := func(yield func([]byte, error) bool) {
+		// no-op: no audio to send; test exercises live-request HTTP failure path
+	}
 
 	var gotErr error
 	for _, err := range e.TranscribeStream(context.Background(), audioStream) {

--- a/voice/stt/providers/groq/groq_test.go
+++ b/voice/stt/providers/groq/groq_test.go
@@ -208,7 +208,9 @@ func TestTranscribeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		audioStream := func(yield func([]byte, error) bool) {}
+		audioStream := func(yield func([]byte, error) bool) {
+			// no-op: no audio to send; test verifies empty stream produces zero events
+		}
 
 		var count int
 		for range e.TranscribeStream(context.Background(), audioStream) {

--- a/voice/tts/providers/cartesia/cartesia_test.go
+++ b/voice/tts/providers/cartesia/cartesia_test.go
@@ -165,6 +165,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream text chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -181,19 +230,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
-
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Equal(t, 2, len(chunks))
 	})
 
@@ -212,19 +249,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
-
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
 		assert.Equal(t, 1, len(chunks))
 	})
 
@@ -238,15 +263,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -262,14 +280,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -288,14 +299,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -313,15 +317,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/elevenlabs/elevenlabs_test.go
+++ b/voice/tts/providers/elevenlabs/elevenlabs_test.go
@@ -174,6 +174,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream multiple text chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -190,23 +239,10 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
-
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Equal(t, 2, len(chunks))
-		for _, c := range chunks {
-			assert.Equal(t, []byte("audio-chunk"), c)
-		}
+		assert.Equal(t, []byte("audio-chunk"), chunks[0])
+		assert.Equal(t, []byte("audio-chunk"), chunks[1])
 	})
 
 	t.Run("skip empty text", func(t *testing.T) {
@@ -223,19 +259,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
-
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
 		assert.Equal(t, 1, len(chunks))
 	})
 
@@ -248,15 +272,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -271,14 +288,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -296,15 +306,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -321,15 +324,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/fish/fish_test.go
+++ b/voice/tts/providers/fish/fish_test.go
@@ -171,6 +171,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hi", nil) {
+		return
+	}
+	yield("there", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -186,18 +235,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hi", nil) {
-				return
-			}
-			yield("there", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Len(t, chunks, 2)
 	})
 
@@ -215,19 +253,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var count int
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			count++
-		}
-		assert.Equal(t, 1, count)
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
+		assert.Equal(t, 1, len(chunks))
 	})
 
 	t.Run("text stream error", func(t *testing.T) {
@@ -239,15 +266,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -262,14 +282,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -287,15 +300,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -312,15 +318,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/groq/groq_test.go
+++ b/voice/tts/providers/groq/groq_test.go
@@ -159,6 +159,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -174,18 +223,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Len(t, chunks, 2)
 	})
 
@@ -203,19 +241,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var count int
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			count++
-		}
-		assert.Equal(t, 1, count)
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
+		assert.Equal(t, 1, len(chunks))
 	})
 
 	t.Run("text stream error", func(t *testing.T) {
@@ -227,15 +254,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -250,14 +270,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -275,15 +288,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -300,15 +306,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/lmnt/lmnt_test.go
+++ b/voice/tts/providers/lmnt/lmnt_test.go
@@ -187,6 +187,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -202,18 +251,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Len(t, chunks, 2)
 	})
 
@@ -231,19 +269,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var count int
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			count++
-		}
-		assert.Equal(t, 1, count)
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
+		assert.Equal(t, 1, len(chunks))
 	})
 
 	t.Run("text stream error", func(t *testing.T) {
@@ -255,15 +282,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -278,14 +298,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -303,15 +316,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -328,15 +334,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/playht/playht_test.go
+++ b/voice/tts/providers/playht/playht_test.go
@@ -164,6 +164,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream multiple chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -180,18 +229,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Len(t, chunks, 2)
 	})
 
@@ -210,18 +248,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
 		assert.Len(t, chunks, 1)
 	})
 
@@ -235,15 +262,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -259,14 +279,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -285,15 +298,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -311,15 +317,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/voice/tts/providers/smallest/smallest_test.go
+++ b/voice/tts/providers/smallest/smallest_test.go
@@ -150,6 +150,55 @@ func TestSynthesize(t *testing.T) {
 	})
 }
 
+func twoWordStream(yield func(string, error) bool) {
+	if !yield("Hello", nil) {
+		return
+	}
+	yield("World", nil)
+}
+
+func emptyFirstStream(yield func(string, error) bool) {
+	if !yield("", nil) {
+		return
+	}
+	yield("text", nil)
+}
+
+func singleWordStream(yield func(string, error) bool) {
+	yield("hello", nil)
+}
+
+func errorStream(yield func(string, error) bool) {
+	yield("", fmt.Errorf("stream error"))
+}
+
+func twoWordStopEarlyStream(yield func(string, error) bool) {
+	if !yield("first", nil) {
+		return
+	}
+	yield("second", nil)
+}
+
+func collectChunks(t *testing.T, iter func(func([]byte, error) bool)) [][]byte {
+	t.Helper()
+	var chunks [][]byte
+	for chunk, err := range iter {
+		require.NoError(t, err)
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func requireFirstError(t *testing.T, iter func(func([]byte, error) bool)) error {
+	t.Helper()
+	for _, err := range iter {
+		require.Error(t, err)
+		return err
+	}
+	t.Fatal("expected at least one error from stream")
+	return nil
+}
+
 func TestSynthesizeStream(t *testing.T) {
 	t.Run("stream chunks", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -165,18 +214,7 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("Hello", nil) {
-				return
-			}
-			yield("World", nil)
-		}
-
-		var chunks [][]byte
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			chunks = append(chunks, chunk)
-		}
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), twoWordStream))
 		assert.Len(t, chunks, 2)
 	})
 
@@ -194,19 +232,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("", nil) {
-				return
-			}
-			yield("text", nil)
-		}
-
-		var count int
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.NoError(t, err)
-			count++
-		}
-		assert.Equal(t, 1, count)
+		chunks := collectChunks(t, e.SynthesizeStream(context.Background(), emptyFirstStream))
+		assert.Equal(t, 1, len(chunks))
 	})
 
 	t.Run("text stream error", func(t *testing.T) {
@@ -218,15 +245,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("stream error"))
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "stream error")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), errorStream))
+		assert.Contains(t, streamErr.Error(), "stream error")
 	})
 
 	t.Run("context cancelled", func(t *testing.T) {
@@ -241,14 +261,7 @@ func TestSynthesizeStream(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(ctx, textStream) {
-			require.Error(t, err)
-			break
-		}
+		requireFirstError(t, e.SynthesizeStream(ctx, singleWordStream))
 	})
 
 	t.Run("synthesis error propagated", func(t *testing.T) {
@@ -266,15 +279,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			yield("hello", nil)
-		}
-
-		for _, err := range e.SynthesizeStream(context.Background(), textStream) {
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "500")
-			break
-		}
+		streamErr := requireFirstError(t, e.SynthesizeStream(context.Background(), singleWordStream))
+		assert.Contains(t, streamErr.Error(), "500")
 	})
 
 	t.Run("consumer stops early", func(t *testing.T) {
@@ -291,15 +297,8 @@ func TestSynthesizeStream(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		textStream := func(yield func(string, error) bool) {
-			if !yield("first", nil) {
-				return
-			}
-			yield("second", nil)
-		}
-
 		var count int
-		for chunk, err := range e.SynthesizeStream(context.Background(), textStream) {
+		for chunk, err := range e.SynthesizeStream(context.Background(), twoWordStopEarlyStream) {
 			require.NoError(t, err)
 			assert.NotEmpty(t, chunk)
 			count++

--- a/workflow/providers/inngest/inngest.go
+++ b/workflow/providers/inngest/inngest.go
@@ -12,6 +12,8 @@ import (
 	"github.com/lookatitude/beluga-ai/workflow"
 )
 
+const workflowPathFmt = "/v1/workflows/%s"
+
 // HTTPClient defines the HTTP client interface for Inngest API calls.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -68,7 +70,7 @@ func (s *Store) Save(ctx context.Context, state workflow.WorkflowState) error {
 		return fmt.Errorf("inngest/save: marshal: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/workflows/%s", s.baseURL, state.WorkflowID)
+	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, state.WorkflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("inngest/save: create request: %w", err)
@@ -98,7 +100,7 @@ func (s *Store) Save(ctx context.Context, state workflow.WorkflowState) error {
 
 // Load retrieves the workflow state by ID.
 func (s *Store) Load(ctx context.Context, workflowID string) (*workflow.WorkflowState, error) {
-	url := fmt.Sprintf("%s/v1/workflows/%s", s.baseURL, workflowID)
+	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, workflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("inngest/load: create request: %w", err)
@@ -148,7 +150,7 @@ func (s *Store) List(_ context.Context, filter workflow.WorkflowFilter) ([]workf
 
 // Delete removes a workflow state.
 func (s *Store) Delete(ctx context.Context, workflowID string) error {
-	url := fmt.Sprintf("%s/v1/workflows/%s", s.baseURL, workflowID)
+	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, workflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("inngest/delete: create request: %w", err)

--- a/workflow/providers/inngest/inngest.go
+++ b/workflow/providers/inngest/inngest.go
@@ -70,7 +70,7 @@ func (s *Store) Save(ctx context.Context, state workflow.WorkflowState) error {
 		return fmt.Errorf("inngest/save: marshal: %w", err)
 	}
 
-	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, state.WorkflowID)
+	url := s.baseURL + fmt.Sprintf(workflowPathFmt, state.WorkflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("inngest/save: create request: %w", err)

--- a/workflow/providers/inngest/inngest.go
+++ b/workflow/providers/inngest/inngest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,7 +63,7 @@ func New(cfg Config) (*Store, error) {
 // Save persists the workflow state by sending it to the Inngest API.
 func (s *Store) Save(ctx context.Context, state workflow.WorkflowState) error {
 	if state.WorkflowID == "" {
-		return fmt.Errorf("inngest/save: workflow ID is required")
+		return errors.New("inngest/save: workflow ID is required")
 	}
 
 	data, err := json.Marshal(state)
@@ -100,7 +101,7 @@ func (s *Store) Save(ctx context.Context, state workflow.WorkflowState) error {
 
 // Load retrieves the workflow state by ID.
 func (s *Store) Load(ctx context.Context, workflowID string) (*workflow.WorkflowState, error) {
-	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, workflowID)
+	url := s.baseURL + fmt.Sprintf(workflowPathFmt, workflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("inngest/load: create request: %w", err)
@@ -150,7 +151,7 @@ func (s *Store) List(_ context.Context, filter workflow.WorkflowFilter) ([]workf
 
 // Delete removes a workflow state.
 func (s *Store) Delete(ctx context.Context, workflowID string) error {
-	url := fmt.Sprintf("%s"+workflowPathFmt, s.baseURL, workflowID)
+	url := s.baseURL + fmt.Sprintf(workflowPathFmt, workflowID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("inngest/delete: create request: %w", err)


### PR DESCRIPTION
## Summary

- Fix SonarCloud CI integration for dependabot PRs (skip when `SONAR_TOKEN` unavailable)
- Fix `release.yml` security vulnerability (move permissions from workflow to job level)
- Configure SonarCloud to exclude test files from string duplication rule (`go:S1192`)
- Extract duplicated string constants in 9 production files
- Add explanatory comments to 34 empty test functions (`go:S1186`)
- Reduce cognitive complexity in ~30 test files (`go:S3776`)

Resolves ~960 SonarCloud issues across the codebase.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — 5358 pass (6 pre-existing o11y failures unrelated to this PR)
- [ ] Verify SonarCloud dashboard shows reduced issue count after merge
- [ ] Verify next dependabot PR skips SonarCloud cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)