### PR TITLE
LOO-12: Metacognitive Agents (Self-Model Improvement)

### DIFF
--- a/agent/metacognitive/doc.go
+++ b/agent/metacognitive/doc.go
@@ -1,0 +1,21 @@
+// Package metacognitive provides self-model improvement capabilities for agents.
+//
+// It implements cross-session learning inspired by ExpeL (Experience Learning)
+// and ERL (Experience Reinforcement Learning) research. Agents accumulate
+// heuristics from their successes and failures, persist them across sessions,
+// and retrieve relevant ones to guide future behavior.
+//
+// Key components:
+//
+//   - SelfModel: persistent typed self-knowledge (heuristics + capability scores)
+//   - SelfModelStore: persistence interface with in-memory implementation
+//   - Monitor: hooks-based signal collection from agent execution
+//   - HeuristicExtractor: extracts learnings from execution signals
+//   - MetacognitivePlugin: runtime.Plugin that injects and persists learnings
+//
+// Usage:
+//
+//	store := metacognitive.NewInMemoryStore()
+//	plugin := metacognitive.NewPlugin(store)
+//	runner := runtime.NewRunner(myAgent, runtime.WithPlugins(plugin))
+package metacognitive

--- a/agent/metacognitive/extractor.go
+++ b/agent/metacognitive/extractor.go
@@ -157,13 +157,62 @@ func normalizeError(errMsg string) string {
 	return lower
 }
 
-// summarizeError truncates an error message to a reasonable length.
+// summarizeError sanitizes and truncates an error message. Errors may
+// originate from LLM output, remote tool calls, or network peers — any of
+// which could plant crafted text that later becomes part of an injected
+// heuristic. We strip control characters, collapse whitespace, and drop
+// obvious instruction-like markers before truncation to limit stored prompt
+// injection risk.
 func summarizeError(errMsg string) string {
 	const maxLen = 200
-	if len(errMsg) <= maxLen {
-		return errMsg
+	cleaned := sanitizeUntrustedText(errMsg)
+	if len(cleaned) <= maxLen {
+		return cleaned
 	}
-	return errMsg[:maxLen] + "..."
+	return cleaned[:maxLen] + "..."
+}
+
+// sanitizeUntrustedText removes control characters, collapses whitespace,
+// and neutralizes obvious instruction markers. It is a defensive filter, not
+// a complete prompt-injection defense.
+func sanitizeUntrustedText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		// Drop control characters except basic spaces and tabs (which we
+		// normalize to a single space).
+		if r == '\n' || r == '\r' || r == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		if r == ' ' {
+			if !prevSpace {
+				b.WriteRune(r)
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	out := strings.TrimSpace(b.String())
+	// Neutralize common instruction-like phrases to blunt the most obvious
+	// stored-injection payloads. Substring replacement is intentionally
+	// conservative.
+	replacer := strings.NewReplacer(
+		"ignore previous", "[redacted]",
+		"ignore the above", "[redacted]",
+		"system:", "system",
+		"assistant:", "assistant",
+	)
+	return replacer.Replace(out)
 }
 
 // generateID creates a short random hex ID for heuristics.

--- a/agent/metacognitive/extractor.go
+++ b/agent/metacognitive/extractor.go
@@ -1,0 +1,177 @@
+package metacognitive
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// HeuristicExtractor derives heuristics from execution signals and the
+// current self-model. Implementations range from simple rule-based extraction
+// to LLM-powered analysis.
+type HeuristicExtractor interface {
+	// Extract analyzes the signals and model to produce new heuristics.
+	Extract(ctx context.Context, signals MonitoringSignals, model *SelfModel) ([]Heuristic, error)
+}
+
+// Compile-time check.
+var _ HeuristicExtractor = (*SimpleExtractor)(nil)
+
+// SimpleExtractor is a rule-based heuristic extractor that derives learnings
+// from failures and successes without requiring an LLM.
+//
+// On failure: extracts "avoid" heuristics from error messages and tool failures.
+// On success with notable patterns: extracts "prefer" heuristics.
+type SimpleExtractor struct{}
+
+// NewSimpleExtractor creates a new rule-based SimpleExtractor.
+func NewSimpleExtractor() *SimpleExtractor {
+	return &SimpleExtractor{}
+}
+
+// Extract derives heuristics from the execution signals.
+func (e *SimpleExtractor) Extract(ctx context.Context, signals MonitoringSignals, model *SelfModel) ([]Heuristic, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var heuristics []Heuristic
+
+	taskType := signals.TaskType
+	if taskType == "" {
+		taskType = "general"
+	}
+
+	if !signals.Success {
+		// Failure-derived heuristics.
+		heuristics = append(heuristics, e.extractFromFailure(signals, taskType)...)
+	} else {
+		// Success-derived heuristics.
+		heuristics = append(heuristics, e.extractFromSuccess(signals, taskType, model)...)
+	}
+
+	return heuristics, nil
+}
+
+// extractFromFailure generates "avoid" heuristics from failure signals.
+func (e *SimpleExtractor) extractFromFailure(signals MonitoringSignals, taskType string) []Heuristic {
+	var heuristics []Heuristic
+
+	// Extract from errors.
+	seen := make(map[string]bool)
+	for _, errMsg := range signals.Errors {
+		// Deduplicate similar errors.
+		key := normalizeError(errMsg)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		h := Heuristic{
+			ID:        generateID(),
+			Content:   fmt.Sprintf("Avoid: encountered error during %s task: %s", taskType, summarizeError(errMsg)),
+			Source:    "failure",
+			TaskType:  taskType,
+			Utility:   0.7,
+			CreatedAt: time.Now(),
+		}
+		heuristics = append(heuristics, h)
+	}
+
+	// High iteration count suggests inefficient approach.
+	if signals.IterationCount > 5 {
+		h := Heuristic{
+			ID:        generateID(),
+			Content:   fmt.Sprintf("Avoid: excessive iterations (%d) on %s tasks. Consider a more direct approach.", signals.IterationCount, taskType),
+			Source:    "failure",
+			TaskType:  taskType,
+			Utility:   0.6,
+			CreatedAt: time.Now(),
+		}
+		heuristics = append(heuristics, h)
+	}
+
+	return heuristics
+}
+
+// extractFromSuccess generates "prefer" heuristics from successful executions.
+func (e *SimpleExtractor) extractFromSuccess(signals MonitoringSignals, taskType string, model *SelfModel) []Heuristic {
+	var heuristics []Heuristic
+
+	// Fast completion is worth noting.
+	if signals.IterationCount <= 2 && len(signals.ToolCalls) > 0 {
+		toolList := strings.Join(signals.ToolCalls, ", ")
+		h := Heuristic{
+			ID:        generateID(),
+			Content:   fmt.Sprintf("Prefer: for %s tasks, using tools [%s] resolved the task efficiently in %d iterations.", taskType, toolList, signals.IterationCount),
+			Source:    "success",
+			TaskType:  taskType,
+			Utility:   0.8,
+			CreatedAt: time.Now(),
+		}
+		heuristics = append(heuristics, h)
+	}
+
+	// Novel tool combination (not seen in existing heuristics).
+	if len(signals.ToolCalls) >= 2 && !hasToolCombinationHeuristic(model, signals.ToolCalls) {
+		toolList := strings.Join(signals.ToolCalls, " -> ")
+		h := Heuristic{
+			ID:        generateID(),
+			Content:   fmt.Sprintf("Prefer: successful tool sequence for %s: %s", taskType, toolList),
+			Source:    "success",
+			TaskType:  taskType,
+			Utility:   0.6,
+			CreatedAt: time.Now(),
+		}
+		heuristics = append(heuristics, h)
+	}
+
+	return heuristics
+}
+
+// hasToolCombinationHeuristic checks if the model already has a heuristic
+// mentioning the same tool combination.
+func hasToolCombinationHeuristic(model *SelfModel, tools []string) bool {
+	if model == nil {
+		return false
+	}
+	toolList := strings.Join(tools, " -> ")
+	for _, h := range model.Heuristics {
+		if strings.Contains(h.Content, toolList) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeError produces a deduplication key for an error message.
+func normalizeError(errMsg string) string {
+	lower := strings.ToLower(errMsg)
+	// Truncate to first 80 chars for dedup key.
+	if len(lower) > 80 {
+		lower = lower[:80]
+	}
+	return lower
+}
+
+// summarizeError truncates an error message to a reasonable length.
+func summarizeError(errMsg string) string {
+	const maxLen = 200
+	if len(errMsg) <= maxLen {
+		return errMsg
+	}
+	return errMsg[:maxLen] + "..."
+}
+
+// generateID creates a short random hex ID for heuristics.
+func generateID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: use timestamp-based ID.
+		return fmt.Sprintf("h_%d", time.Now().UnixNano())
+	}
+	return "h_" + hex.EncodeToString(b)
+}

--- a/agent/metacognitive/extractor_test.go
+++ b/agent/metacognitive/extractor_test.go
@@ -1,0 +1,181 @@
+package metacognitive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimpleExtractor_CompileTimeCheck(t *testing.T) {
+	var _ HeuristicExtractor = (*SimpleExtractor)(nil)
+}
+
+func TestSimpleExtractor_Extract(t *testing.T) {
+	extractor := NewSimpleExtractor()
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		signals    MonitoringSignals
+		model      *SelfModel
+		wantMin    int    // minimum expected heuristics
+		wantSource string // expected source for first heuristic
+	}{
+		{
+			name: "failure with errors produces avoid heuristics",
+			signals: MonitoringSignals{
+				TaskInput: "search for documents",
+				TaskType:  "search",
+				Success:   false,
+				Errors:    []string{"timeout connecting to API"},
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    1,
+			wantSource: "failure",
+		},
+		{
+			name: "failure with high iterations",
+			signals: MonitoringSignals{
+				TaskInput:      "complex task",
+				TaskType:       "coding",
+				Success:        false,
+				IterationCount: 10,
+				Errors:         []string{"exceeded max iterations"},
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    2, // error heuristic + iteration heuristic
+			wantSource: "failure",
+		},
+		{
+			name: "success with efficient tool use",
+			signals: MonitoringSignals{
+				TaskInput:      "find info",
+				TaskType:       "search",
+				Success:        true,
+				ToolCalls:      []string{"web_search"},
+				IterationCount: 1,
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    1,
+			wantSource: "success",
+		},
+		{
+			name: "success with novel tool combination",
+			signals: MonitoringSignals{
+				TaskInput:      "analyze data",
+				TaskType:       "analysis",
+				Success:        true,
+				ToolCalls:      []string{"fetch_data", "transform"},
+				IterationCount: 2,
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    1,
+			wantSource: "success",
+		},
+		{
+			name: "success with known tool combination produces fewer heuristics",
+			signals: MonitoringSignals{
+				TaskInput:      "analyze data",
+				TaskType:       "analysis",
+				Success:        true,
+				ToolCalls:      []string{"fetch_data", "transform"},
+				IterationCount: 2,
+			},
+			model: &SelfModel{
+				AgentID: "agent-1",
+				Heuristics: []Heuristic{
+					{Content: "Prefer: successful tool sequence for analysis: fetch_data -> transform"},
+				},
+			},
+			wantMin:    1, // efficient use heuristic, but not novel combo
+			wantSource: "success",
+		},
+		{
+			name: "success with many iterations no tools",
+			signals: MonitoringSignals{
+				TaskInput:      "think deeply",
+				TaskType:       "reasoning",
+				Success:        true,
+				IterationCount: 5,
+			},
+			model:   NewSelfModel("agent-1"),
+			wantMin: 0,
+		},
+		{
+			name: "failure deduplicates similar errors",
+			signals: MonitoringSignals{
+				TaskInput: "task",
+				TaskType:  "general",
+				Success:   false,
+				Errors:    []string{"connection timeout", "connection timeout"},
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    1,
+			wantSource: "failure",
+		},
+		{
+			name: "empty task type defaults to general",
+			signals: MonitoringSignals{
+				TaskInput: "task",
+				Success:   false,
+				Errors:    []string{"some error"},
+			},
+			model:      NewSelfModel("agent-1"),
+			wantMin:    1,
+			wantSource: "failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			heuristics, err := extractor.Extract(ctx, tt.signals, tt.model)
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(heuristics), tt.wantMin, "expected at least %d heuristics", tt.wantMin)
+
+			if tt.wantSource != "" && len(heuristics) > 0 {
+				assert.Equal(t, tt.wantSource, heuristics[0].Source)
+			}
+
+			// Verify all heuristics have required fields.
+			for _, h := range heuristics {
+				assert.NotEmpty(t, h.ID, "heuristic must have an ID")
+				assert.NotEmpty(t, h.Content, "heuristic must have content")
+				assert.NotEmpty(t, h.Source, "heuristic must have a source")
+				assert.NotEmpty(t, h.TaskType, "heuristic must have a task type")
+				assert.Greater(t, h.Utility, 0.0, "heuristic must have positive utility")
+				assert.False(t, h.CreatedAt.IsZero(), "heuristic must have creation time")
+			}
+		})
+	}
+}
+
+func TestSimpleExtractor_ContextCancellation(t *testing.T) {
+	extractor := NewSimpleExtractor()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := extractor.Extract(ctx, MonitoringSignals{Success: false, Errors: []string{"err"}}, nil)
+	assert.Error(t, err)
+}
+
+func TestSummarizeError(t *testing.T) {
+	short := "short error"
+	assert.Equal(t, short, summarizeError(short))
+
+	long := make([]byte, 300)
+	for i := range long {
+		long[i] = 'a'
+	}
+	result := summarizeError(string(long))
+	assert.Len(t, result, 203) // 200 + "..."
+	assert.True(t, len(result) <= 203)
+}
+
+func TestGenerateID(t *testing.T) {
+	id1 := generateID()
+	id2 := generateID()
+	assert.NotEqual(t, id1, id2, "IDs must be unique")
+	assert.Contains(t, id1, "h_", "ID must start with h_ prefix")
+}

--- a/agent/metacognitive/monitor.go
+++ b/agent/metacognitive/monitor.go
@@ -1,0 +1,108 @@
+package metacognitive
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// Monitor collects execution signals from agent hooks. It attaches to an
+// agent's AfterAct, OnEnd, OnError, and OnToolCall hooks to build a
+// MonitoringSignals snapshot for each turn.
+type Monitor struct {
+	mu      sync.Mutex
+	signals MonitoringSignals
+	start   time.Time
+}
+
+// NewMonitor creates a new Monitor ready to collect signals.
+func NewMonitor() *Monitor {
+	return &Monitor{
+		start: time.Now(),
+	}
+}
+
+// Hooks returns agent.Hooks that the monitor uses to collect signals.
+// Attach these to an agent via agent.WithHooks.
+func (m *Monitor) Hooks() agent.Hooks {
+	return agent.Hooks{
+		OnStart: func(_ context.Context, input string) error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.start = time.Now()
+			m.signals.TaskInput = input
+			m.signals.Success = true // optimistic; cleared on error
+			return nil
+		},
+		AfterAct: func(_ context.Context, _ agent.Action, obs agent.Observation) error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.signals.IterationCount++
+			if obs.Error != nil {
+				m.signals.Errors = append(m.signals.Errors, obs.Error.Error())
+			}
+			return nil
+		},
+		OnEnd: func(_ context.Context, result string, err error) {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.signals.Outcome = result
+			m.signals.TotalLatency = time.Since(m.start)
+			if err != nil {
+				m.signals.Success = false
+				m.signals.Errors = append(m.signals.Errors, err.Error())
+			}
+		},
+		OnError: func(_ context.Context, err error) error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.signals.Success = false
+			if err != nil {
+				m.signals.Errors = append(m.signals.Errors, err.Error())
+			}
+			return err
+		},
+		OnToolCall: func(_ context.Context, call agent.ToolCallInfo) error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.signals.ToolCalls = append(m.signals.ToolCalls, call.Name)
+			return nil
+		},
+		OnToolResult: func(_ context.Context, call agent.ToolCallInfo, result *tool.Result) error {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if result != nil && result.IsError {
+				m.signals.Errors = append(m.signals.Errors, "tool "+call.Name+" failed")
+			}
+			return nil
+		},
+	}
+}
+
+// Signals returns a copy of the currently accumulated monitoring signals.
+func (m *Monitor) Signals() MonitoringSignals {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.signals
+	// Copy slices to prevent aliasing.
+	if len(m.signals.ToolCalls) > 0 {
+		s.ToolCalls = make([]string, len(m.signals.ToolCalls))
+		copy(s.ToolCalls, m.signals.ToolCalls)
+	}
+	if len(m.signals.Errors) > 0 {
+		s.Errors = make([]string, len(m.signals.Errors))
+		copy(s.Errors, m.signals.Errors)
+	}
+	return s
+}
+
+// Reset clears all accumulated signals and restarts the timer.
+func (m *Monitor) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.signals = MonitoringSignals{}
+	m.start = time.Now()
+}

--- a/agent/metacognitive/monitor_test.go
+++ b/agent/metacognitive/monitor_test.go
@@ -1,0 +1,172 @@
+package metacognitive
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+func TestMonitor_NewMonitor(t *testing.T) {
+	m := NewMonitor()
+	require.NotNil(t, m)
+	s := m.Signals()
+	assert.Empty(t, s.TaskInput)
+	assert.False(t, s.Success)
+}
+
+func TestMonitor_HooksOnStart(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+
+	err := hooks.OnStart(context.Background(), "test input")
+	require.NoError(t, err)
+
+	s := m.Signals()
+	assert.Equal(t, "test input", s.TaskInput)
+	assert.True(t, s.Success, "success should be optimistic after OnStart")
+}
+
+func TestMonitor_HooksAfterAct(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+
+	// Successful observation.
+	err := hooks.AfterAct(ctx, agent.Action{}, agent.Observation{})
+	require.NoError(t, err)
+
+	s := m.Signals()
+	assert.Equal(t, 1, s.IterationCount)
+	assert.Empty(t, s.Errors)
+
+	// Observation with error.
+	err = hooks.AfterAct(ctx, agent.Action{}, agent.Observation{
+		Error: errors.New("tool failed"),
+	})
+	require.NoError(t, err)
+
+	s = m.Signals()
+	assert.Equal(t, 2, s.IterationCount)
+	assert.Contains(t, s.Errors, "tool failed")
+}
+
+func TestMonitor_HooksOnEnd(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	time.Sleep(5 * time.Millisecond) // Ensure measurable latency.
+	hooks.OnEnd(ctx, "result text", nil)
+
+	s := m.Signals()
+	assert.Equal(t, "result text", s.Outcome)
+	assert.True(t, s.Success)
+	assert.Greater(t, s.TotalLatency, time.Duration(0))
+}
+
+func TestMonitor_HooksOnEndWithError(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	hooks.OnEnd(ctx, "", errors.New("execution failed"))
+
+	s := m.Signals()
+	assert.False(t, s.Success)
+	assert.Contains(t, s.Errors, "execution failed")
+}
+
+func TestMonitor_HooksOnError(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	origErr := errors.New("something broke")
+	retErr := hooks.OnError(ctx, origErr)
+
+	assert.Equal(t, origErr, retErr, "OnError must pass through the error")
+	s := m.Signals()
+	assert.False(t, s.Success)
+	assert.Contains(t, s.Errors, "something broke")
+}
+
+func TestMonitor_HooksOnToolCall(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	err := hooks.OnToolCall(ctx, agent.ToolCallInfo{Name: "search", CallID: "c1"})
+	require.NoError(t, err)
+	err = hooks.OnToolCall(ctx, agent.ToolCallInfo{Name: "calculate", CallID: "c2"})
+	require.NoError(t, err)
+
+	s := m.Signals()
+	assert.Equal(t, []string{"search", "calculate"}, s.ToolCalls)
+}
+
+func TestMonitor_HooksOnToolResult(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+
+	// Successful tool result.
+	err := hooks.OnToolResult(ctx, agent.ToolCallInfo{Name: "search"}, tool.TextResult("ok"))
+	require.NoError(t, err)
+	s := m.Signals()
+	assert.Empty(t, s.Errors)
+
+	// Failed tool result.
+	err = hooks.OnToolResult(ctx, agent.ToolCallInfo{Name: "fetch"}, &tool.Result{IsError: true})
+	require.NoError(t, err)
+	s = m.Signals()
+	assert.Contains(t, s.Errors, "tool fetch failed")
+}
+
+func TestMonitor_Reset(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	_ = hooks.OnToolCall(ctx, agent.ToolCallInfo{Name: "search"})
+	hooks.OnEnd(ctx, "result", nil)
+
+	s := m.Signals()
+	assert.NotEmpty(t, s.TaskInput)
+
+	m.Reset()
+	s = m.Signals()
+	assert.Empty(t, s.TaskInput)
+	assert.Empty(t, s.ToolCalls)
+	assert.Empty(t, s.Outcome)
+}
+
+func TestMonitor_SignalsReturnsCopy(t *testing.T) {
+	m := NewMonitor()
+	hooks := m.Hooks()
+	ctx := context.Background()
+
+	_ = hooks.OnStart(ctx, "input")
+	_ = hooks.OnToolCall(ctx, agent.ToolCallInfo{Name: "search"})
+
+	s1 := m.Signals()
+	s1.ToolCalls = append(s1.ToolCalls, "mutated")
+
+	s2 := m.Signals()
+	assert.Len(t, s2.ToolCalls, 1, "mutation of returned signals must not affect monitor")
+}

--- a/agent/metacognitive/plugin.go
+++ b/agent/metacognitive/plugin.go
@@ -1,0 +1,321 @@
+package metacognitive
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/runtime"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// DefaultMaxHeuristics is the maximum number of heuristics injected per turn.
+const DefaultMaxHeuristics = 5
+
+// DefaultEMAAlpha is the exponential moving average smoothing factor for
+// capability score updates. Higher values weight recent observations more.
+const DefaultEMAAlpha = 0.3
+
+// Compile-time check.
+var _ runtime.Plugin = (*Plugin)(nil)
+
+// Plugin is a runtime.Plugin that implements cross-session metacognitive
+// learning. It loads relevant heuristics before each turn, injects them as
+// system context, and extracts new heuristics after each turn.
+type Plugin struct {
+	store         SelfModelStore
+	extractor     HeuristicExtractor
+	maxHeuristics int
+	emaAlpha      float64
+	hooks         Hooks
+
+	// monitor collects signals from agent hooks during execution.
+	monitor *Monitor
+}
+
+// PluginOption configures a Plugin.
+type PluginOption func(*Plugin)
+
+// WithExtractor sets the heuristic extractor. Defaults to SimpleExtractor.
+func WithExtractor(e HeuristicExtractor) PluginOption {
+	return func(p *Plugin) {
+		if e != nil {
+			p.extractor = e
+		}
+	}
+}
+
+// WithMaxHeuristics sets the maximum number of heuristics to inject per turn.
+// Defaults to DefaultMaxHeuristics.
+func WithMaxHeuristics(n int) PluginOption {
+	return func(p *Plugin) {
+		if n > 0 {
+			p.maxHeuristics = n
+		}
+	}
+}
+
+// WithEMAAlpha sets the exponential moving average alpha for capability
+// score updates. Must be between 0 and 1. Defaults to DefaultEMAAlpha.
+func WithEMAAlpha(alpha float64) PluginOption {
+	return func(p *Plugin) {
+		if alpha > 0 && alpha <= 1 {
+			p.emaAlpha = alpha
+		}
+	}
+}
+
+// WithHooks sets the metacognitive hooks for observing learning events.
+func WithHooks(h Hooks) PluginOption {
+	return func(p *Plugin) {
+		p.hooks = h
+	}
+}
+
+// NewPlugin creates a MetacognitivePlugin with the given store and options.
+func NewPlugin(store SelfModelStore, opts ...PluginOption) *Plugin {
+	p := &Plugin{
+		store:         store,
+		extractor:     NewSimpleExtractor(),
+		maxHeuristics: DefaultMaxHeuristics,
+		emaAlpha:      DefaultEMAAlpha,
+		monitor:       NewMonitor(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Name returns the plugin identifier.
+func (p *Plugin) Name() string { return "metacognitive" }
+
+// Monitor returns the plugin's monitor so callers can attach its hooks to
+// agents for signal collection.
+func (p *Plugin) Monitor() *Monitor { return p.monitor }
+
+// BeforeTurn loads the agent's self-model, retrieves relevant heuristics
+// based on the input, and prepends them as system context to the message.
+func (p *Plugin) BeforeTurn(ctx context.Context, session *runtime.Session, input schema.Message) (schema.Message, error) {
+	if session == nil {
+		return input, nil
+	}
+
+	agentID := session.AgentID
+	if agentID == "" {
+		return input, nil
+	}
+
+	// Reset the monitor for this turn.
+	p.monitor.Reset()
+
+	model, err := p.store.Load(ctx, agentID)
+	if err != nil {
+		// Non-fatal: proceed without metacognitive context.
+		return input, nil
+	}
+
+	if p.hooks.OnSelfModelLoaded != nil {
+		p.hooks.OnSelfModelLoaded(model)
+	}
+
+	// Extract query from input message.
+	query := extractTextFromMessage(input)
+	if query == "" {
+		return input, nil
+	}
+
+	// Search for relevant heuristics.
+	heuristics, err := p.store.SearchHeuristics(ctx, agentID, query, p.maxHeuristics)
+	if err != nil || len(heuristics) == 0 {
+		return input, nil
+	}
+
+	// Build metacognitive context message.
+	context := buildHeuristicContext(heuristics)
+
+	// Store the context in session state so AfterTurn can read it.
+	if session.State == nil {
+		session.State = make(map[string]any)
+	}
+	session.State["metacognitive.input"] = query
+	session.State["metacognitive.model_loaded"] = true
+
+	// Prepend system message with heuristics. We return the original input
+	// unchanged and store context in session state. The actual injection
+	// would happen at the agent level if the plugin had message-list access.
+	// Since Plugin.BeforeTurn receives a single message, we augment the
+	// session state for the agent to read. For systems that support it, we
+	// wrap the message with a system prefix.
+	_ = context // Store in session for agent retrieval.
+	session.State["metacognitive.context"] = context
+
+	return input, nil
+}
+
+// AfterTurn collects monitoring signals, extracts new heuristics, updates
+// capability scores, and persists the updated self-model.
+func (p *Plugin) AfterTurn(ctx context.Context, session *runtime.Session, events []agent.Event) ([]agent.Event, error) {
+	if session == nil {
+		return events, nil
+	}
+
+	agentID := session.AgentID
+	if agentID == "" {
+		return events, nil
+	}
+
+	// Collect signals from monitor.
+	signals := p.monitor.Signals()
+
+	// Supplement signals from events if monitor didn't capture everything.
+	signals = enrichSignalsFromEvents(signals, events)
+
+	// Read task type from session state if set.
+	if session.State != nil {
+		if tt, ok := session.State["metacognitive.task_type"].(string); ok {
+			signals.TaskType = tt
+		}
+	}
+
+	// Load the model.
+	model, err := p.store.Load(ctx, agentID)
+	if err != nil {
+		return events, nil
+	}
+
+	// Extract new heuristics.
+	newHeuristics, err := p.extractor.Extract(ctx, signals, model)
+	if err != nil {
+		return events, nil
+	}
+
+	// Add new heuristics to the model.
+	for _, h := range newHeuristics {
+		model.Heuristics = append(model.Heuristics, h)
+		if p.hooks.OnHeuristicExtracted != nil {
+			p.hooks.OnHeuristicExtracted(h)
+		}
+	}
+
+	// Update capability scores.
+	p.updateCapabilityScore(model, signals)
+
+	// Persist.
+	model.UpdatedAt = time.Now()
+	if err := p.store.Save(ctx, model); err != nil {
+		// Non-fatal: heuristics are lost but execution continues.
+		return events, nil
+	}
+
+	return events, nil
+}
+
+// OnError passes through the error unchanged. The monitor's OnError hook
+// captures error signals independently.
+func (p *Plugin) OnError(_ context.Context, err error) error {
+	return err
+}
+
+// updateCapabilityScore applies an EMA update to the capability score
+// for the task type in the signals.
+func (p *Plugin) updateCapabilityScore(model *SelfModel, signals MonitoringSignals) {
+	taskType := signals.TaskType
+	if taskType == "" {
+		taskType = "general"
+	}
+
+	score, ok := model.Capabilities[taskType]
+	if !ok {
+		score = &CapabilityScore{TaskType: taskType}
+		model.Capabilities[taskType] = score
+	}
+
+	// EMA update: score_new = score_old + alpha * (outcome - score_old)
+	outcome := 0.0
+	if signals.Success {
+		outcome = 1.0
+	}
+
+	if score.SampleCount == 0 {
+		score.SuccessRate = outcome
+	} else {
+		score.SuccessRate = score.SuccessRate + p.emaAlpha*(outcome-score.SuccessRate)
+	}
+
+	// Latency EMA.
+	if score.SampleCount == 0 {
+		score.AvgLatency = signals.TotalLatency
+	} else {
+		oldNanos := float64(score.AvgLatency.Nanoseconds())
+		newNanos := float64(signals.TotalLatency.Nanoseconds())
+		score.AvgLatency = time.Duration(oldNanos + p.emaAlpha*(newNanos-oldNanos))
+	}
+
+	score.SampleCount++
+	score.LastUpdated = time.Now()
+
+	if p.hooks.OnCapabilityUpdated != nil {
+		p.hooks.OnCapabilityUpdated(taskType, *score)
+	}
+}
+
+// extractTextFromMessage extracts text content from a schema.Message.
+func extractTextFromMessage(msg schema.Message) string {
+	if msg == nil {
+		return ""
+	}
+	parts := msg.GetContent()
+	var texts []string
+	for _, part := range parts {
+		if tp, ok := part.(schema.TextPart); ok {
+			texts = append(texts, tp.Text)
+		}
+	}
+	return strings.Join(texts, " ")
+}
+
+// buildHeuristicContext formats heuristics as a system context string.
+func buildHeuristicContext(heuristics []Heuristic) string {
+	var sb strings.Builder
+	sb.WriteString("[Metacognitive Heuristics]\n")
+	sb.WriteString("The following learned heuristics may help with this task:\n")
+	for i, h := range heuristics {
+		sb.WriteString(fmt.Sprintf("%d. [%s] %s\n", i+1, h.Source, h.Content))
+	}
+	return sb.String()
+}
+
+// enrichSignalsFromEvents supplements monitoring signals with data from
+// agent events if the monitor hooks did not capture everything.
+func enrichSignalsFromEvents(signals MonitoringSignals, events []agent.Event) MonitoringSignals {
+	// If monitor captured outcome, keep it.
+	if signals.Outcome != "" {
+		return signals
+	}
+
+	var texts []string
+	hasError := false
+	for _, evt := range events {
+		switch evt.Type {
+		case agent.EventText:
+			texts = append(texts, evt.Text)
+		case agent.EventError:
+			hasError = true
+			signals.Errors = append(signals.Errors, evt.Text)
+		case agent.EventToolCall:
+			if evt.ToolCall != nil {
+				signals.ToolCalls = append(signals.ToolCalls, evt.ToolCall.Name)
+			}
+		}
+	}
+	if len(texts) > 0 {
+		signals.Outcome = strings.Join(texts, "")
+	}
+	if hasError {
+		signals.Success = false
+	}
+	return signals
+}

--- a/agent/metacognitive/plugin.go
+++ b/agent/metacognitive/plugin.go
@@ -18,6 +18,11 @@ const DefaultMaxHeuristics = 5
 // capability score updates. Higher values weight recent observations more.
 const DefaultEMAAlpha = 0.3
 
+// DefaultMaxStoredHeuristics is the default upper bound on the total
+// heuristics persisted per self-model. When exceeded, the lowest-utility
+// heuristics are pruned. Set via WithMaxStoredHeuristics.
+const DefaultMaxStoredHeuristics = 200
+
 // Compile-time check.
 var _ runtime.Plugin = (*Plugin)(nil)
 
@@ -25,11 +30,12 @@ var _ runtime.Plugin = (*Plugin)(nil)
 // learning. It loads relevant heuristics before each turn, injects them as
 // system context, and extracts new heuristics after each turn.
 type Plugin struct {
-	store         SelfModelStore
-	extractor     HeuristicExtractor
-	maxHeuristics int
-	emaAlpha      float64
-	hooks         Hooks
+	store               SelfModelStore
+	extractor           HeuristicExtractor
+	maxHeuristics       int
+	maxStoredHeuristics int
+	emaAlpha            float64
+	hooks               Hooks
 
 	// monitor collects signals from agent hooks during execution.
 	monitor *Monitor
@@ -74,14 +80,26 @@ func WithHooks(h Hooks) PluginOption {
 	}
 }
 
+// WithMaxStoredHeuristics caps the number of heuristics persisted per
+// self-model. When AfterTurn causes the total to exceed this value, the
+// lowest-utility heuristics are pruned. Defaults to DefaultMaxStoredHeuristics.
+func WithMaxStoredHeuristics(n int) PluginOption {
+	return func(p *Plugin) {
+		if n > 0 {
+			p.maxStoredHeuristics = n
+		}
+	}
+}
+
 // NewPlugin creates a MetacognitivePlugin with the given store and options.
 func NewPlugin(store SelfModelStore, opts ...PluginOption) *Plugin {
 	p := &Plugin{
-		store:         store,
-		extractor:     NewSimpleExtractor(),
-		maxHeuristics: DefaultMaxHeuristics,
-		emaAlpha:      DefaultEMAAlpha,
-		monitor:       NewMonitor(),
+		store:               store,
+		extractor:           NewSimpleExtractor(),
+		maxHeuristics:       DefaultMaxHeuristics,
+		maxStoredHeuristics: DefaultMaxStoredHeuristics,
+		emaAlpha:            DefaultEMAAlpha,
+		monitor:             NewMonitor(),
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -134,7 +152,7 @@ func (p *Plugin) BeforeTurn(ctx context.Context, session *runtime.Session, input
 	}
 
 	// Build metacognitive context message.
-	context := buildHeuristicContext(heuristics)
+	heuristicCtx := buildHeuristicContext(heuristics)
 
 	// Store the context in session state so AfterTurn can read it.
 	if session.State == nil {
@@ -142,17 +160,14 @@ func (p *Plugin) BeforeTurn(ctx context.Context, session *runtime.Session, input
 	}
 	session.State["metacognitive.input"] = query
 	session.State["metacognitive.model_loaded"] = true
+	session.State["metacognitive.context"] = heuristicCtx
 
-	// Prepend system message with heuristics. We return the original input
-	// unchanged and store context in session state. The actual injection
-	// would happen at the agent level if the plugin had message-list access.
-	// Since Plugin.BeforeTurn receives a single message, we augment the
-	// session state for the agent to read. For systems that support it, we
-	// wrap the message with a system prefix.
-	_ = context // Store in session for agent retrieval.
-	session.State["metacognitive.context"] = context
-
-	return input, nil
+	// Prepend the heuristic context to the user message so the LLM actually
+	// sees the learned heuristics. Preserves the original user text verbatim
+	// after a newline separator.
+	originalText := extractTextFromMessage(input)
+	augmented := schema.NewHumanMessage(heuristicCtx + "\n" + originalText)
+	return augmented, nil
 }
 
 // AfterTurn collects monitoring signals, extracts new heuristics, updates
@@ -198,6 +213,12 @@ func (p *Plugin) AfterTurn(ctx context.Context, session *runtime.Session, events
 		if p.hooks.OnHeuristicExtracted != nil {
 			p.hooks.OnHeuristicExtracted(h)
 		}
+	}
+
+	// Prune stored heuristics to stay within the configured cap. Keeping the
+	// highest-utility entries bounds SearchHeuristics scan cost and memory.
+	if p.maxStoredHeuristics > 0 && len(model.Heuristics) > p.maxStoredHeuristics {
+		pruneHeuristicsByUtility(model, p.maxStoredHeuristics)
 	}
 
 	// Update capability scores.
@@ -275,6 +296,27 @@ func extractTextFromMessage(msg schema.Message) string {
 		}
 	}
 	return strings.Join(texts, " ")
+}
+
+// pruneHeuristicsByUtility trims the model's heuristics slice to the top
+// maxStored entries by Utility (descending).
+func pruneHeuristicsByUtility(model *SelfModel, maxStored int) {
+	// Use a simple in-place selection to avoid importing sort here; caller
+	// invokes this only on the pruning boundary.
+	hs := model.Heuristics
+	// Partial sort: bubble the top maxStored by utility to the front.
+	for i := 0; i < maxStored && i < len(hs); i++ {
+		best := i
+		for j := i + 1; j < len(hs); j++ {
+			if hs[j].Utility > hs[best].Utility {
+				best = j
+			}
+		}
+		if best != i {
+			hs[i], hs[best] = hs[best], hs[i]
+		}
+	}
+	model.Heuristics = hs[:maxStored]
 }
 
 // buildHeuristicContext formats heuristics as a system context string.

--- a/agent/metacognitive/plugin_test.go
+++ b/agent/metacognitive/plugin_test.go
@@ -1,0 +1,431 @@
+package metacognitive
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/runtime"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+func TestPlugin_CompileTimeCheck(t *testing.T) {
+	var _ runtime.Plugin = (*Plugin)(nil)
+}
+
+func TestPlugin_Name(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+	assert.Equal(t, "metacognitive", p.Name())
+}
+
+func TestPlugin_Defaults(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+	assert.Equal(t, DefaultMaxHeuristics, p.maxHeuristics)
+	assert.InDelta(t, DefaultEMAAlpha, p.emaAlpha, 0.001)
+	assert.NotNil(t, p.extractor)
+	assert.NotNil(t, p.monitor)
+}
+
+func TestPlugin_Options(t *testing.T) {
+	store := NewInMemoryStore()
+	ext := NewSimpleExtractor()
+
+	var hooksCalled bool
+	p := NewPlugin(store,
+		WithExtractor(ext),
+		WithMaxHeuristics(10),
+		WithEMAAlpha(0.5),
+		WithHooks(Hooks{
+			OnSelfModelLoaded: func(m *SelfModel) { hooksCalled = true },
+		}),
+	)
+
+	assert.Equal(t, 10, p.maxHeuristics)
+	assert.InDelta(t, 0.5, p.emaAlpha, 0.001)
+
+	// Trigger the hook via a BeforeTurn with saved model.
+	ctx := context.Background()
+	sess := runtime.NewSession("s1", "agent-1")
+	m := NewSelfModel("agent-1")
+	m.Heuristics = []Heuristic{{ID: "h1", Content: "test search", Utility: 0.5, TaskType: "search"}}
+	require.NoError(t, store.Save(ctx, m))
+
+	_, err := p.BeforeTurn(ctx, sess, schema.NewHumanMessage("search query"))
+	require.NoError(t, err)
+	assert.True(t, hooksCalled)
+}
+
+func TestPlugin_WithExtractorNil(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store, WithExtractor(nil))
+	// Should keep the default extractor.
+	assert.NotNil(t, p.extractor)
+}
+
+func TestPlugin_WithMaxHeuristicsInvalid(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store, WithMaxHeuristics(-1))
+	assert.Equal(t, DefaultMaxHeuristics, p.maxHeuristics)
+
+	p = NewPlugin(store, WithMaxHeuristics(0))
+	assert.Equal(t, DefaultMaxHeuristics, p.maxHeuristics)
+}
+
+func TestPlugin_WithEMAAlphaInvalid(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store, WithEMAAlpha(0))
+	assert.InDelta(t, DefaultEMAAlpha, p.emaAlpha, 0.001)
+
+	p = NewPlugin(store, WithEMAAlpha(1.5))
+	assert.InDelta(t, DefaultEMAAlpha, p.emaAlpha, 0.001)
+}
+
+func TestPlugin_BeforeTurn_NilSession(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+
+	msg, err := p.BeforeTurn(context.Background(), nil, schema.NewHumanMessage("hi"))
+	require.NoError(t, err)
+	assert.Equal(t, "human", string(msg.GetRole()))
+}
+
+func TestPlugin_BeforeTurn_EmptyAgentID(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+	sess := runtime.NewSession("s1", "")
+
+	msg, err := p.BeforeTurn(context.Background(), sess, schema.NewHumanMessage("hi"))
+	require.NoError(t, err)
+	assert.Equal(t, "human", string(msg.GetRole()))
+}
+
+func TestPlugin_BeforeTurn_StoresContextInSession(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	// Seed the store with heuristics.
+	m := NewSelfModel("agent-1")
+	m.Heuristics = []Heuristic{
+		{ID: "h1", Content: "Avoid: timeout in search", Source: "failure", TaskType: "search", Utility: 0.9},
+	}
+	require.NoError(t, store.Save(ctx, m))
+
+	p := NewPlugin(store)
+	sess := runtime.NewSession("s1", "agent-1")
+
+	_, err := p.BeforeTurn(ctx, sess, schema.NewHumanMessage("search for documents"))
+	require.NoError(t, err)
+
+	// Check that metacognitive context was stored in session state.
+	ctxStr, ok := sess.State["metacognitive.context"].(string)
+	assert.True(t, ok, "metacognitive context should be stored in session")
+	assert.Contains(t, ctxStr, "timeout")
+}
+
+func TestPlugin_BeforeTurn_NoHeuristics(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+	sess := runtime.NewSession("s1", "agent-1")
+
+	msg, err := p.BeforeTurn(context.Background(), sess, schema.NewHumanMessage("hi"))
+	require.NoError(t, err)
+	assert.Equal(t, "human", string(msg.GetRole()))
+
+	// No context stored since no heuristics found.
+	_, ok := sess.State["metacognitive.context"]
+	assert.False(t, ok)
+}
+
+func TestPlugin_AfterTurn_ExtractsAndSaves(t *testing.T) {
+	store := NewInMemoryStore()
+
+	var extractedHeuristics []Heuristic
+	var mu sync.Mutex
+	p := NewPlugin(store, WithHooks(Hooks{
+		OnHeuristicExtracted: func(h Heuristic) {
+			mu.Lock()
+			defer mu.Unlock()
+			extractedHeuristics = append(extractedHeuristics, h)
+		},
+	}))
+
+	ctx := context.Background()
+	sess := runtime.NewSession("s1", "agent-1")
+
+	// Simulate a failed turn with events.
+	events := []agent.Event{
+		{Type: agent.EventError, Text: "API timeout occurred"},
+	}
+
+	evts, err := p.AfterTurn(ctx, sess, events)
+	require.NoError(t, err)
+	assert.Len(t, evts, 1, "events must be passed through unchanged")
+
+	// Verify the model was saved.
+	model, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, model.Heuristics, "heuristics should be extracted and saved")
+
+	mu.Lock()
+	assert.NotEmpty(t, extractedHeuristics, "OnHeuristicExtracted hook should fire")
+	mu.Unlock()
+}
+
+func TestPlugin_AfterTurn_UpdatesCapabilityScore(t *testing.T) {
+	store := NewInMemoryStore()
+
+	var updatedScores []CapabilityScore
+	p := NewPlugin(store, WithHooks(Hooks{
+		OnCapabilityUpdated: func(taskType string, score CapabilityScore) {
+			updatedScores = append(updatedScores, score)
+		},
+	}))
+
+	ctx := context.Background()
+	sess := runtime.NewSession("s1", "agent-1")
+	sess.State["metacognitive.task_type"] = "search"
+
+	// First successful turn.
+	_, err := p.AfterTurn(ctx, sess, []agent.Event{
+		{Type: agent.EventText, Text: "success result"},
+	})
+	require.NoError(t, err)
+
+	model, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	score, ok := model.Capabilities["search"]
+	require.True(t, ok)
+	assert.Equal(t, 1, score.SampleCount)
+
+	assert.NotEmpty(t, updatedScores)
+}
+
+func TestPlugin_AfterTurn_NilSession(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+
+	events := []agent.Event{{Type: agent.EventText, Text: "hi"}}
+	evts, err := p.AfterTurn(context.Background(), nil, events)
+	require.NoError(t, err)
+	assert.Len(t, evts, 1)
+}
+
+func TestPlugin_OnError_Passthrough(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"nil error", nil},
+		{"non-nil error", assert.AnError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.OnError(context.Background(), tt.err)
+			assert.Equal(t, tt.err, got)
+		})
+	}
+}
+
+func TestPlugin_CapabilityScore_EMA(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store, WithEMAAlpha(0.5))
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+
+	// First observation: success.
+	p.updateCapabilityScore(model, MonitoringSignals{
+		TaskType:     "search",
+		Success:      true,
+		TotalLatency: 100 * time.Millisecond,
+	})
+	assert.InDelta(t, 1.0, model.Capabilities["search"].SuccessRate, 0.001)
+	assert.Equal(t, 1, model.Capabilities["search"].SampleCount)
+
+	// Second observation: failure.
+	p.updateCapabilityScore(model, MonitoringSignals{
+		TaskType:     "search",
+		Success:      false,
+		TotalLatency: 200 * time.Millisecond,
+	})
+	// EMA: 1.0 + 0.5 * (0.0 - 1.0) = 0.5
+	assert.InDelta(t, 0.5, model.Capabilities["search"].SuccessRate, 0.001)
+	assert.Equal(t, 2, model.Capabilities["search"].SampleCount)
+
+	// Third observation: success.
+	p.updateCapabilityScore(model, MonitoringSignals{
+		TaskType:     "search",
+		Success:      true,
+		TotalLatency: 50 * time.Millisecond,
+	})
+	// EMA: 0.5 + 0.5 * (1.0 - 0.5) = 0.75
+	assert.InDelta(t, 0.75, model.Capabilities["search"].SuccessRate, 0.001)
+	assert.Equal(t, 3, model.Capabilities["search"].SampleCount)
+
+	_ = ctx // used in setup
+}
+
+func TestPlugin_CapabilityScore_DefaultTaskType(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+
+	model := NewSelfModel("agent-1")
+	p.updateCapabilityScore(model, MonitoringSignals{
+		Success:      true,
+		TotalLatency: 100 * time.Millisecond,
+	})
+
+	_, ok := model.Capabilities["general"]
+	assert.True(t, ok, "empty task type should default to 'general'")
+}
+
+func TestPlugin_Monitor(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store)
+	m := p.Monitor()
+	require.NotNil(t, m)
+	assert.IsType(t, &Monitor{}, m)
+}
+
+func TestPlugin_EnrichSignalsFromEvents(t *testing.T) {
+	tests := []struct {
+		name        string
+		signals     MonitoringSignals
+		events      []agent.Event
+		wantOutcome string
+		wantSuccess bool
+	}{
+		{
+			name:    "enriches from text events",
+			signals: MonitoringSignals{Success: true},
+			events: []agent.Event{
+				{Type: agent.EventText, Text: "hello "},
+				{Type: agent.EventText, Text: "world"},
+			},
+			wantOutcome: "hello world",
+			wantSuccess: true,
+		},
+		{
+			name:    "marks failure on error event",
+			signals: MonitoringSignals{Success: true},
+			events: []agent.Event{
+				{Type: agent.EventError, Text: "failed"},
+			},
+			wantOutcome: "",
+			wantSuccess: false,
+		},
+		{
+			name:        "preserves existing outcome",
+			signals:     MonitoringSignals{Outcome: "existing", Success: true},
+			events:      []agent.Event{{Type: agent.EventText, Text: "new"}},
+			wantOutcome: "existing",
+			wantSuccess: true,
+		},
+		{
+			name:    "collects tool calls from events",
+			signals: MonitoringSignals{Success: true},
+			events: []agent.Event{
+				{Type: agent.EventToolCall, ToolCall: &schema.ToolCall{Name: "search"}},
+			},
+			wantOutcome: "",
+			wantSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := enrichSignalsFromEvents(tt.signals, tt.events)
+			assert.Equal(t, tt.wantOutcome, result.Outcome)
+			assert.Equal(t, tt.wantSuccess, result.Success)
+		})
+	}
+}
+
+func TestPlugin_BuildHeuristicContext(t *testing.T) {
+	heuristics := []Heuristic{
+		{Source: "failure", Content: "Avoid: timeout errors"},
+		{Source: "success", Content: "Prefer: caching"},
+	}
+
+	ctx := buildHeuristicContext(heuristics)
+	assert.Contains(t, ctx, "[Metacognitive Heuristics]")
+	assert.Contains(t, ctx, "1. [failure] Avoid: timeout errors")
+	assert.Contains(t, ctx, "2. [success] Prefer: caching")
+}
+
+func TestPlugin_ExtractTextFromMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  schema.Message
+		want string
+	}{
+		{
+			name: "human message",
+			msg:  schema.NewHumanMessage("hello world"),
+			want: "hello world",
+		},
+		{
+			name: "nil message",
+			msg:  nil,
+			want: "",
+		},
+		{
+			name: "system message",
+			msg:  schema.NewSystemMessage("system prompt"),
+			want: "system prompt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractTextFromMessage(tt.msg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPlugin_FullRoundTrip(t *testing.T) {
+	store := NewInMemoryStore()
+	p := NewPlugin(store, WithMaxHeuristics(3))
+	ctx := context.Background()
+	sess := runtime.NewSession("s1", "agent-1")
+
+	// Turn 1: failure, should extract heuristics.
+	_, err := p.BeforeTurn(ctx, sess, schema.NewHumanMessage("search for data"))
+	require.NoError(t, err)
+
+	p.Monitor().Reset()
+	hooks := p.Monitor().Hooks()
+	_ = hooks.OnStart(ctx, "search for data")
+	_ = hooks.OnError(ctx, assert.AnError)
+	hooks.OnEnd(ctx, "", assert.AnError)
+
+	_, err = p.AfterTurn(ctx, sess, []agent.Event{
+		{Type: agent.EventError, Text: "search failed"},
+	})
+	require.NoError(t, err)
+
+	// Verify heuristics were saved.
+	model, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, model.Heuristics)
+
+	// Turn 2: should retrieve heuristics from turn 1.
+	_, err = p.BeforeTurn(ctx, sess, schema.NewHumanMessage("search again"))
+	require.NoError(t, err)
+
+	ctxStr, ok := sess.State["metacognitive.context"].(string)
+	assert.True(t, ok, "should have metacognitive context from previous heuristics")
+	assert.Contains(t, ctxStr, "Heuristics")
+}

--- a/agent/metacognitive/store.go
+++ b/agent/metacognitive/store.go
@@ -95,10 +95,11 @@ func (s *InMemoryStore) SearchHeuristics(ctx context.Context, agentID, query str
 		return nil, nil
 	}
 
-	s.mu.RLock()
-	m, ok := s.models[agentID]
-	s.mu.RUnlock()
+	// Use a full Lock so we can safely bump UsageCount on matched heuristics.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
+	m, ok := s.models[agentID]
 	if !ok || len(m.Heuristics) == 0 {
 		return nil, nil
 	}
@@ -107,16 +108,19 @@ func (s *InMemoryStore) SearchHeuristics(ctx context.Context, agentID, query str
 	terms := strings.Fields(queryLower)
 	if len(terms) == 0 {
 		// No query terms; return most useful heuristics.
-		return s.topByUtility(m.Heuristics, k), nil
+		top := s.topByUtility(m.Heuristics, k)
+		bumpUsageCountLocked(m, top)
+		return top, nil
 	}
 
 	type scored struct {
+		idx   int
 		h     Heuristic
 		score float64
 	}
 
 	var results []scored
-	for _, h := range m.Heuristics {
+	for i, h := range m.Heuristics {
 		contentLower := strings.ToLower(h.Content)
 		taskLower := strings.ToLower(h.TaskType)
 		matches := 0
@@ -130,7 +134,7 @@ func (s *InMemoryStore) SearchHeuristics(ctx context.Context, agentID, query str
 			if utility <= 0 {
 				utility = 0.1
 			}
-			results = append(results, scored{h: h, score: float64(matches) * utility})
+			results = append(results, scored{idx: i, h: h, score: float64(matches) * utility})
 		}
 	}
 
@@ -140,9 +144,28 @@ func (s *InMemoryStore) SearchHeuristics(ctx context.Context, agentID, query str
 
 	out := make([]Heuristic, 0, k)
 	for i := 0; i < len(results) && i < k; i++ {
-		out = append(out, results[i].h)
+		// Increment usage count on the stored heuristic so retrieval
+		// statistics remain accurate across Search calls.
+		m.Heuristics[results[i].idx].UsageCount++
+		// Return a copy that reflects the updated UsageCount.
+		h := m.Heuristics[results[i].idx]
+		out = append(out, h)
 	}
 	return out, nil
+}
+
+// bumpUsageCountLocked increments UsageCount for every heuristic present in
+// selected. Caller must hold s.mu in write mode.
+func bumpUsageCountLocked(m *SelfModel, selected []Heuristic) {
+	byID := make(map[string]struct{}, len(selected))
+	for _, h := range selected {
+		byID[h.ID] = struct{}{}
+	}
+	for i := range m.Heuristics {
+		if _, ok := byID[m.Heuristics[i].ID]; ok {
+			m.Heuristics[i].UsageCount++
+		}
+	}
 }
 
 // topByUtility returns the top k heuristics sorted by utility descending.

--- a/agent/metacognitive/store.go
+++ b/agent/metacognitive/store.go
@@ -1,0 +1,177 @@
+package metacognitive
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// SelfModelStore persists and retrieves self-models across sessions.
+type SelfModelStore interface {
+	// Load retrieves the self-model for the given agent ID.
+	// Returns a new empty model if none exists.
+	Load(ctx context.Context, agentID string) (*SelfModel, error)
+
+	// Save persists the self-model.
+	Save(ctx context.Context, model *SelfModel) error
+
+	// SearchHeuristics finds the k most relevant heuristics for a query.
+	// Implementations may use embedding similarity or keyword matching.
+	SearchHeuristics(ctx context.Context, agentID, query string, k int) ([]Heuristic, error)
+}
+
+// Compile-time check.
+var _ SelfModelStore = (*InMemoryStore)(nil)
+
+// InMemoryStore is a thread-safe in-memory implementation of SelfModelStore.
+// Suitable for testing and single-process deployments.
+type InMemoryStore struct {
+	mu     sync.RWMutex
+	models map[string]*SelfModel
+}
+
+// NewInMemoryStore creates a new InMemoryStore.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		models: make(map[string]*SelfModel),
+	}
+}
+
+// Load retrieves the self-model for the given agent ID. If no model exists,
+// a new empty model is created and returned (but not persisted until Save).
+func (s *InMemoryStore) Load(ctx context.Context, agentID string) (*SelfModel, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if agentID == "" {
+		return nil, core.NewError("metacognitive.store.load", core.ErrInvalidInput, "agent ID must not be empty", nil)
+	}
+
+	s.mu.RLock()
+	m, ok := s.models[agentID]
+	s.mu.RUnlock()
+
+	if !ok {
+		return NewSelfModel(agentID), nil
+	}
+
+	// Return a copy to prevent data races on the caller side.
+	return s.copyModel(m), nil
+}
+
+// Save persists the self-model. Overwrites any existing model for the agent.
+func (s *InMemoryStore) Save(ctx context.Context, model *SelfModel) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if model == nil {
+		return core.NewError("metacognitive.store.save", core.ErrInvalidInput, "model must not be nil", nil)
+	}
+	if model.AgentID == "" {
+		return core.NewError("metacognitive.store.save", core.ErrInvalidInput, "agent ID must not be empty", nil)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.models[model.AgentID] = s.copyModel(model)
+	return nil
+}
+
+// SearchHeuristics performs keyword-based search over an agent's heuristics.
+// It scores each heuristic by counting query term matches in the content and
+// task type, then returns the top k results sorted by relevance (match count
+// * utility).
+func (s *InMemoryStore) SearchHeuristics(ctx context.Context, agentID, query string, k int) ([]Heuristic, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if agentID == "" {
+		return nil, core.NewError("metacognitive.store.search", core.ErrInvalidInput, "agent ID must not be empty", nil)
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+
+	s.mu.RLock()
+	m, ok := s.models[agentID]
+	s.mu.RUnlock()
+
+	if !ok || len(m.Heuristics) == 0 {
+		return nil, nil
+	}
+
+	queryLower := strings.ToLower(query)
+	terms := strings.Fields(queryLower)
+	if len(terms) == 0 {
+		// No query terms; return most useful heuristics.
+		return s.topByUtility(m.Heuristics, k), nil
+	}
+
+	type scored struct {
+		h     Heuristic
+		score float64
+	}
+
+	var results []scored
+	for _, h := range m.Heuristics {
+		contentLower := strings.ToLower(h.Content)
+		taskLower := strings.ToLower(h.TaskType)
+		matches := 0
+		for _, term := range terms {
+			if strings.Contains(contentLower, term) || strings.Contains(taskLower, term) {
+				matches++
+			}
+		}
+		if matches > 0 {
+			utility := h.Utility
+			if utility <= 0 {
+				utility = 0.1
+			}
+			results = append(results, scored{h: h, score: float64(matches) * utility})
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].score > results[j].score
+	})
+
+	out := make([]Heuristic, 0, k)
+	for i := 0; i < len(results) && i < k; i++ {
+		out = append(out, results[i].h)
+	}
+	return out, nil
+}
+
+// topByUtility returns the top k heuristics sorted by utility descending.
+func (s *InMemoryStore) topByUtility(hs []Heuristic, k int) []Heuristic {
+	sorted := make([]Heuristic, len(hs))
+	copy(sorted, hs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Utility > sorted[j].Utility
+	})
+	if len(sorted) > k {
+		sorted = sorted[:k]
+	}
+	return sorted
+}
+
+// copyModel creates a deep copy of a SelfModel.
+func (s *InMemoryStore) copyModel(m *SelfModel) *SelfModel {
+	cp := &SelfModel{
+		AgentID:      m.AgentID,
+		UpdatedAt:    m.UpdatedAt,
+		Capabilities: make(map[string]*CapabilityScore, len(m.Capabilities)),
+	}
+	if len(m.Heuristics) > 0 {
+		cp.Heuristics = make([]Heuristic, len(m.Heuristics))
+		copy(cp.Heuristics, m.Heuristics)
+	}
+	for k, v := range m.Capabilities {
+		vc := *v
+		cp.Capabilities[k] = &vc
+	}
+	return cp
+}

--- a/agent/metacognitive/store_test.go
+++ b/agent/metacognitive/store_test.go
@@ -1,0 +1,316 @@
+package metacognitive
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryStore_CompileTimeCheck(t *testing.T) {
+	var _ SelfModelStore = (*InMemoryStore)(nil)
+}
+
+func TestInMemoryStore_LoadNewAgent(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model, err := store.Load(ctx, "agent-new")
+	require.NoError(t, err)
+	require.NotNil(t, model)
+	assert.Equal(t, "agent-new", model.AgentID)
+	assert.Empty(t, model.Heuristics)
+	assert.NotNil(t, model.Capabilities)
+}
+
+func TestInMemoryStore_SaveAndLoad(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+	model.Heuristics = []Heuristic{
+		{ID: "h1", Content: "test heuristic", Source: "failure", TaskType: "search", Utility: 0.7},
+	}
+	model.Capabilities["search"] = &CapabilityScore{
+		TaskType:    "search",
+		SuccessRate: 0.8,
+		SampleCount: 5,
+	}
+
+	err := store.Save(ctx, model)
+	require.NoError(t, err)
+
+	loaded, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "agent-1", loaded.AgentID)
+	assert.Len(t, loaded.Heuristics, 1)
+	assert.Equal(t, "test heuristic", loaded.Heuristics[0].Content)
+	assert.InDelta(t, 0.8, loaded.Capabilities["search"].SuccessRate, 0.001)
+}
+
+func TestInMemoryStore_SaveOverwrite(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model1 := NewSelfModel("agent-1")
+	model1.Heuristics = []Heuristic{{ID: "h1", Content: "first"}}
+	require.NoError(t, store.Save(ctx, model1))
+
+	model2 := NewSelfModel("agent-1")
+	model2.Heuristics = []Heuristic{{ID: "h2", Content: "second"}}
+	require.NoError(t, store.Save(ctx, model2))
+
+	loaded, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Len(t, loaded.Heuristics, 1)
+	assert.Equal(t, "second", loaded.Heuristics[0].Content)
+}
+
+func TestInMemoryStore_LoadReturnsCopy(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+	model.Heuristics = []Heuristic{{ID: "h1", Content: "original"}}
+	require.NoError(t, store.Save(ctx, model))
+
+	loaded, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	loaded.Heuristics[0].Content = "mutated"
+
+	loaded2, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, "original", loaded2.Heuristics[0].Content, "mutation must not affect stored model")
+}
+
+func TestInMemoryStore_EmptyAgentID(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	_, err := store.Load(ctx, "")
+	assert.Error(t, err)
+
+	err = store.Save(ctx, &SelfModel{})
+	assert.Error(t, err)
+
+	_, err = store.SearchHeuristics(ctx, "", "query", 5)
+	assert.Error(t, err)
+}
+
+func TestInMemoryStore_SaveNilModel(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	err := store.Save(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestInMemoryStore_ContextCancellation(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := store.Load(ctx, "agent-1")
+	assert.Error(t, err)
+
+	err = store.Save(ctx, NewSelfModel("agent-1"))
+	assert.Error(t, err)
+
+	_, err = store.SearchHeuristics(ctx, "agent-1", "query", 5)
+	assert.Error(t, err)
+}
+
+func TestInMemoryStore_SearchHeuristics(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+	model.Heuristics = []Heuristic{
+		{ID: "h1", Content: "Avoid: timeout errors in search tasks", Source: "failure", TaskType: "search", Utility: 0.9},
+		{ID: "h2", Content: "Prefer: use caching for repeated queries", Source: "success", TaskType: "search", Utility: 0.8},
+		{ID: "h3", Content: "Avoid: parsing errors in code generation", Source: "failure", TaskType: "coding", Utility: 0.7},
+		{ID: "h4", Content: "Prefer: validate input before processing", Source: "success", TaskType: "general", Utility: 0.6},
+	}
+	require.NoError(t, store.Save(ctx, model))
+
+	tests := []struct {
+		name    string
+		query   string
+		k       int
+		wantLen int
+		wantIDs []string // expected IDs in order
+	}{
+		{
+			name:    "search by task type",
+			query:   "search",
+			k:       5,
+			wantLen: 2,
+			wantIDs: []string{"h1", "h2"},
+		},
+		{
+			name:    "search by keyword",
+			query:   "timeout",
+			k:       5,
+			wantLen: 1,
+			wantIDs: []string{"h1"},
+		},
+		{
+			name:    "limit results",
+			query:   "search errors",
+			k:       1,
+			wantLen: 1,
+		},
+		{
+			name:    "no matches",
+			query:   "nonexistent xyz",
+			k:       5,
+			wantLen: 0,
+		},
+		{
+			name:    "k is zero",
+			query:   "search",
+			k:       0,
+			wantLen: 0,
+		},
+		{
+			name:    "empty query returns top by utility",
+			query:   "",
+			k:       2,
+			wantLen: 2,
+			wantIDs: []string{"h1", "h2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := store.SearchHeuristics(ctx, "agent-1", tt.query, tt.k)
+			require.NoError(t, err)
+			assert.Len(t, results, tt.wantLen)
+
+			if len(tt.wantIDs) > 0 && len(results) > 0 {
+				gotIDs := make([]string, len(results))
+				for i, h := range results {
+					gotIDs[i] = h.ID
+				}
+				for _, wantID := range tt.wantIDs {
+					assert.Contains(t, gotIDs, wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestInMemoryStore_SearchHeuristics_AgentNotFound(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	results, err := store.SearchHeuristics(ctx, "nonexistent", "query", 5)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestInMemoryStore_ConcurrentAccess(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+	const n = 50
+
+	var wg sync.WaitGroup
+	wg.Add(n * 3)
+
+	// Concurrent saves.
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			m := NewSelfModel("agent-1")
+			m.Heuristics = []Heuristic{{ID: "h", Content: "test", Utility: 0.5}}
+			_ = store.Save(ctx, m)
+		}()
+	}
+
+	// Concurrent loads.
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = store.Load(ctx, "agent-1")
+		}()
+	}
+
+	// Concurrent searches.
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = store.SearchHeuristics(ctx, "agent-1", "test", 3)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestInMemoryStore_SearchHeuristics_ZeroUtility(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+	model.Heuristics = []Heuristic{
+		{ID: "h1", Content: "zero utility heuristic about search", Utility: 0.0, TaskType: "search"},
+		{ID: "h2", Content: "positive utility about search", Utility: 0.5, TaskType: "search"},
+	}
+	require.NoError(t, store.Save(ctx, model))
+
+	results, err := store.SearchHeuristics(ctx, "agent-1", "search", 5)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	// Higher utility should come first.
+	assert.Equal(t, "h2", results[0].ID)
+}
+
+func TestInMemoryStore_MultipleAgents(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	m1 := NewSelfModel("agent-1")
+	m1.Heuristics = []Heuristic{{ID: "h1", Content: "agent 1 heuristic"}}
+	require.NoError(t, store.Save(ctx, m1))
+
+	m2 := NewSelfModel("agent-2")
+	m2.Heuristics = []Heuristic{{ID: "h2", Content: "agent 2 heuristic"}}
+	require.NoError(t, store.Save(ctx, m2))
+
+	loaded1, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Len(t, loaded1.Heuristics, 1)
+	assert.Equal(t, "agent 1 heuristic", loaded1.Heuristics[0].Content)
+
+	loaded2, err := store.Load(ctx, "agent-2")
+	require.NoError(t, err)
+	assert.Len(t, loaded2.Heuristics, 1)
+	assert.Equal(t, "agent 2 heuristic", loaded2.Heuristics[0].Content)
+}
+
+func TestInMemoryStore_CapabilityScoreDeepCopy(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	model := NewSelfModel("agent-1")
+	model.Capabilities["search"] = &CapabilityScore{
+		TaskType:    "search",
+		SuccessRate: 0.8,
+		SampleCount: 5,
+		AvgLatency:  time.Second,
+		LastUpdated: time.Now(),
+	}
+	require.NoError(t, store.Save(ctx, model))
+
+	loaded, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	loaded.Capabilities["search"].SuccessRate = 0.1
+
+	loaded2, err := store.Load(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.8, loaded2.Capabilities["search"].SuccessRate, 0.001,
+		"mutation of loaded capability must not affect stored model")
+}

--- a/agent/metacognitive/types.go
+++ b/agent/metacognitive/types.go
@@ -1,0 +1,115 @@
+package metacognitive
+
+import (
+	"time"
+)
+
+// SelfModel holds persistent self-knowledge for an agent, including
+// accumulated heuristics and capability scores across task types.
+type SelfModel struct {
+	// AgentID identifies the agent this model belongs to.
+	AgentID string
+
+	// Heuristics are learned rules derived from execution experience.
+	Heuristics []Heuristic
+
+	// Capabilities maps task types to their performance scores.
+	Capabilities map[string]*CapabilityScore
+
+	// UpdatedAt is the timestamp of the last model update.
+	UpdatedAt time.Time
+}
+
+// NewSelfModel creates a new SelfModel for the given agent ID.
+func NewSelfModel(agentID string) *SelfModel {
+	return &SelfModel{
+		AgentID:      agentID,
+		Heuristics:   nil,
+		Capabilities: make(map[string]*CapabilityScore),
+		UpdatedAt:    time.Now(),
+	}
+}
+
+// Heuristic is a learned rule extracted from agent execution experience.
+// Heuristics can be derived from failures ("avoid X") or successes ("prefer X").
+type Heuristic struct {
+	// ID uniquely identifies this heuristic.
+	ID string
+
+	// Content is the human-readable heuristic text.
+	Content string
+
+	// Source indicates how this heuristic was derived: "failure" or "success".
+	Source string
+
+	// TaskType categorizes the task that produced this heuristic.
+	TaskType string
+
+	// Utility is the estimated usefulness of this heuristic (0.0 to 1.0).
+	Utility float64
+
+	// UsageCount tracks how many times this heuristic has been retrieved.
+	UsageCount int
+
+	// CreatedAt is when this heuristic was first extracted.
+	CreatedAt time.Time
+}
+
+// CapabilityScore tracks an agent's performance on a specific task type
+// using exponential moving average for smooth updates.
+type CapabilityScore struct {
+	// TaskType identifies the task category.
+	TaskType string
+
+	// SuccessRate is the EMA of success outcomes (0.0 to 1.0).
+	SuccessRate float64
+
+	// SampleCount is the total number of observations.
+	SampleCount int
+
+	// AvgLatency is the EMA of execution duration.
+	AvgLatency time.Duration
+
+	// LastUpdated is when this score was last modified.
+	LastUpdated time.Time
+}
+
+// MonitoringSignals captures execution telemetry from a single agent turn.
+type MonitoringSignals struct {
+	// TaskInput is the original user input for this turn.
+	TaskInput string
+
+	// TaskType categorizes the task (may be empty if unclassified).
+	TaskType string
+
+	// Outcome is the agent's final response text.
+	Outcome string
+
+	// Success indicates whether the turn completed without errors.
+	Success bool
+
+	// ToolCalls lists the names of tools invoked during the turn.
+	ToolCalls []string
+
+	// IterationCount is the number of plan-act loop iterations.
+	IterationCount int
+
+	// TotalLatency is the wall-clock duration of the turn.
+	TotalLatency time.Duration
+
+	// Errors collects error messages encountered during the turn.
+	Errors []string
+}
+
+// Hooks provides optional callbacks for observing metacognitive events.
+// All fields are optional; nil hooks are skipped.
+type Hooks struct {
+	// OnHeuristicExtracted is called when a new heuristic is derived.
+	OnHeuristicExtracted func(h Heuristic)
+
+	// OnCapabilityUpdated is called when a capability score changes.
+	OnCapabilityUpdated func(taskType string, score CapabilityScore)
+
+	// OnSelfModelLoaded is called when a self-model is loaded from the store.
+	OnSelfModelLoaded func(model *SelfModel)
+}

--- a/agent/metacognitive/types_test.go
+++ b/agent/metacognitive/types_test.go
@@ -1,0 +1,64 @@
+package metacognitive
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSelfModel(t *testing.T) {
+	m := NewSelfModel("agent-1")
+	require.NotNil(t, m)
+	assert.Equal(t, "agent-1", m.AgentID)
+	assert.Empty(t, m.Heuristics)
+	assert.NotNil(t, m.Capabilities)
+	assert.False(t, m.UpdatedAt.IsZero())
+}
+
+func TestHeuristic_Fields(t *testing.T) {
+	h := Heuristic{
+		ID:         "h_123",
+		Content:    "Avoid: excessive retries",
+		Source:     "failure",
+		TaskType:   "search",
+		Utility:    0.8,
+		UsageCount: 3,
+		CreatedAt:  time.Now(),
+	}
+	assert.Equal(t, "h_123", h.ID)
+	assert.Equal(t, "failure", h.Source)
+	assert.Equal(t, 0.8, h.Utility)
+	assert.Equal(t, 3, h.UsageCount)
+}
+
+func TestCapabilityScore_Fields(t *testing.T) {
+	cs := CapabilityScore{
+		TaskType:    "coding",
+		SuccessRate: 0.85,
+		SampleCount: 20,
+		AvgLatency:  2 * time.Second,
+		LastUpdated: time.Now(),
+	}
+	assert.Equal(t, "coding", cs.TaskType)
+	assert.InDelta(t, 0.85, cs.SuccessRate, 0.001)
+	assert.Equal(t, 20, cs.SampleCount)
+	assert.Equal(t, 2*time.Second, cs.AvgLatency)
+}
+
+func TestMonitoringSignals_Zero(t *testing.T) {
+	var s MonitoringSignals
+	assert.Empty(t, s.TaskInput)
+	assert.False(t, s.Success)
+	assert.Nil(t, s.ToolCalls)
+	assert.Nil(t, s.Errors)
+}
+
+func TestHooks_NilFields(t *testing.T) {
+	// All fields should be nil by default.
+	var h Hooks
+	assert.Nil(t, h.OnHeuristicExtracted)
+	assert.Nil(t, h.OnCapabilityUpdated)
+	assert.Nil(t, h.OnSelfModelLoaded)
+}


### PR DESCRIPTION
## Summary
- agent/metacognitive package, persistent SelfModel with heuristics, MetacognitivePlugin (BeforeTurn inject, AfterTurn extract+EMA)

## Linear
- LOO-12: https://linear.app/lookatitude/issue/LOO-12

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)