### PR TITLE
LOO-9: Temporal Knowledge Graph Memory

### DIFF
--- a/memory/graph.go
+++ b/memory/graph.go
@@ -1,6 +1,9 @@
 package memory
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Entity represents a node in the knowledge graph.
 type Entity struct {
@@ -10,9 +13,16 @@ type Entity struct {
 	Type string
 	// Properties holds arbitrary key-value attributes of the entity.
 	Properties map[string]any
+	// CreatedAt records when this entity was first observed. Zero value means unset.
+	CreatedAt time.Time
+	// Summary is a human-readable summary of this entity.
+	Summary string
 }
 
 // Relation represents a directed edge between two entities in the knowledge graph.
+// Relations support bi-temporal modeling: system time (CreatedAt/ExpiredAt) tracks
+// when the fact was ingested and invalidated in the system, while valid time
+// (ValidAt/InvalidAt) tracks when the fact was true in the real world.
 type Relation struct {
 	// From is the source entity ID.
 	From string
@@ -22,6 +32,18 @@ type Relation struct {
 	Type string
 	// Properties holds arbitrary key-value attributes of the relation.
 	Properties map[string]any
+	// CreatedAt is the system time when this relation was ingested.
+	CreatedAt time.Time
+	// ExpiredAt is the system time when this relation was invalidated.
+	// Nil means the relation is still active in the system.
+	ExpiredAt *time.Time
+	// ValidAt is the valid time when this fact became true in the real world.
+	ValidAt time.Time
+	// InvalidAt is the valid time when this fact ceased to be true in the real world.
+	// Nil means the fact is still considered true.
+	InvalidAt *time.Time
+	// Episodes contains the UUIDs of episodes that support this relation.
+	Episodes []string
 }
 
 // GraphResult holds the result of a graph query, containing matched entities
@@ -50,4 +72,51 @@ type GraphStore interface {
 	// Neighbors returns all entities and relations within the given depth
 	// from the specified entity.
 	Neighbors(ctx context.Context, entityID string, depth int) ([]Entity, []Relation, error)
+}
+
+// QueryOption configures temporal query behavior.
+type QueryOption func(*QueryOptions)
+
+// QueryOptions holds the resolved configuration for a temporal query.
+type QueryOptions struct {
+	// Limit is the maximum number of results to return.
+	Limit int
+}
+
+// WithQueryLimit sets the maximum number of results for a temporal query.
+func WithQueryLimit(limit int) QueryOption {
+	return func(o *QueryOptions) {
+		if limit > 0 {
+			o.Limit = limit
+		}
+	}
+}
+
+// ApplyQueryOptions resolves the given QueryOption functions into a QueryOptions value.
+func ApplyQueryOptions(opts []QueryOption) QueryOptions {
+	o := QueryOptions{Limit: 1000} // default limit to prevent unbounded results
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// TemporalGraphStore extends GraphStore with bi-temporal query capabilities.
+// It supports querying the knowledge graph as it was at a specific point in time,
+// invalidating relations, and retrieving the full history of relations between entities.
+type TemporalGraphStore interface {
+	GraphStore
+
+	// QueryAsOf returns entities and relations valid at a specific point in time.
+	// Only relations where ValidAt <= validTime and (InvalidAt is nil or InvalidAt > validTime)
+	// are included. The opts parameter can be used to limit results.
+	QueryAsOf(ctx context.Context, query string, validTime time.Time, opts ...QueryOption) ([]Entity, []Relation, error)
+
+	// InvalidateRelation marks a relation as no longer valid at the given time.
+	// It sets the InvalidAt field to invalidAt and ExpiredAt to the current system time.
+	InvalidateRelation(ctx context.Context, relationID string, invalidAt time.Time) error
+
+	// History returns all versions of relations between two entities, including
+	// invalidated ones, ordered by ValidAt ascending.
+	History(ctx context.Context, fromID, toID string) ([]Relation, error)
 }

--- a/memory/stores/neo4j/neo4j.go
+++ b/memory/stores/neo4j/neo4j.go
@@ -3,6 +3,7 @@ package neo4j
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/lookatitude/beluga-ai/memory"
 	driver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
@@ -145,13 +146,21 @@ func (g *GraphStore) Close(ctx context.Context) error {
 
 // AddEntity adds or updates an entity in the graph. Entities are stored as
 // Neo4j nodes with a label matching the entity type and properties set from
-// the entity's Properties map.
+// the entity's Properties map. Temporal fields (CreatedAt, Summary) are
+// stored as native Neo4j properties.
 func (g *GraphStore) AddEntity(ctx context.Context, entity memory.Entity) error {
 	cypher := "MERGE (e:Entity {id: $id}) SET e.type = $type, e += $props"
+	props := sanitizeProps(entity.Properties)
+	if !entity.CreatedAt.IsZero() {
+		props["created_at"] = entity.CreatedAt
+	}
+	if entity.Summary != "" {
+		props["summary"] = entity.Summary
+	}
 	params := map[string]any{
 		"id":    entity.ID,
 		"type":  entity.Type,
-		"props": sanitizeProps(entity.Properties),
+		"props": props,
 	}
 	if err := g.runner.executeWrite(ctx, cypher, params); err != nil {
 		return fmt.Errorf("neo4j/add_entity: %w", err)
@@ -159,7 +168,9 @@ func (g *GraphStore) AddEntity(ctx context.Context, entity memory.Entity) error 
 	return nil
 }
 
-// AddRelation creates a directed relationship between two entities.
+// AddRelation creates a directed relationship between two entities. Temporal
+// properties (created_at, expired_at, valid_at, invalid_at) in the props map
+// are passed through as native Neo4j datetime values.
 func (g *GraphStore) AddRelation(ctx context.Context, from, to, relation string, props map[string]any) error {
 	cypher := `MATCH (a:Entity {id: $from})
 MATCH (b:Entity {id: $to})
@@ -173,6 +184,25 @@ SET r += $props`
 	}
 	if err := g.runner.executeWrite(ctx, cypher, params); err != nil {
 		return fmt.Errorf("neo4j/add_relation: %w", err)
+	}
+	return nil
+}
+
+// SetupSchema creates indexes on temporal fields for efficient querying.
+// This should be called once during initialization.
+func (g *GraphStore) SetupSchema(ctx context.Context) error {
+	indexes := []string{
+		"CREATE INDEX entity_id IF NOT EXISTS FOR (e:Entity) ON (e.id)",
+		"CREATE INDEX entity_type IF NOT EXISTS FOR (e:Entity) ON (e.type)",
+		"CREATE INDEX entity_created_at IF NOT EXISTS FOR (e:Entity) ON (e.created_at)",
+		"CREATE INDEX rel_valid_at IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.valid_at)",
+		"CREATE INDEX rel_invalid_at IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.invalid_at)",
+		"CREATE INDEX rel_expired_at IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.expired_at)",
+	}
+	for _, cypher := range indexes {
+		if err := g.runner.executeWrite(ctx, cypher, nil); err != nil {
+			return fmt.Errorf("neo4j/setup_schema: %w", err)
+		}
 	}
 	return nil
 }
@@ -310,8 +340,9 @@ func getString(props map[string]any, key string) string {
 }
 
 // sanitizeProps returns a copy of the properties map that only contains
-// Neo4j-compatible values (strings, numbers, booleans). Nil maps are
-// returned as empty maps to avoid Cypher SET errors.
+// Neo4j-compatible values (strings, numbers, booleans, time.Time). Nil maps
+// are returned as empty maps to avoid Cypher SET errors. time.Time values
+// are passed through as native Neo4j datetime values.
 func sanitizeProps(props map[string]any) map[string]any {
 	if props == nil {
 		return map[string]any{}
@@ -319,7 +350,7 @@ func sanitizeProps(props map[string]any) map[string]any {
 	result := make(map[string]any, len(props))
 	for k, v := range props {
 		switch v.(type) {
-		case string, int, int64, float64, bool:
+		case string, int, int64, float64, bool, time.Time:
 			result[k] = v
 		default:
 			result[k] = fmt.Sprintf("%v", v)

--- a/memory/temporal/conflict.go
+++ b/memory/temporal/conflict.go
@@ -1,0 +1,72 @@
+package temporal
+
+import (
+	"context"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/memory"
+)
+
+// ConflictResolver determines how to handle temporal conflicts between relations.
+// When a new relation is added that may contradict existing relations, the resolver
+// decides which relations should be invalidated.
+type ConflictResolver interface {
+	// Resolve examines the newRelation against a set of candidate relations and
+	// returns the list of candidates that should be invalidated. The returned
+	// relations will have their InvalidAt and ExpiredAt fields set accordingly.
+	Resolve(ctx context.Context, newRelation *memory.Relation, candidates []memory.Relation) ([]memory.Relation, error)
+}
+
+// TemporalResolver implements the Graphiti 2-condition invalidation algorithm.
+// For each candidate relation, it checks:
+//  1. If the candidate is already superseded (InvalidAt != nil && InvalidAt <= newRelation.ValidAt),
+//     the candidate and new relation coexist without conflict.
+//  2. If the new relation is already invalidated before the candidate became valid
+//     (newRelation.InvalidAt != nil && newRelation.InvalidAt <= candidate.ValidAt),
+//     they coexist without conflict (non-overlapping time ranges).
+//  3. Otherwise, if the candidate's ValidAt < newRelation.ValidAt, the candidate
+//     is invalidated: its InvalidAt is set to newRelation.ValidAt and its ExpiredAt
+//     is set to the current system time.
+type TemporalResolver struct{}
+
+// NewTemporalResolver creates a new TemporalResolver.
+func NewTemporalResolver() *TemporalResolver {
+	return &TemporalResolver{}
+}
+
+// Resolve applies the Graphiti 2-condition algorithm to determine which candidate
+// relations should be invalidated by the new relation.
+func (r *TemporalResolver) Resolve(_ context.Context, newRelation *memory.Relation, candidates []memory.Relation) ([]memory.Relation, error) {
+	if newRelation == nil {
+		return nil, nil
+	}
+
+	var invalidated []memory.Relation
+	now := time.Now()
+
+	for _, candidate := range candidates {
+		// Condition 1: candidate already superseded -- coexist.
+		if candidate.InvalidAt != nil && !candidate.InvalidAt.After(newRelation.ValidAt) {
+			continue
+		}
+
+		// Condition 2: new relation ends before candidate starts -- non-overlapping, coexist.
+		if newRelation.InvalidAt != nil && !newRelation.InvalidAt.After(candidate.ValidAt) {
+			continue
+		}
+
+		// Condition 3: candidate is older -- invalidate it.
+		if candidate.ValidAt.Before(newRelation.ValidAt) {
+			invalidAt := newRelation.ValidAt
+			candidate.InvalidAt = &invalidAt
+			expiredAt := now
+			candidate.ExpiredAt = &expiredAt
+			invalidated = append(invalidated, candidate)
+		}
+	}
+
+	return invalidated, nil
+}
+
+// Compile-time check that TemporalResolver implements ConflictResolver.
+var _ ConflictResolver = (*TemporalResolver)(nil)

--- a/memory/temporal/conflict_test.go
+++ b/memory/temporal/conflict_test.go
@@ -1,0 +1,220 @@
+package temporal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemporalResolver_Resolve(t *testing.T) {
+	resolver := NewTemporalResolver()
+	ctx := context.Background()
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		newRelation     *memory.Relation
+		candidates      []memory.Relation
+		wantInvalidated int
+		wantNilResult   bool
+	}{
+		{
+			name:          "nil new relation returns nil",
+			newRelation:   nil,
+			candidates:    nil,
+			wantNilResult: true,
+		},
+		{
+			name: "no candidates returns empty",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime.Add(24 * time.Hour),
+			},
+			candidates:      nil,
+			wantInvalidated: 0,
+		},
+		{
+			name: "candidate already superseded coexists",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime.Add(48 * time.Hour),
+			},
+			candidates: []memory.Relation{
+				{
+					From:      "a",
+					To:        "b",
+					Type:      "works_at",
+					ValidAt:   baseTime,
+					InvalidAt: timePtr(baseTime.Add(24 * time.Hour)), // already invalidated before new relation
+				},
+			},
+			wantInvalidated: 0,
+		},
+		{
+			name: "non-overlapping time ranges coexist",
+			newRelation: &memory.Relation{
+				From:      "a",
+				To:        "b",
+				Type:      "works_at",
+				ValidAt:   baseTime,
+				InvalidAt: timePtr(baseTime.Add(24 * time.Hour)),
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime.Add(48 * time.Hour),
+					Properties: map[string]any{"id": "rel-1"},
+				},
+			},
+			wantInvalidated: 0,
+		},
+		{
+			name: "older candidate is invalidated",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime.Add(48 * time.Hour),
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime,
+					Properties: map[string]any{"id": "rel-1"},
+				},
+			},
+			wantInvalidated: 1,
+		},
+		{
+			name: "newer candidate is not invalidated",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime,
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime.Add(48 * time.Hour),
+					Properties: map[string]any{"id": "rel-1"},
+				},
+			},
+			wantInvalidated: 0,
+		},
+		{
+			name: "multiple candidates mixed resolution",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime.Add(72 * time.Hour),
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime,
+					Properties: map[string]any{"id": "rel-1"},
+				},
+				{
+					From:      "a",
+					To:        "b",
+					Type:      "works_at",
+					ValidAt:   baseTime.Add(24 * time.Hour),
+					InvalidAt: timePtr(baseTime.Add(48 * time.Hour)), // already superseded
+				},
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime.Add(48 * time.Hour),
+					Properties: map[string]any{"id": "rel-3"},
+				},
+			},
+			wantInvalidated: 2, // rel-1 and rel-3 invalidated, rel-2 already superseded
+		},
+		{
+			name: "candidate with same ValidAt not invalidated",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime,
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime, // same time -- not strictly before
+					Properties: map[string]any{"id": "rel-1"},
+				},
+			},
+			wantInvalidated: 0,
+		},
+		{
+			name: "candidate InvalidAt equals new ValidAt coexists",
+			newRelation: &memory.Relation{
+				From:    "a",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: baseTime.Add(24 * time.Hour),
+			},
+			candidates: []memory.Relation{
+				{
+					From:       "a",
+					To:         "b",
+					Type:       "works_at",
+					ValidAt:    baseTime,
+					InvalidAt:  timePtr(baseTime.Add(24 * time.Hour)), // exactly equals new ValidAt
+					Properties: map[string]any{"id": "rel-1"},
+				},
+			},
+			wantInvalidated: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolver.Resolve(ctx, tt.newRelation, tt.candidates)
+			require.NoError(t, err)
+
+			if tt.wantNilResult {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.Len(t, result, tt.wantInvalidated)
+
+			// Verify invalidated relations have InvalidAt and ExpiredAt set.
+			for _, r := range result {
+				assert.NotNil(t, r.InvalidAt, "invalidated relation should have InvalidAt set")
+				assert.NotNil(t, r.ExpiredAt, "invalidated relation should have ExpiredAt set")
+			}
+		})
+	}
+}
+
+func TestTemporalResolver_CompileTimeCheck(t *testing.T) {
+	var _ ConflictResolver = (*TemporalResolver)(nil)
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/memory/temporal/hooks.go
+++ b/memory/temporal/hooks.go
@@ -1,0 +1,21 @@
+package temporal
+
+import (
+	"context"
+
+	"github.com/lookatitude/beluga-ai/memory"
+)
+
+// Hooks provides optional callback functions for temporal memory operations.
+// All fields are optional -- nil hooks are skipped.
+type Hooks struct {
+	// OnConflictResolved is called after conflict resolution invalidates existing relations.
+	// The invalidated slice contains relations that were marked as no longer valid,
+	// and newRelation is the relation that triggered the invalidation.
+	OnConflictResolved func(ctx context.Context, invalidated []memory.Relation, newRelation memory.Relation)
+
+	// OnEntityMerged is called when an existing entity is updated with new information.
+	// The existing parameter holds the entity before the merge, and merged holds the
+	// entity after the merge.
+	OnEntityMerged func(ctx context.Context, existing, merged memory.Entity)
+}

--- a/memory/temporal/inmemory.go
+++ b/memory/temporal/inmemory.go
@@ -213,6 +213,7 @@ func (s *InMemoryStore) Neighbors(ctx context.Context, entityID string, depth in
 	}
 
 	visited := map[string]bool{entityID: true}
+	relSeen := map[string]bool{}
 	frontier := []string{entityID}
 	var resultEntities []memory.Entity
 	var resultRelations []memory.Relation
@@ -232,7 +233,17 @@ func (s *InMemoryStore) Neighbors(ctx context.Context, entityID string, depth in
 				} else {
 					continue
 				}
-				resultRelations = append(resultRelations, rel)
+				// Dedup relations across frontier levels using Properties["id"].
+				if relID, ok := rel.Properties["id"].(string); ok && relID != "" {
+					if relSeen[relID] {
+						// already recorded this relation
+					} else {
+						relSeen[relID] = true
+						resultRelations = append(resultRelations, rel)
+					}
+				} else {
+					resultRelations = append(resultRelations, rel)
+				}
 				if !visited[neighborID] {
 					visited[neighborID] = true
 					if e, ok := s.entities[neighborID]; ok {
@@ -273,6 +284,9 @@ func (s *InMemoryStore) QueryAsOf(ctx context.Context, query string, validTime t
 	var relations []memory.Relation
 
 	for _, e := range s.entities {
+		if !e.CreatedAt.IsZero() && e.CreatedAt.After(validTime) {
+			continue // entity did not exist at validTime
+		}
 		if q == "" || strings.Contains(strings.ToLower(e.Type), q) ||
 			strings.Contains(strings.ToLower(e.ID), q) ||
 			strings.Contains(strings.ToLower(e.Summary), q) {
@@ -316,6 +330,11 @@ func (s *InMemoryStore) InvalidateRelation(ctx context.Context, relationID strin
 
 	for i := range s.relations {
 		if id, ok := s.relations[i].Properties["id"]; ok && id == relationID {
+			// Idempotent: if the relation is already invalidated, preserve the
+			// original InvalidAt/ExpiredAt timestamps rather than overwriting.
+			if s.relations[i].ExpiredAt != nil {
+				return nil
+			}
 			now := time.Now()
 			s.relations[i].InvalidAt = &invalidAt
 			s.relations[i].ExpiredAt = &now

--- a/memory/temporal/inmemory.go
+++ b/memory/temporal/inmemory.go
@@ -1,0 +1,367 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/memory"
+)
+
+// InMemoryStore is a thread-safe in-memory implementation of memory.TemporalGraphStore.
+// It stores entities and relations in maps protected by a sync.RWMutex and supports
+// all temporal query operations.
+type InMemoryStore struct {
+	mu        sync.RWMutex
+	entities  map[string]memory.Entity
+	relations []memory.Relation
+	nextRelID int
+}
+
+// NewInMemoryStore creates a new empty InMemoryStore.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		entities: make(map[string]memory.Entity),
+	}
+}
+
+// AddEntity adds or updates an entity in the in-memory graph. If an entity with
+// the same ID already exists, its properties, type, and summary are updated.
+// CreatedAt is only set on first creation.
+func (s *InMemoryStore) AddEntity(ctx context.Context, entity memory.Entity) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if entity.ID == "" {
+		return core.NewError("temporal.add_entity", core.ErrInvalidInput, "entity ID must not be empty", nil)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.entities[entity.ID]; ok {
+		// Preserve original creation time.
+		if entity.CreatedAt.IsZero() {
+			entity.CreatedAt = existing.CreatedAt
+		}
+		// Merge properties.
+		if existing.Properties != nil && entity.Properties != nil {
+			merged := make(map[string]any, len(existing.Properties)+len(entity.Properties))
+			for k, v := range existing.Properties {
+				merged[k] = v
+			}
+			for k, v := range entity.Properties {
+				merged[k] = v
+			}
+			entity.Properties = merged
+		} else if entity.Properties == nil {
+			entity.Properties = existing.Properties
+		}
+	} else if entity.CreatedAt.IsZero() {
+		entity.CreatedAt = time.Now()
+	}
+
+	s.entities[entity.ID] = entity
+	return nil
+}
+
+// AddRelation creates a directed relationship between two entities. Both entities
+// must already exist. The relation is assigned a unique ID stored in Properties["id"].
+func (s *InMemoryStore) AddRelation(ctx context.Context, from, to, relation string, props map[string]any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if from == "" || to == "" {
+		return core.NewError("temporal.add_relation", core.ErrInvalidInput, "from and to entity IDs must not be empty", nil)
+	}
+	if relation == "" {
+		return core.NewError("temporal.add_relation", core.ErrInvalidInput, "relation type must not be empty", nil)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.entities[from]; !ok {
+		return core.NewError("temporal.add_relation", core.ErrNotFound, fmt.Sprintf("source entity %q not found", from), nil)
+	}
+	if _, ok := s.entities[to]; !ok {
+		return core.NewError("temporal.add_relation", core.ErrNotFound, fmt.Sprintf("target entity %q not found", to), nil)
+	}
+
+	if props == nil {
+		props = make(map[string]any)
+	}
+
+	s.nextRelID++
+	relID := fmt.Sprintf("rel-%d", s.nextRelID)
+	props["id"] = relID
+
+	now := time.Now()
+	rel := memory.Relation{
+		From:       from,
+		To:         to,
+		Type:       relation,
+		Properties: props,
+		CreatedAt:  now,
+		ValidAt:    now,
+	}
+	s.relations = append(s.relations, rel)
+	return nil
+}
+
+// AddTemporalRelation creates a directed relationship with explicit temporal fields.
+// Both entities must already exist. This is the preferred method when the caller knows
+// the valid time and episodes for the relation.
+func (s *InMemoryStore) AddTemporalRelation(ctx context.Context, rel memory.Relation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if rel.From == "" || rel.To == "" {
+		return core.NewError("temporal.add_temporal_relation", core.ErrInvalidInput, "from and to entity IDs must not be empty", nil)
+	}
+	if rel.Type == "" {
+		return core.NewError("temporal.add_temporal_relation", core.ErrInvalidInput, "relation type must not be empty", nil)
+	}
+	if rel.ValidAt.IsZero() {
+		return core.NewError("temporal.add_temporal_relation", core.ErrInvalidInput, "ValidAt must not be zero", nil)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.entities[rel.From]; !ok {
+		return core.NewError("temporal.add_temporal_relation", core.ErrNotFound, fmt.Sprintf("source entity %q not found", rel.From), nil)
+	}
+	if _, ok := s.entities[rel.To]; !ok {
+		return core.NewError("temporal.add_temporal_relation", core.ErrNotFound, fmt.Sprintf("target entity %q not found", rel.To), nil)
+	}
+
+	if rel.Properties == nil {
+		rel.Properties = make(map[string]any)
+	}
+
+	if _, ok := rel.Properties["id"]; !ok {
+		s.nextRelID++
+		rel.Properties["id"] = fmt.Sprintf("rel-%d", s.nextRelID)
+	}
+
+	if rel.CreatedAt.IsZero() {
+		rel.CreatedAt = time.Now()
+	}
+
+	s.relations = append(s.relations, rel)
+	return nil
+}
+
+// Query executes a simple query against the in-memory graph. The query string is
+// interpreted as a case-insensitive substring match against entity types and relation types.
+func (s *InMemoryStore) Query(ctx context.Context, query string) ([]memory.GraphResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := strings.ToLower(query)
+	var entities []memory.Entity
+	var relations []memory.Relation
+
+	for _, e := range s.entities {
+		if strings.Contains(strings.ToLower(e.Type), q) ||
+			strings.Contains(strings.ToLower(e.ID), q) ||
+			strings.Contains(strings.ToLower(e.Summary), q) {
+			entities = append(entities, e)
+		}
+	}
+
+	for _, r := range s.relations {
+		if r.ExpiredAt != nil {
+			continue // skip system-expired relations
+		}
+		if strings.Contains(strings.ToLower(r.Type), q) {
+			relations = append(relations, r)
+		}
+	}
+
+	return []memory.GraphResult{{
+		Entities:  entities,
+		Relations: relations,
+	}}, nil
+}
+
+// Neighbors returns all entities and relations within the given depth from the
+// specified entity, using breadth-first traversal. Only active relations (not
+// system-expired) are traversed.
+func (s *InMemoryStore) Neighbors(ctx context.Context, entityID string, depth int) ([]memory.Entity, []memory.Relation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if depth <= 0 {
+		depth = 1
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if _, ok := s.entities[entityID]; !ok {
+		return nil, nil, core.NewError("temporal.neighbors", core.ErrNotFound, fmt.Sprintf("entity %q not found", entityID), nil)
+	}
+
+	visited := map[string]bool{entityID: true}
+	frontier := []string{entityID}
+	var resultEntities []memory.Entity
+	var resultRelations []memory.Relation
+
+	for d := 0; d < depth && len(frontier) > 0; d++ {
+		var nextFrontier []string
+		for _, nodeID := range frontier {
+			for _, rel := range s.relations {
+				if rel.ExpiredAt != nil {
+					continue
+				}
+				var neighborID string
+				if rel.From == nodeID {
+					neighborID = rel.To
+				} else if rel.To == nodeID {
+					neighborID = rel.From
+				} else {
+					continue
+				}
+				resultRelations = append(resultRelations, rel)
+				if !visited[neighborID] {
+					visited[neighborID] = true
+					if e, ok := s.entities[neighborID]; ok {
+						resultEntities = append(resultEntities, e)
+						nextFrontier = append(nextFrontier, neighborID)
+					}
+				}
+			}
+		}
+		frontier = nextFrontier
+	}
+
+	return resultEntities, resultRelations, nil
+}
+
+// QueryAsOf returns entities and relations that were valid at the specified time.
+// A relation is considered valid at a point in time if:
+//   - ValidAt <= validTime, AND
+//   - InvalidAt is nil OR InvalidAt > validTime, AND
+//   - ExpiredAt is nil (not system-expired)
+//
+// The query string filters by type/ID substring match (same as Query).
+func (s *InMemoryStore) QueryAsOf(ctx context.Context, query string, validTime time.Time, opts ...memory.QueryOption) ([]memory.Entity, []memory.Relation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+	if validTime.IsZero() {
+		return nil, nil, core.NewError("temporal.query_as_of", core.ErrInvalidInput, "validTime must not be zero", nil)
+	}
+
+	qopts := memory.ApplyQueryOptions(opts)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := strings.ToLower(query)
+	var entities []memory.Entity
+	var relations []memory.Relation
+
+	for _, e := range s.entities {
+		if q == "" || strings.Contains(strings.ToLower(e.Type), q) ||
+			strings.Contains(strings.ToLower(e.ID), q) ||
+			strings.Contains(strings.ToLower(e.Summary), q) {
+			entities = append(entities, e)
+		}
+	}
+
+	for _, r := range s.relations {
+		if r.ExpiredAt != nil {
+			continue // system-expired
+		}
+		if !r.ValidAt.After(validTime) && (r.InvalidAt == nil || r.InvalidAt.After(validTime)) {
+			if q == "" || strings.Contains(strings.ToLower(r.Type), q) {
+				relations = append(relations, r)
+				if len(relations) >= qopts.Limit {
+					break
+				}
+			}
+		}
+	}
+
+	return entities, relations, nil
+}
+
+// InvalidateRelation marks a relation as no longer valid. The relation is identified
+// by its ID stored in Properties["id"]. InvalidAt is set to the provided time and
+// ExpiredAt is set to the current system time.
+func (s *InMemoryStore) InvalidateRelation(ctx context.Context, relationID string, invalidAt time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if relationID == "" {
+		return core.NewError("temporal.invalidate_relation", core.ErrInvalidInput, "relation ID must not be empty", nil)
+	}
+	if invalidAt.IsZero() {
+		return core.NewError("temporal.invalidate_relation", core.ErrInvalidInput, "invalidAt must not be zero", nil)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range s.relations {
+		if id, ok := s.relations[i].Properties["id"]; ok && id == relationID {
+			now := time.Now()
+			s.relations[i].InvalidAt = &invalidAt
+			s.relations[i].ExpiredAt = &now
+			return nil
+		}
+	}
+
+	return core.NewError("temporal.invalidate_relation", core.ErrNotFound, fmt.Sprintf("relation %q not found", relationID), nil)
+}
+
+// History returns all versions of relations between two entities, including
+// invalidated ones, ordered by ValidAt ascending.
+func (s *InMemoryStore) History(ctx context.Context, fromID, toID string) ([]memory.Relation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if fromID == "" || toID == "" {
+		return nil, core.NewError("temporal.history", core.ErrInvalidInput, "fromID and toID must not be empty", nil)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []memory.Relation
+	for _, r := range s.relations {
+		if r.From == fromID && r.To == toID {
+			result = append(result, r)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ValidAt.Before(result[j].ValidAt)
+	})
+
+	return result, nil
+}
+
+// Clear removes all entities and relations from the in-memory store.
+func (s *InMemoryStore) Clear(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entities = make(map[string]memory.Entity)
+	s.relations = nil
+	s.nextRelID = 0
+	return nil
+}
+
+// Compile-time check that InMemoryStore implements TemporalGraphStore.
+var _ memory.TemporalGraphStore = (*InMemoryStore)(nil)

--- a/memory/temporal/inmemory_test.go
+++ b/memory/temporal/inmemory_test.go
@@ -1,0 +1,508 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryStore_AddEntity(t *testing.T) {
+	tests := []struct {
+		name    string
+		entity  memory.Entity
+		wantErr bool
+	}{
+		{
+			name: "valid entity",
+			entity: memory.Entity{
+				ID:         "person-1",
+				Type:       "person",
+				Properties: map[string]any{"name": "Alice"},
+			},
+		},
+		{
+			name:    "empty ID errors",
+			entity:  memory.Entity{ID: "", Type: "person"},
+			wantErr: true,
+		},
+		{
+			name: "nil properties accepted",
+			entity: memory.Entity{
+				ID:   "person-2",
+				Type: "person",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewInMemoryStore()
+			err := store.AddEntity(context.Background(), tt.entity)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInMemoryStore_AddEntity_Merge(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	// Add initial entity.
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := store.AddEntity(ctx, memory.Entity{
+		ID:         "person-1",
+		Type:       "person",
+		Properties: map[string]any{"name": "Alice", "age": 30},
+		CreatedAt:  created,
+	})
+	require.NoError(t, err)
+
+	// Update entity -- should merge properties and preserve CreatedAt.
+	err = store.AddEntity(ctx, memory.Entity{
+		ID:         "person-1",
+		Type:       "person",
+		Properties: map[string]any{"age": 31, "city": "NYC"},
+		Summary:    "Alice from NYC",
+	})
+	require.NoError(t, err)
+
+	// Verify merge.
+	store.mu.RLock()
+	entity := store.entities["person-1"]
+	store.mu.RUnlock()
+
+	assert.Equal(t, created, entity.CreatedAt) // preserved
+	assert.Equal(t, "Alice", entity.Properties["name"])
+	assert.Equal(t, 31, entity.Properties["age"]) // updated
+	assert.Equal(t, "NYC", entity.Properties["city"])
+	assert.Equal(t, "Alice from NYC", entity.Summary)
+}
+
+func TestInMemoryStore_AddRelation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	// Add entities first.
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+
+	tests := []struct {
+		name     string
+		from     string
+		to       string
+		relation string
+		wantErr  bool
+	}{
+		{name: "valid relation", from: "a", to: "b", relation: "works_at"},
+		{name: "empty from errors", from: "", to: "b", relation: "works_at", wantErr: true},
+		{name: "empty to errors", from: "a", to: "", relation: "works_at", wantErr: true},
+		{name: "empty relation errors", from: "a", to: "b", relation: "", wantErr: true},
+		{name: "missing from entity", from: "x", to: "b", relation: "works_at", wantErr: true},
+		{name: "missing to entity", from: "a", to: "x", relation: "works_at", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.AddRelation(ctx, tt.from, tt.to, tt.relation, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInMemoryStore_AddTemporalRelation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+
+	validAt := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		rel     memory.Relation
+		wantErr bool
+	}{
+		{
+			name: "valid temporal relation",
+			rel: memory.Relation{
+				From:     "a",
+				To:       "b",
+				Type:     "works_at",
+				ValidAt:  validAt,
+				Episodes: []string{"ep-1"},
+			},
+		},
+		{
+			name: "zero ValidAt errors",
+			rel: memory.Relation{
+				From: "a",
+				To:   "b",
+				Type: "works_at",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty from errors",
+			rel: memory.Relation{
+				From:    "",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: validAt,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing entity errors",
+			rel: memory.Relation{
+				From:    "x",
+				To:      "b",
+				Type:    "works_at",
+				ValidAt: validAt,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.AddTemporalRelation(ctx, tt.rel)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInMemoryStore_Query(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "alice", Type: "person", Summary: "Alice Smith"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "acme", Type: "company", Summary: "ACME Corp"}))
+	require.NoError(t, store.AddRelation(ctx, "alice", "acme", "works_at", nil))
+
+	tests := []struct {
+		name          string
+		query         string
+		wantEntities  int
+		wantRelations int
+	}{
+		{name: "match by type", query: "person", wantEntities: 1, wantRelations: 0},
+		{name: "match by ID", query: "acme", wantEntities: 1, wantRelations: 0},
+		{name: "match relation type", query: "works_at", wantEntities: 0, wantRelations: 1},
+		{name: "no match", query: "zzz", wantEntities: 0, wantRelations: 0},
+		{name: "case insensitive", query: "PERSON", wantEntities: 1, wantRelations: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := store.Query(ctx, tt.query)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Len(t, results[0].Entities, tt.wantEntities)
+			assert.Len(t, results[0].Relations, tt.wantRelations)
+		})
+	}
+}
+
+func TestInMemoryStore_Neighbors(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	// Create a chain: a -> b -> c
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "c", Type: "person"}))
+	require.NoError(t, store.AddRelation(ctx, "a", "b", "knows", nil))
+	require.NoError(t, store.AddRelation(ctx, "b", "c", "knows", nil))
+
+	t.Run("depth 1", func(t *testing.T) {
+		entities, relations, err := store.Neighbors(ctx, "a", 1)
+		require.NoError(t, err)
+		assert.Len(t, entities, 1)  // b
+		assert.Len(t, relations, 1) // a->b
+	})
+
+	t.Run("depth 2", func(t *testing.T) {
+		entities, relations, err := store.Neighbors(ctx, "a", 2)
+		require.NoError(t, err)
+		assert.Len(t, entities, 2) // b, c
+		assert.GreaterOrEqual(t, len(relations), 2)
+	})
+
+	t.Run("missing entity errors", func(t *testing.T) {
+		_, _, err := store.Neighbors(ctx, "x", 1)
+		require.Error(t, err)
+	})
+}
+
+func TestInMemoryStore_QueryAsOf(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "c", Type: "company"}))
+
+	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// a worked_at b from t1 to t2
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "a",
+		To:         "b",
+		Type:       "works_at",
+		ValidAt:    t1,
+		InvalidAt:  timePtr(t2),
+		Properties: map[string]any{"id": "rel-1"},
+	}))
+
+	// a works_at c from t2 onward
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "a",
+		To:         "c",
+		Type:       "works_at",
+		ValidAt:    t2,
+		Properties: map[string]any{"id": "rel-2"},
+	}))
+
+	tests := []struct {
+		name          string
+		query         string
+		validTime     time.Time
+		wantRelations int
+		wantErr       bool
+	}{
+		{
+			name:          "query at t1 gets first relation",
+			query:         "works_at",
+			validTime:     t1.Add(time.Hour),
+			wantRelations: 1,
+		},
+		{
+			name:          "query at t2 gets second relation only",
+			query:         "works_at",
+			validTime:     t2.Add(time.Hour),
+			wantRelations: 1,
+		},
+		{
+			name:          "query at t3 gets second relation",
+			query:         "works_at",
+			validTime:     t3,
+			wantRelations: 1,
+		},
+		{
+			name:      "zero time errors",
+			query:     "works_at",
+			validTime: time.Time{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, relations, err := store.QueryAsOf(ctx, tt.query, tt.validTime)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, relations, tt.wantRelations)
+		})
+	}
+}
+
+func TestInMemoryStore_InvalidateRelation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+
+	validAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "a",
+		To:         "b",
+		Type:       "works_at",
+		ValidAt:    validAt,
+		Properties: map[string]any{"id": "rel-1"},
+	}))
+
+	invalidAt := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		relID   string
+		time    time.Time
+		wantErr bool
+	}{
+		{name: "valid invalidation", relID: "rel-1", time: invalidAt},
+		{name: "empty ID errors", relID: "", time: invalidAt, wantErr: true},
+		{name: "zero time errors", relID: "rel-1", time: time.Time{}, wantErr: true},
+		{name: "not found errors", relID: "rel-999", time: invalidAt, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := store.InvalidateRelation(ctx, tt.relID, tt.time)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInMemoryStore_History(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+
+	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "a",
+		To:         "b",
+		Type:       "works_at",
+		ValidAt:    t1,
+		Properties: map[string]any{"id": "rel-1"},
+	}))
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "a",
+		To:         "b",
+		Type:       "works_at",
+		ValidAt:    t2,
+		Properties: map[string]any{"id": "rel-2"},
+	}))
+
+	t.Run("returns all versions sorted by ValidAt", func(t *testing.T) {
+		history, err := store.History(ctx, "a", "b")
+		require.NoError(t, err)
+		require.Len(t, history, 2)
+		assert.True(t, history[0].ValidAt.Before(history[1].ValidAt))
+	})
+
+	t.Run("no history for non-existent pair", func(t *testing.T) {
+		history, err := store.History(ctx, "a", "c")
+		require.NoError(t, err)
+		assert.Empty(t, history)
+	})
+
+	t.Run("empty IDs error", func(t *testing.T) {
+		_, err := store.History(ctx, "", "b")
+		require.Error(t, err)
+	})
+}
+
+func TestInMemoryStore_Clear(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "b", Type: "company"}))
+	require.NoError(t, store.AddRelation(ctx, "a", "b", "works_at", nil))
+
+	err := store.Clear(ctx)
+	require.NoError(t, err)
+
+	// Verify empty.
+	store.mu.RLock()
+	assert.Empty(t, store.entities)
+	assert.Empty(t, store.relations)
+	store.mu.RUnlock()
+}
+
+func TestInMemoryStore_ContextCancellation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.AddEntity(ctx, memory.Entity{ID: "a", Type: "person"})
+	assert.ErrorIs(t, err, context.Canceled)
+
+	err = store.AddRelation(ctx, "a", "b", "knows", nil)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = store.Query(ctx, "test")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, _, err = store.Neighbors(ctx, "a", 1)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, _, err = store.QueryAsOf(ctx, "test", time.Now())
+	assert.ErrorIs(t, err, context.Canceled)
+
+	err = store.InvalidateRelation(ctx, "rel-1", time.Now())
+	assert.ErrorIs(t, err, context.Canceled)
+
+	_, err = store.History(ctx, "a", "b")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestInMemoryStore_ThreadSafety(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	// Pre-populate entities.
+	for i := 0; i < 10; i++ {
+		require.NoError(t, store.AddEntity(ctx, memory.Entity{
+			ID:   fmt.Sprintf("e-%d", i),
+			Type: "node",
+		}))
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+
+	// Concurrent reads and writes.
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			_ = store.AddEntity(ctx, memory.Entity{
+				ID:   fmt.Sprintf("concurrent-%d", n),
+				Type: "node",
+			})
+		}(i)
+	}
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = store.Query(ctx, "node")
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = store.History(ctx, "e-0", "e-1")
+		}()
+	}
+
+	wg.Wait()
+}

--- a/memory/temporal/options.go
+++ b/memory/temporal/options.go
@@ -1,0 +1,35 @@
+// Package temporal provides bi-temporal knowledge graph memory for agents.
+// It implements the Graphiti-inspired 2-condition conflict resolution algorithm
+// and supports querying the knowledge graph as it existed at any point in time.
+package temporal
+
+// Option configures a TemporalMemory.
+type Option func(*options)
+
+type options struct {
+	resolver ConflictResolver
+	hooks    Hooks
+}
+
+func defaultOptions() options {
+	return options{
+		resolver: NewTemporalResolver(),
+	}
+}
+
+// WithConflictResolver sets a custom conflict resolver for the temporal memory.
+// If not set, the default TemporalResolver (Graphiti 2-condition algorithm) is used.
+func WithConflictResolver(r ConflictResolver) Option {
+	return func(o *options) {
+		if r != nil {
+			o.resolver = r
+		}
+	}
+}
+
+// WithHooks sets the hooks for the temporal memory.
+func WithHooks(h Hooks) Option {
+	return func(o *options) {
+		o.hooks = h
+	}
+}

--- a/memory/temporal/temporal.go
+++ b/memory/temporal/temporal.go
@@ -1,0 +1,292 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/memory"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// TemporalMemory wraps a TemporalGraphStore to provide a Memory-compatible interface
+// with bi-temporal knowledge graph capabilities. It supports saving conversation turns
+// as graph entities/relations, loading relevant context, and querying the graph as
+// it existed at any point in time.
+type TemporalMemory struct {
+	store    memory.TemporalGraphStore
+	resolver ConflictResolver
+	hooks    Hooks
+}
+
+// New creates a new TemporalMemory backed by the given TemporalGraphStore.
+// If no conflict resolver is provided via options, the default TemporalResolver is used.
+func New(store memory.TemporalGraphStore, opts ...Option) *TemporalMemory {
+	o := defaultOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &TemporalMemory{
+		store:    store,
+		resolver: o.resolver,
+		hooks:    o.hooks,
+	}
+}
+
+// Save persists a conversation turn as entities and relations in the temporal graph.
+// The input message is stored as a "message" entity and relations are created to
+// represent the conversation flow.
+func (tm *TemporalMemory) Save(ctx context.Context, input, output schema.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	// Create entities for input and output messages.
+	inputText := extractText(input)
+	outputText := extractText(output)
+
+	inputEntity := memory.Entity{
+		ID:         fmt.Sprintf("msg-input-%d", now.UnixNano()),
+		Type:       "message",
+		Properties: map[string]any{"role": string(input.GetRole()), "text": inputText},
+		CreatedAt:  now,
+		Summary:    truncate(inputText, 200),
+	}
+
+	outputEntity := memory.Entity{
+		ID:         fmt.Sprintf("msg-output-%d", now.UnixNano()),
+		Type:       "message",
+		Properties: map[string]any{"role": string(output.GetRole()), "text": outputText},
+		CreatedAt:  now,
+		Summary:    truncate(outputText, 200),
+	}
+
+	if err := tm.store.AddEntity(ctx, inputEntity); err != nil {
+		return fmt.Errorf("temporal: save input entity: %w", err)
+	}
+	if err := tm.store.AddEntity(ctx, outputEntity); err != nil {
+		return fmt.Errorf("temporal: save output entity: %w", err)
+	}
+
+	// Create a "responds_to" relation between output and input.
+	props := map[string]any{
+		"turn_timestamp": now.Format(time.RFC3339Nano),
+	}
+	if err := tm.store.AddRelation(ctx, outputEntity.ID, inputEntity.ID, "responds_to", props); err != nil {
+		return fmt.Errorf("temporal: save relation: %w", err)
+	}
+
+	return nil
+}
+
+// Load retrieves messages from the graph by querying for message entities matching
+// the given query string. Returns messages ordered by creation time.
+func (tm *TemporalMemory) Load(ctx context.Context, query string) ([]schema.Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	results, err := tm.store.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("temporal: load: %w", err)
+	}
+
+	var msgs []schema.Message
+	for _, result := range results {
+		for _, entity := range result.Entities {
+			if entity.Type != "message" {
+				continue
+			}
+			msg := entityToMessage(entity)
+			if msg != nil {
+				msgs = append(msgs, msg)
+			}
+		}
+	}
+
+	return msgs, nil
+}
+
+// LoadAt retrieves messages that were valid at a specific point in time. This enables
+// querying the knowledge graph as it existed at any historical moment.
+func (tm *TemporalMemory) LoadAt(ctx context.Context, query string, validTime time.Time) ([]schema.Message, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if validTime.IsZero() {
+		return nil, core.NewError("temporal.load_at", core.ErrInvalidInput, "validTime must not be zero", nil)
+	}
+
+	entities, _, err := tm.store.QueryAsOf(ctx, query, validTime)
+	if err != nil {
+		return nil, fmt.Errorf("temporal: load_at: %w", err)
+	}
+
+	var msgs []schema.Message
+	for _, entity := range entities {
+		if entity.Type != "message" {
+			continue
+		}
+		msg := entityToMessage(entity)
+		if msg != nil {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	return msgs, nil
+}
+
+// Search finds documents in the graph relevant to the given query. The k parameter
+// limits the number of results returned.
+func (tm *TemporalMemory) Search(ctx context.Context, query string, k int) ([]schema.Document, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+
+	results, err := tm.store.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("temporal: search: %w", err)
+	}
+
+	var docs []schema.Document
+	for _, result := range results {
+		for _, entity := range result.Entities {
+			if len(docs) >= k {
+				break
+			}
+			docs = append(docs, schema.Document{
+				ID:       entity.ID,
+				Content:  entity.Summary,
+				Metadata: entity.Properties,
+			})
+		}
+	}
+
+	return docs, nil
+}
+
+// Clear removes all data from the underlying store by creating a fresh store.
+// Note: For the in-memory store, this is handled by replacing the internal state.
+// For persistent stores, this delegates to the store's Clear method if available.
+func (tm *TemporalMemory) Clear(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// If the store supports clearing, use it.
+	type clearer interface {
+		Clear(ctx context.Context) error
+	}
+	if c, ok := tm.store.(clearer); ok {
+		return c.Clear(ctx)
+	}
+
+	return nil
+}
+
+// ResolveConflicts runs the conflict resolution algorithm for a new relation against
+// existing relations between the same entities. This should be called when adding
+// knowledge that may contradict existing facts.
+func (tm *TemporalMemory) ResolveConflicts(ctx context.Context, newRelation *memory.Relation) ([]memory.Relation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if newRelation == nil {
+		return nil, core.NewError("temporal.resolve_conflicts", core.ErrInvalidInput, "newRelation must not be nil", nil)
+	}
+
+	// Get history of relations between these entities.
+	candidates, err := tm.store.History(ctx, newRelation.From, newRelation.To)
+	if err != nil {
+		return nil, fmt.Errorf("temporal: resolve_conflicts history: %w", err)
+	}
+
+	// Filter to only same-type relations as candidates.
+	var sameType []memory.Relation
+	for _, c := range candidates {
+		if c.Type == newRelation.Type {
+			sameType = append(sameType, c)
+		}
+	}
+
+	invalidated, err := tm.resolver.Resolve(ctx, newRelation, sameType)
+	if err != nil {
+		return nil, fmt.Errorf("temporal: resolve_conflicts: %w", err)
+	}
+
+	// Apply invalidations to the store.
+	for _, inv := range invalidated {
+		if id, ok := inv.Properties["id"]; ok {
+			if relID, ok := id.(string); ok {
+				if inv.InvalidAt != nil {
+					if err := tm.store.InvalidateRelation(ctx, relID, *inv.InvalidAt); err != nil {
+						return nil, fmt.Errorf("temporal: apply invalidation: %w", err)
+					}
+				}
+			}
+		}
+	}
+
+	// Fire hook.
+	if tm.hooks.OnConflictResolved != nil && len(invalidated) > 0 {
+		tm.hooks.OnConflictResolved(ctx, invalidated, *newRelation)
+	}
+
+	return invalidated, nil
+}
+
+// Store returns the underlying TemporalGraphStore for direct access to graph operations.
+func (tm *TemporalMemory) Store() memory.TemporalGraphStore {
+	return tm.store
+}
+
+// entityToMessage converts a message entity back to a schema.Message.
+func entityToMessage(entity memory.Entity) schema.Message {
+	text, _ := entity.Properties["text"].(string)
+	role, _ := entity.Properties["role"].(string)
+
+	switch schema.Role(role) {
+	case schema.RoleHuman:
+		return schema.NewHumanMessage(text)
+	case schema.RoleAI:
+		return schema.NewAIMessage(text)
+	case schema.RoleSystem:
+		return schema.NewSystemMessage(text)
+	default:
+		if text != "" {
+			return schema.NewHumanMessage(text)
+		}
+		return nil
+	}
+}
+
+// extractText extracts the text content from a message.
+func extractText(msg schema.Message) string {
+	parts := msg.GetContent()
+	for _, p := range parts {
+		if tp, ok := p.(schema.TextPart); ok {
+			return tp.Text
+		}
+	}
+	return ""
+}
+
+// truncate shortens a string to at most maxLen characters, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// Compile-time check that TemporalMemory implements memory.Memory.
+var _ memory.Memory = (*TemporalMemory)(nil)

--- a/memory/temporal/temporal.go
+++ b/memory/temporal/temporal.go
@@ -220,16 +220,23 @@ func (tm *TemporalMemory) ResolveConflicts(ctx context.Context, newRelation *mem
 		return nil, fmt.Errorf("temporal: resolve_conflicts: %w", err)
 	}
 
-	// Apply invalidations to the store.
+	// Apply invalidations to the store. Silently skipping a candidate here
+	// would desync the in-memory invalidated slice from the underlying store,
+	// so missing or malformed identifiers must surface as errors.
 	for _, inv := range invalidated {
-		if id, ok := inv.Properties["id"]; ok {
-			if relID, ok := id.(string); ok {
-				if inv.InvalidAt != nil {
-					if err := tm.store.InvalidateRelation(ctx, relID, *inv.InvalidAt); err != nil {
-						return nil, fmt.Errorf("temporal: apply invalidation: %w", err)
-					}
-				}
-			}
+		id, ok := inv.Properties["id"]
+		if !ok {
+			return nil, core.NewError("temporal.resolve_conflicts", core.ErrInvalidInput, "invalidated relation missing Properties[\"id\"]", nil)
+		}
+		relID, ok := id.(string)
+		if !ok {
+			return nil, core.NewError("temporal.resolve_conflicts", core.ErrInvalidInput, "invalidated relation Properties[\"id\"] is not a string", nil)
+		}
+		if inv.InvalidAt == nil {
+			continue
+		}
+		if err := tm.store.InvalidateRelation(ctx, relID, *inv.InvalidAt); err != nil {
+			return nil, fmt.Errorf("temporal: apply invalidation: %w", err)
 		}
 	}
 

--- a/memory/temporal/temporal_test.go
+++ b/memory/temporal/temporal_test.go
@@ -1,0 +1,301 @@
+package temporal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/memory"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMemory(t *testing.T) (*TemporalMemory, *InMemoryStore) {
+	t.Helper()
+	store := NewInMemoryStore()
+	tm := New(store)
+	return tm, store
+}
+
+func TestTemporalMemory_Save(t *testing.T) {
+	tm, store := newTestMemory(t)
+	ctx := context.Background()
+
+	input := schema.NewHumanMessage("hello")
+	output := schema.NewAIMessage("hi there")
+
+	err := tm.Save(ctx, input, output)
+	require.NoError(t, err)
+
+	// Verify entities were created.
+	store.mu.RLock()
+	assert.Len(t, store.entities, 2)
+	assert.Len(t, store.relations, 1)
+	store.mu.RUnlock()
+}
+
+func TestTemporalMemory_Save_ContextCancelled(t *testing.T) {
+	tm, _ := newTestMemory(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := tm.Save(ctx, schema.NewHumanMessage("hello"), schema.NewAIMessage("hi"))
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestTemporalMemory_Load(t *testing.T) {
+	tm, _ := newTestMemory(t)
+	ctx := context.Background()
+
+	// Save a conversation turn.
+	err := tm.Save(ctx, schema.NewHumanMessage("hello"), schema.NewAIMessage("hi there"))
+	require.NoError(t, err)
+
+	// Load messages matching "message" (the entity type).
+	msgs, err := tm.Load(ctx, "message")
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2) // input + output entities
+}
+
+func TestTemporalMemory_Load_Empty(t *testing.T) {
+	tm, _ := newTestMemory(t)
+	ctx := context.Background()
+
+	msgs, err := tm.Load(ctx, "anything")
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+}
+
+func TestTemporalMemory_LoadAt(t *testing.T) {
+	store := NewInMemoryStore()
+	tm := New(store)
+	ctx := context.Background()
+
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Add message entities directly for controlled temporal testing.
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{
+		ID:         "msg-1",
+		Type:       "message",
+		Properties: map[string]any{"role": "human", "text": "hello"},
+		CreatedAt:  t1,
+	}))
+
+	// Add a temporal relation valid from t1.
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "msg-1",
+		To:         "msg-1",
+		Type:       "message",
+		ValidAt:    t1,
+		Properties: map[string]any{"id": "rel-msg-1"},
+	}))
+
+	t.Run("load at valid time", func(t *testing.T) {
+		msgs, err := tm.LoadAt(ctx, "message", t1.Add(time.Hour))
+		require.NoError(t, err)
+		assert.NotEmpty(t, msgs)
+	})
+
+	t.Run("zero time errors", func(t *testing.T) {
+		_, err := tm.LoadAt(ctx, "message", time.Time{})
+		require.Error(t, err)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		_, err := tm.LoadAt(cancelCtx, "message", t1)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+func TestTemporalMemory_Search(t *testing.T) {
+	tm, _ := newTestMemory(t)
+	ctx := context.Background()
+
+	// Save some data.
+	require.NoError(t, tm.Save(ctx, schema.NewHumanMessage("what is Go?"), schema.NewAIMessage("Go is a programming language")))
+
+	t.Run("search with results", func(t *testing.T) {
+		docs, err := tm.Search(ctx, "message", 10)
+		require.NoError(t, err)
+		assert.NotEmpty(t, docs)
+		for _, doc := range docs {
+			assert.NotEmpty(t, doc.ID)
+		}
+	})
+
+	t.Run("search with k=0 returns nil", func(t *testing.T) {
+		docs, err := tm.Search(ctx, "message", 0)
+		require.NoError(t, err)
+		assert.Nil(t, docs)
+	})
+
+	t.Run("search with no match", func(t *testing.T) {
+		docs, err := tm.Search(ctx, "zzzzz", 10)
+		require.NoError(t, err)
+		assert.Empty(t, docs)
+	})
+}
+
+func TestTemporalMemory_Clear(t *testing.T) {
+	tm, store := newTestMemory(t)
+	ctx := context.Background()
+
+	require.NoError(t, tm.Save(ctx, schema.NewHumanMessage("hello"), schema.NewAIMessage("hi")))
+
+	err := tm.Clear(ctx)
+	require.NoError(t, err)
+
+	store.mu.RLock()
+	assert.Empty(t, store.entities)
+	assert.Empty(t, store.relations)
+	store.mu.RUnlock()
+}
+
+func TestTemporalMemory_ResolveConflicts(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	var hookCalled bool
+	tm := New(store, WithHooks(Hooks{
+		OnConflictResolved: func(_ context.Context, invalidated []memory.Relation, _ memory.Relation) {
+			hookCalled = true
+			assert.NotEmpty(t, invalidated)
+		},
+	}))
+
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "alice", Type: "person"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "acme", Type: "company"}))
+	require.NoError(t, store.AddEntity(ctx, memory.Entity{ID: "globex", Type: "company"}))
+
+	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Alice worked at ACME from t1.
+	require.NoError(t, store.AddTemporalRelation(ctx, memory.Relation{
+		From:       "alice",
+		To:         "acme",
+		Type:       "works_at",
+		ValidAt:    t1,
+		Properties: map[string]any{"id": "rel-1"},
+	}))
+
+	// Now Alice works at Globex from t2. Resolve conflicts.
+	newRel := &memory.Relation{
+		From:    "alice",
+		To:      "acme",
+		Type:    "works_at",
+		ValidAt: t2,
+	}
+
+	invalidated, err := tm.ResolveConflicts(ctx, newRel)
+	require.NoError(t, err)
+	assert.Len(t, invalidated, 1)
+	assert.True(t, hookCalled, "OnConflictResolved hook should have been called")
+}
+
+func TestTemporalMemory_ResolveConflicts_NilRelation(t *testing.T) {
+	tm, _ := newTestMemory(t)
+	_, err := tm.ResolveConflicts(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestTemporalMemory_Store(t *testing.T) {
+	store := NewInMemoryStore()
+	tm := New(store)
+	assert.Equal(t, store, tm.Store())
+}
+
+func TestTemporalMemory_CompileTimeCheck(t *testing.T) {
+	var _ memory.Memory = (*TemporalMemory)(nil)
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{name: "short string unchanged", input: "hello", maxLen: 10, want: "hello"},
+		{name: "exact length unchanged", input: "hello", maxLen: 5, want: "hello"},
+		{name: "truncated with ellipsis", input: "hello world", maxLen: 8, want: "hello..."},
+		{name: "very short maxLen", input: "hello", maxLen: 2, want: "he"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.input, tt.maxLen)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	msg := schema.NewHumanMessage("hello world")
+	assert.Equal(t, "hello world", extractText(msg))
+}
+
+func TestEntityToMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		entity   memory.Entity
+		wantRole schema.Role
+		wantNil  bool
+	}{
+		{
+			name: "human message",
+			entity: memory.Entity{
+				Type:       "message",
+				Properties: map[string]any{"role": "human", "text": "hello"},
+			},
+			wantRole: schema.RoleHuman,
+		},
+		{
+			name: "ai message",
+			entity: memory.Entity{
+				Type:       "message",
+				Properties: map[string]any{"role": "ai", "text": "hi"},
+			},
+			wantRole: schema.RoleAI,
+		},
+		{
+			name: "system message",
+			entity: memory.Entity{
+				Type:       "message",
+				Properties: map[string]any{"role": "system", "text": "you are helpful"},
+			},
+			wantRole: schema.RoleSystem,
+		},
+		{
+			name: "unknown role with text defaults to human",
+			entity: memory.Entity{
+				Type:       "message",
+				Properties: map[string]any{"role": "unknown", "text": "data"},
+			},
+			wantRole: schema.RoleHuman,
+		},
+		{
+			name: "unknown role without text returns nil",
+			entity: memory.Entity{
+				Type:       "message",
+				Properties: map[string]any{"role": "unknown"},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := entityToMessage(tt.entity)
+			if tt.wantNil {
+				assert.Nil(t, msg)
+				return
+			}
+			require.NotNil(t, msg)
+			assert.Equal(t, tt.wantRole, msg.GetRole())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- bi-temporal Entity/Relation, TemporalGraphStore interface, Graphiti-style 2-condition conflict resolution, point-in-time queries

## Linear
- LOO-9: https://linear.app/lookatitude/issue/LOO-9

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)