### PR TITLE
LOO-15: Shared Blackboard / Shared Context Layer

### DIFF
--- a/state/blackboard/blackboard.go
+++ b/state/blackboard/blackboard.go
@@ -74,18 +74,26 @@ type Blackboard struct {
 	closed    bool
 }
 
-// New creates a Blackboard backed by the given VersionedStore.
+// New creates a Blackboard backed by the given VersionedStore. When hooks
+// are provided via WithBlackboardHooks they are wrapped around the
+// underlying VersionedStore so that Get/Set/Delete/Watch fire the callbacks.
 func New(store state.VersionedStore, opts ...Option) *Blackboard {
 	o := options{}
 	for _, opt := range opts {
 		opt(&o)
 	}
 
-	// Build the reducer store on top of the versioned store.
-	reducer := state.NewReducerStore(store, o.reducerOpts...)
+	// Apply hook middleware to the underlying versioned store when configured.
+	versioned := store
+	if o.hasHooks {
+		versioned = state.WrapVersionedWithHooks(store, o.hooks)
+	}
+
+	// Build the reducer store on top of the (possibly hooked) versioned store.
+	reducer := state.NewReducerStore(versioned, o.reducerOpts...)
 
 	return &Blackboard{
-		store:     store,
+		store:     versioned,
 		reducer:   reducer,
 		ownership: state.NewOwnershipManager(),
 		opts:      o,
@@ -160,7 +168,18 @@ func (b *Blackboard) Delete(ctx context.Context, agentID, key string) error {
 // Watch returns an iter.Seq2 stream of state changes for the specified keys.
 // If no keys are provided, this returns immediately with no events.
 // The stream ends when the context is cancelled or the blackboard is closed.
+// If the blackboard is already closed, the stream yields a single errClosed
+// and returns, matching the behavior of Set/Get/Delete.
 func (b *Blackboard) Watch(ctx context.Context, keys ...string) iter.Seq2[state.StateChange, error] {
+	b.mu.RLock()
+	closed := b.closed
+	b.mu.RUnlock()
+	if closed {
+		return func(yield func(state.StateChange, error) bool) {
+			yield(state.StateChange{}, errClosed)
+		}
+	}
+
 	if len(keys) == 0 {
 		return func(yield func(state.StateChange, error) bool) {}
 	}

--- a/state/blackboard/blackboard.go
+++ b/state/blackboard/blackboard.go
@@ -1,0 +1,279 @@
+// Package blackboard provides an enhanced shared state layer for multi-agent
+// coordination. It wraps a state.VersionedStore with ownership enforcement,
+// per-key reducers, and iter.Seq2 watch streams.
+//
+// # Usage
+//
+//	store := inmemory.New()
+//	bb := blackboard.New(store,
+//	    blackboard.WithReducers(
+//	        state.WithReducer("counter", func(old, new any) any {
+//	            o, _ := old.(int)
+//	            n, _ := new.(int)
+//	            return o + n
+//	        }),
+//	    ),
+//	)
+//	defer bb.Close()
+//
+//	bb.Set(ctx, "agent-1", "counter", 5)
+//	bb.Set(ctx, "agent-2", "counter", 3) // merged to 8
+package blackboard
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/state"
+)
+
+// Option configures a Blackboard.
+type Option func(*options)
+
+type options struct {
+	reducerOpts      []state.ReducerOption
+	enforceOwnership bool
+	hooks            state.Hooks
+	hasHooks         bool
+}
+
+// WithReducers adds reducer options to the blackboard. Reducers are applied
+// when Set is called, merging old and new values instead of overwriting.
+func WithReducers(opts ...state.ReducerOption) Option {
+	return func(o *options) {
+		o.reducerOpts = append(o.reducerOpts, opts...)
+	}
+}
+
+// WithEnforceOwnership enables ownership enforcement. When enabled, only the
+// agent that claimed a key can write to it.
+func WithEnforceOwnership() Option {
+	return func(o *options) {
+		o.enforceOwnership = true
+	}
+}
+
+// WithBlackboardHooks attaches hooks to the underlying store operations.
+func WithBlackboardHooks(hooks state.Hooks) Option {
+	return func(o *options) {
+		o.hooks = hooks
+		o.hasHooks = true
+	}
+}
+
+// Blackboard is a shared state layer for multi-agent coordination. It
+// combines versioned state storage with ownership tracking and per-key
+// reducer merging.
+type Blackboard struct {
+	store     state.VersionedStore
+	reducer   *state.ReducerStore
+	ownership *state.OwnershipManager
+	opts      options
+	mu        sync.RWMutex
+	closed    bool
+}
+
+// New creates a Blackboard backed by the given VersionedStore.
+func New(store state.VersionedStore, opts ...Option) *Blackboard {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	// Build the reducer store on top of the versioned store.
+	reducer := state.NewReducerStore(store, o.reducerOpts...)
+
+	return &Blackboard{
+		store:     store,
+		reducer:   reducer,
+		ownership: state.NewOwnershipManager(),
+		opts:      o,
+	}
+}
+
+// Set stores a value under the given key, attributed to agentID. If a reducer
+// is configured for the key, the old and new values are merged. If ownership
+// enforcement is enabled, only the owner may write to claimed keys.
+func (b *Blackboard) Set(ctx context.Context, agentID, key string, value any) error {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return errClosed
+	}
+	b.mu.RUnlock()
+
+	if b.opts.enforceOwnership {
+		if err := b.ownership.CheckWrite(key, agentID); err != nil {
+			return err
+		}
+	}
+
+	ctx = state.WithOwnerID(ctx, agentID)
+	return b.reducer.Set(ctx, key, value)
+}
+
+// Get retrieves the value for the given key.
+func (b *Blackboard) Get(ctx context.Context, key string) (any, error) {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return nil, errClosed
+	}
+	b.mu.RUnlock()
+
+	return b.store.Get(ctx, key)
+}
+
+// GetVersioned retrieves the value and version for the given key.
+func (b *Blackboard) GetVersioned(ctx context.Context, key string) (any, uint64, error) {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return nil, 0, errClosed
+	}
+	b.mu.RUnlock()
+
+	return b.store.GetVersioned(ctx, key)
+}
+
+// Delete removes the given key, attributed to agentID. If ownership
+// enforcement is enabled, only the owner may delete claimed keys.
+func (b *Blackboard) Delete(ctx context.Context, agentID, key string) error {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return errClosed
+	}
+	b.mu.RUnlock()
+
+	if b.opts.enforceOwnership {
+		if err := b.ownership.CheckWrite(key, agentID); err != nil {
+			return err
+		}
+	}
+
+	ctx = state.WithOwnerID(ctx, agentID)
+	return b.store.Delete(ctx, key)
+}
+
+// Watch returns an iter.Seq2 stream of state changes for the specified keys.
+// If no keys are provided, this returns immediately with no events.
+// The stream ends when the context is cancelled or the blackboard is closed.
+func (b *Blackboard) Watch(ctx context.Context, keys ...string) iter.Seq2[state.StateChange, error] {
+	if len(keys) == 0 {
+		return func(yield func(state.StateChange, error) bool) {}
+	}
+
+	if len(keys) == 1 {
+		return state.WatchSeq(ctx, b.store, keys[0])
+	}
+
+	// For multiple keys, merge watch channels into a single stream.
+	return func(yield func(state.StateChange, error) bool) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		merged := make(chan state.StateChange, 16*len(keys))
+		var wg sync.WaitGroup
+
+		for _, key := range keys {
+			ch, err := b.store.Watch(ctx, key)
+			if err != nil {
+				yield(state.StateChange{}, err)
+				return
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case change, ok := <-ch:
+						if !ok {
+							return
+						}
+						select {
+						case merged <- change:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}()
+		}
+
+		// Close merged when all watchers complete.
+		go func() {
+			wg.Wait()
+			close(merged)
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				yield(state.StateChange{}, ctx.Err())
+				return
+			case change, ok := <-merged:
+				if !ok {
+					return
+				}
+				if !yield(change, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// ClaimOwnership grants ownerID exclusive write access to key. Returns an
+// error if the key is already claimed by a different owner.
+func (b *Blackboard) ClaimOwnership(ctx context.Context, agentID, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return b.ownership.Claim(key, agentID)
+}
+
+// ReleaseOwnership removes the ownership claim on key. Only the current owner
+// can release.
+func (b *Blackboard) ReleaseOwnership(ctx context.Context, agentID, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return b.ownership.Release(key, agentID)
+}
+
+// CompareAndSwap atomically sets the value for key only if the current version
+// matches expectedVersion.
+func (b *Blackboard) CompareAndSwap(ctx context.Context, agentID, key string, expectedVersion uint64, value any) (uint64, error) {
+	b.mu.RLock()
+	if b.closed {
+		b.mu.RUnlock()
+		return 0, errClosed
+	}
+	b.mu.RUnlock()
+
+	if b.opts.enforceOwnership {
+		if err := b.ownership.CheckWrite(key, agentID); err != nil {
+			return 0, err
+		}
+	}
+
+	return b.store.CompareAndSwap(ctx, key, expectedVersion, value)
+}
+
+// Close releases resources held by the blackboard.
+func (b *Blackboard) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	return b.store.Close()
+}
+
+var errClosed = state.ErrStoreClosed

--- a/state/blackboard/blackboard_test.go
+++ b/state/blackboard/blackboard_test.go
@@ -1,0 +1,346 @@
+package blackboard
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lookatitude/beluga-ai/state"
+	"github.com/lookatitude/beluga-ai/state/providers/inmemory"
+)
+
+func newTestBlackboard(opts ...Option) (*Blackboard, func()) {
+	store := inmemory.New()
+	bb := New(store, opts...)
+	return bb, func() { bb.Close() }
+}
+
+func TestBlackboard_SetAndGet(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, bb.Set(ctx, "agent-1", "key", "value"))
+
+	val, err := bb.Get(ctx, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestBlackboard_GetVersioned(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, bb.Set(ctx, "agent-1", "key", "v1"))
+	val, ver, err := bb.GetVersioned(ctx, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", val)
+	assert.Equal(t, uint64(1), ver)
+
+	require.NoError(t, bb.Set(ctx, "agent-1", "key", "v2"))
+	val, ver, err = bb.GetVersioned(ctx, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", val)
+	assert.Equal(t, uint64(2), ver)
+}
+
+func TestBlackboard_Delete(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, bb.Set(ctx, "agent-1", "key", "value"))
+	require.NoError(t, bb.Delete(ctx, "agent-1", "key"))
+
+	val, err := bb.Get(ctx, "key")
+	require.NoError(t, err)
+	assert.Nil(t, val)
+}
+
+func TestBlackboard_WatchSingleKey(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start watching in a goroutine.
+	var received []state.StateChange
+	var watchErr error
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for change, err := range bb.Watch(ctx, "key") {
+			if err != nil {
+				watchErr = err
+				return
+			}
+			received = append(received, change)
+			if len(received) >= 2 {
+				return
+			}
+		}
+	}()
+
+	// Give the watch time to set up.
+	time.Sleep(20 * time.Millisecond)
+
+	require.NoError(t, bb.Set(context.Background(), "agent-1", "key", "v1"))
+	require.NoError(t, bb.Set(context.Background(), "agent-1", "key", "v2"))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch events")
+	}
+
+	assert.NoError(t, watchErr)
+	assert.Len(t, received, 2)
+	assert.Equal(t, "v1", received[0].Value)
+	assert.Equal(t, "v2", received[1].Value)
+}
+
+func TestBlackboard_WatchMultipleKeys(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var received []state.StateChange
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for change, err := range bb.Watch(ctx, "k1", "k2") {
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			received = append(received, change)
+			count := len(received)
+			mu.Unlock()
+			if count >= 2 {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	require.NoError(t, bb.Set(context.Background(), "agent-1", "k1", "a"))
+	require.NoError(t, bb.Set(context.Background(), "agent-2", "k2", "b"))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for multi-key watch")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, received, 2)
+
+	keys := map[string]bool{}
+	for _, c := range received {
+		keys[c.Key] = true
+	}
+	assert.True(t, keys["k1"])
+	assert.True(t, keys["k2"])
+}
+
+func TestBlackboard_WatchNoKeys(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+
+	ctx := context.Background()
+	count := 0
+	for range bb.Watch(ctx) {
+		count++
+	}
+	assert.Equal(t, 0, count)
+}
+
+func TestBlackboard_OwnershipEnforcement(t *testing.T) {
+	bb, cleanup := newTestBlackboard(WithEnforceOwnership())
+	defer cleanup()
+	ctx := context.Background()
+
+	// Claim key.
+	require.NoError(t, bb.ClaimOwnership(ctx, "agent-a", "protected"))
+
+	// Owner can write.
+	require.NoError(t, bb.Set(ctx, "agent-a", "protected", "data"))
+
+	// Non-owner cannot write.
+	err := bb.Set(ctx, "agent-b", "protected", "attack")
+	assert.True(t, errors.Is(err, state.ErrOwnershipDenied))
+
+	// Value unchanged.
+	val, err := bb.Get(ctx, "protected")
+	require.NoError(t, err)
+	assert.Equal(t, "data", val)
+
+	// Non-owner cannot delete.
+	err = bb.Delete(ctx, "agent-b", "protected")
+	assert.True(t, errors.Is(err, state.ErrOwnershipDenied))
+
+	// Release and then another agent can claim.
+	require.NoError(t, bb.ReleaseOwnership(ctx, "agent-a", "protected"))
+	require.NoError(t, bb.ClaimOwnership(ctx, "agent-b", "protected"))
+	require.NoError(t, bb.Set(ctx, "agent-b", "protected", "new-data"))
+}
+
+func TestBlackboard_OwnershipNotEnforced(t *testing.T) {
+	bb, cleanup := newTestBlackboard() // No WithEnforceOwnership
+	defer cleanup()
+	ctx := context.Background()
+
+	// Claim key.
+	require.NoError(t, bb.ClaimOwnership(ctx, "agent-a", "key"))
+
+	// Without enforcement, any agent can write to a claimed key.
+	require.NoError(t, bb.Set(ctx, "agent-b", "key", "data"))
+}
+
+func TestBlackboard_Reducers(t *testing.T) {
+	bb, cleanup := newTestBlackboard(
+		WithReducers(
+			state.WithReducer("counter", func(old, new any) any {
+				o, _ := old.(int)
+				n, _ := new.(int)
+				return o + n
+			}),
+		),
+	)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, bb.Set(ctx, "agent-1", "counter", 5))
+	require.NoError(t, bb.Set(ctx, "agent-2", "counter", 3))
+
+	val, err := bb.Get(ctx, "counter")
+	require.NoError(t, err)
+	assert.Equal(t, 8, val)
+}
+
+func TestBlackboard_CompareAndSwap(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+	ctx := context.Background()
+
+	// CAS on new key.
+	newVer, err := bb.CompareAndSwap(ctx, "agent-1", "key", 0, "first")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), newVer)
+
+	// CAS with correct version.
+	newVer, err = bb.CompareAndSwap(ctx, "agent-1", "key", 1, "second")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), newVer)
+
+	// CAS with wrong version.
+	_, err = bb.CompareAndSwap(ctx, "agent-1", "key", 1, "conflict")
+	assert.ErrorIs(t, err, state.ErrVersionMismatch)
+}
+
+func TestBlackboard_CompareAndSwap_OwnershipEnforced(t *testing.T) {
+	bb, cleanup := newTestBlackboard(WithEnforceOwnership())
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, bb.ClaimOwnership(ctx, "agent-a", "key"))
+
+	// Owner CAS works.
+	_, err := bb.CompareAndSwap(ctx, "agent-a", "key", 0, "v1")
+	require.NoError(t, err)
+
+	// Non-owner CAS denied.
+	_, err = bb.CompareAndSwap(ctx, "agent-b", "key", 1, "v2")
+	assert.True(t, errors.Is(err, state.ErrOwnershipDenied))
+}
+
+func TestBlackboard_ClosedOperations(t *testing.T) {
+	bb, _ := newTestBlackboard()
+	require.NoError(t, bb.Close())
+
+	ctx := context.Background()
+
+	err := bb.Set(ctx, "a", "k", "v")
+	assert.ErrorIs(t, err, state.ErrStoreClosed)
+
+	_, err = bb.Get(ctx, "k")
+	assert.ErrorIs(t, err, state.ErrStoreClosed)
+
+	_, _, err = bb.GetVersioned(ctx, "k")
+	assert.ErrorIs(t, err, state.ErrStoreClosed)
+
+	err = bb.Delete(ctx, "a", "k")
+	assert.ErrorIs(t, err, state.ErrStoreClosed)
+
+	_, err = bb.CompareAndSwap(ctx, "a", "k", 0, "v")
+	assert.ErrorIs(t, err, state.ErrStoreClosed)
+}
+
+func TestBlackboard_CloseIdempotent(t *testing.T) {
+	bb, _ := newTestBlackboard()
+	require.NoError(t, bb.Close())
+	require.NoError(t, bb.Close())
+}
+
+func TestBlackboard_ConcurrentMultiAgent(t *testing.T) {
+	bb, cleanup := newTestBlackboard(
+		WithReducers(
+			state.WithReducer("shared", func(old, new any) any {
+				o, _ := old.(int)
+				n, _ := new.(int)
+				return o + n
+			}),
+		),
+	)
+	defer cleanup()
+	ctx := context.Background()
+
+	const agents = 10
+	const opsPerAgent = 50
+
+	var wg sync.WaitGroup
+	wg.Add(agents)
+
+	for i := 0; i < agents; i++ {
+		go func(agentID string) {
+			defer wg.Done()
+			for j := 0; j < opsPerAgent; j++ {
+				_ = bb.Set(ctx, agentID, "shared", 1)
+			}
+		}(string(rune('A' + i)))
+	}
+
+	wg.Wait()
+
+	val, err := bb.Get(ctx, "shared")
+	require.NoError(t, err)
+	assert.Equal(t, agents*opsPerAgent, val.(int))
+}
+
+func TestBlackboard_ClaimOwnership_ContextCancelled(t *testing.T) {
+	bb, cleanup := newTestBlackboard()
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := bb.ClaimOwnership(ctx, "agent", "key")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	err = bb.ReleaseOwnership(ctx, "agent", "key")
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/state/middleware.go
+++ b/state/middleware.go
@@ -108,3 +108,35 @@ func (s *hookedStore) Close() error {
 
 // Ensure hookedStore implements Store at compile time.
 var _ Store = (*hookedStore)(nil)
+
+// WrapVersionedWithHooks returns a VersionedStore that invokes the given
+// Hooks around Get/Set/Delete/Watch and delegates the versioned operations
+// (GetVersioned, CompareAndSwap) to the underlying store without hooks.
+// This is the VersionedStore counterpart of WithHooks.
+func WrapVersionedWithHooks(inner VersionedStore, hooks Hooks) VersionedStore {
+	return &hookedVersionedStore{
+		hookedStore: hookedStore{next: inner, hooks: hooks},
+		inner:       inner,
+	}
+}
+
+// hookedVersionedStore extends hookedStore with the VersionedStore methods,
+// delegating them directly to the inner versioned store.
+type hookedVersionedStore struct {
+	hookedStore
+	inner VersionedStore
+}
+
+// GetVersioned delegates to the inner versioned store. Hooks do not fire
+// on versioned reads because they are conceptually a read variant.
+func (s *hookedVersionedStore) GetVersioned(ctx context.Context, key string) (any, uint64, error) {
+	return s.inner.GetVersioned(ctx, key)
+}
+
+// CompareAndSwap delegates to the inner versioned store. Hooks do not fire
+// on CAS because callers typically use CAS as an explicit conflict path.
+func (s *hookedVersionedStore) CompareAndSwap(ctx context.Context, key string, expectedVersion uint64, value any) (uint64, error) {
+	return s.inner.CompareAndSwap(ctx, key, expectedVersion, value)
+}
+
+var _ VersionedStore = (*hookedVersionedStore)(nil)

--- a/state/ownership.go
+++ b/state/ownership.go
@@ -1,0 +1,145 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// ErrOwnershipDenied is returned when a non-owner attempts to write to a
+// claimed key.
+var ErrOwnershipDenied = fmt.Errorf("state: ownership denied")
+
+// ErrAlreadyClaimed is returned when a key is already claimed by another owner.
+var ErrAlreadyClaimed = fmt.Errorf("state: key already claimed")
+
+// OwnershipManager tracks which agent owns which keys and enforces write
+// access control.
+type OwnershipManager struct {
+	mu     sync.RWMutex
+	claims map[string]string // key -> ownerID
+}
+
+// NewOwnershipManager creates a new OwnershipManager.
+func NewOwnershipManager() *OwnershipManager {
+	return &OwnershipManager{
+		claims: make(map[string]string),
+	}
+}
+
+// Claim registers ownerID as the owner of key. Returns ErrAlreadyClaimed if
+// the key is already claimed by a different owner.
+func (om *OwnershipManager) Claim(key, ownerID string) error {
+	om.mu.Lock()
+	defer om.mu.Unlock()
+
+	if existing, ok := om.claims[key]; ok && existing != ownerID {
+		return fmt.Errorf("%w: key %q owned by %q", ErrAlreadyClaimed, key, existing)
+	}
+	om.claims[key] = ownerID
+	return nil
+}
+
+// Release removes the ownership claim on key. Only the current owner can
+// release. Returns ErrOwnershipDenied if the caller is not the owner.
+func (om *OwnershipManager) Release(key, ownerID string) error {
+	om.mu.Lock()
+	defer om.mu.Unlock()
+
+	existing, ok := om.claims[key]
+	if !ok {
+		return nil // no claim to release
+	}
+	if existing != ownerID {
+		return fmt.Errorf("%w: key %q owned by %q, not %q", ErrOwnershipDenied, key, existing, ownerID)
+	}
+	delete(om.claims, key)
+	return nil
+}
+
+// Owner returns the owner of key, or empty string if unclaimed.
+func (om *OwnershipManager) Owner(key string) string {
+	om.mu.RLock()
+	defer om.mu.RUnlock()
+	return om.claims[key]
+}
+
+// CheckWrite returns nil if ownerID is allowed to write to key.
+// Unclaimed keys are writable by anyone. Claimed keys are only writable
+// by the owner.
+func (om *OwnershipManager) CheckWrite(key, ownerID string) error {
+	om.mu.RLock()
+	defer om.mu.RUnlock()
+
+	existing, ok := om.claims[key]
+	if !ok {
+		return nil // unclaimed, anyone can write
+	}
+	if existing != ownerID {
+		return fmt.Errorf("%w: key %q owned by %q, writer %q", ErrOwnershipDenied, key, existing, ownerID)
+	}
+	return nil
+}
+
+// WithOwnership returns middleware that enforces ownership on Set and Delete
+// operations. The ownerID is extracted from the context using OwnerIDFromContext.
+// Keys without ownership claims are accessible to all writers.
+func WithOwnership(om *OwnershipManager) Middleware {
+	return func(next Store) Store {
+		return &ownedStore{next: next, om: om}
+	}
+}
+
+type ownerIDKey struct{}
+
+// WithOwnerID returns a context with the given owner ID attached.
+func WithOwnerID(ctx context.Context, ownerID string) context.Context {
+	return context.WithValue(ctx, ownerIDKey{}, ownerID)
+}
+
+// OwnerIDFromContext extracts the owner ID from the context.
+// Returns an empty string if no owner ID is set.
+func OwnerIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ownerIDKey{}).(string)
+	return v
+}
+
+// ownedStore wraps a Store with ownership enforcement.
+type ownedStore struct {
+	next Store
+	om   *OwnershipManager
+}
+
+func (s *ownedStore) Get(ctx context.Context, key string) (any, error) {
+	return s.next.Get(ctx, key)
+}
+
+func (s *ownedStore) Set(ctx context.Context, key string, value any) error {
+	ownerID := OwnerIDFromContext(ctx)
+	if ownerID != "" {
+		if err := s.om.CheckWrite(key, ownerID); err != nil {
+			return err
+		}
+	}
+	return s.next.Set(ctx, key, value)
+}
+
+func (s *ownedStore) Delete(ctx context.Context, key string) error {
+	ownerID := OwnerIDFromContext(ctx)
+	if ownerID != "" {
+		if err := s.om.CheckWrite(key, ownerID); err != nil {
+			return err
+		}
+	}
+	return s.next.Delete(ctx, key)
+}
+
+func (s *ownedStore) Watch(ctx context.Context, key string) (<-chan StateChange, error) {
+	return s.next.Watch(ctx, key)
+}
+
+func (s *ownedStore) Close() error {
+	return s.next.Close()
+}
+
+var _ Store = (*ownedStore)(nil)

--- a/state/ownership_test.go
+++ b/state/ownership_test.go
@@ -1,0 +1,110 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnershipManager_ClaimAndRelease(t *testing.T) {
+	om := NewOwnershipManager()
+
+	// Claim a key.
+	require.NoError(t, om.Claim("k1", "agent-a"))
+	assert.Equal(t, "agent-a", om.Owner("k1"))
+
+	// Same owner re-claiming is idempotent.
+	require.NoError(t, om.Claim("k1", "agent-a"))
+
+	// Different owner cannot claim.
+	err := om.Claim("k1", "agent-b")
+	assert.True(t, errors.Is(err, ErrAlreadyClaimed))
+
+	// Release by owner.
+	require.NoError(t, om.Release("k1", "agent-a"))
+	assert.Equal(t, "", om.Owner("k1"))
+
+	// Now agent-b can claim.
+	require.NoError(t, om.Claim("k1", "agent-b"))
+	assert.Equal(t, "agent-b", om.Owner("k1"))
+}
+
+func TestOwnershipManager_ReleaseByNonOwner(t *testing.T) {
+	om := NewOwnershipManager()
+
+	require.NoError(t, om.Claim("k", "owner"))
+	err := om.Release("k", "stranger")
+	assert.True(t, errors.Is(err, ErrOwnershipDenied))
+
+	// Still owned by original.
+	assert.Equal(t, "owner", om.Owner("k"))
+}
+
+func TestOwnershipManager_ReleaseUnclaimed(t *testing.T) {
+	om := NewOwnershipManager()
+	require.NoError(t, om.Release("missing", "anyone"))
+}
+
+func TestOwnershipManager_CheckWrite(t *testing.T) {
+	om := NewOwnershipManager()
+
+	// Unclaimed key — anyone can write.
+	require.NoError(t, om.CheckWrite("k", "anyone"))
+
+	// Claim the key.
+	require.NoError(t, om.Claim("k", "owner"))
+
+	// Owner can write.
+	require.NoError(t, om.CheckWrite("k", "owner"))
+
+	// Non-owner cannot write.
+	err := om.CheckWrite("k", "stranger")
+	assert.True(t, errors.Is(err, ErrOwnershipDenied))
+}
+
+func TestWithOwnerID_Context(t *testing.T) {
+	ctx := context.Background()
+	assert.Equal(t, "", OwnerIDFromContext(ctx))
+
+	ctx = WithOwnerID(ctx, "agent-1")
+	assert.Equal(t, "agent-1", OwnerIDFromContext(ctx))
+}
+
+func TestWithOwnership_Middleware(t *testing.T) {
+	om := NewOwnershipManager()
+	require.NoError(t, om.Claim("protected", "agent-a"))
+
+	inner := newMockStore()
+	store := ApplyMiddleware(inner, WithOwnership(om))
+
+	ctx := context.Background()
+
+	// No owner in context — unclaimed keys work.
+	require.NoError(t, store.Set(ctx, "open", "val"))
+
+	// No owner in context — claimed keys work (no enforcement without owner ID).
+	require.NoError(t, store.Set(ctx, "protected", "val"))
+
+	// Owner in context — owner can write.
+	ctxA := WithOwnerID(ctx, "agent-a")
+	require.NoError(t, store.Set(ctxA, "protected", "val-a"))
+
+	// Non-owner in context — cannot write.
+	ctxB := WithOwnerID(ctx, "agent-b")
+	err := store.Set(ctxB, "protected", "val-b")
+	assert.True(t, errors.Is(err, ErrOwnershipDenied))
+
+	// Get always works regardless of ownership.
+	_, err = store.Get(ctxB, "protected")
+	require.NoError(t, err)
+
+	// Delete by non-owner is denied.
+	err = store.Delete(ctxB, "protected")
+	assert.True(t, errors.Is(err, ErrOwnershipDenied))
+
+	// Delete by owner works.
+	require.NoError(t, store.Delete(ctxA, "protected"))
+}

--- a/state/providers/inmemory/inmemory.go
+++ b/state/providers/inmemory/inmemory.go
@@ -14,10 +14,16 @@ func init() {
 	})
 }
 
-// Store is a thread-safe in-memory implementation of state.Store.
+// entry holds a value and its monotonic version counter.
+type entry struct {
+	value   any
+	version uint64
+}
+
+// Store is a thread-safe in-memory implementation of state.VersionedStore.
 type Store struct {
 	mu       sync.RWMutex
-	data     map[string]any
+	data     map[string]entry
 	watchers map[string][]chan state.StateChange
 	closed   bool
 	done     chan struct{} // closed on Close() to unblock context goroutines
@@ -26,7 +32,7 @@ type Store struct {
 // New creates a new in-memory Store.
 func New() *Store {
 	return &Store{
-		data:     make(map[string]any),
+		data:     make(map[string]entry),
 		watchers: make(map[string][]chan state.StateChange),
 		done:     make(chan struct{}),
 	}
@@ -46,14 +52,35 @@ func (s *Store) Get(ctx context.Context, key string) (any, error) {
 		return nil, fmt.Errorf("state/get: store is closed")
 	}
 
-	val, ok := s.data[key]
+	e, ok := s.data[key]
 	if !ok {
 		return nil, nil
 	}
-	return val, nil
+	return e.value, nil
 }
 
-// Set stores a value under the given key.
+// GetVersioned retrieves the value and current version for the given key.
+// Returns (nil, 0, nil) if the key does not exist.
+func (s *Store) GetVersioned(ctx context.Context, key string) (any, uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, 0, fmt.Errorf("state/get_versioned: %w", err)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, 0, fmt.Errorf("state/get_versioned: store is closed")
+	}
+
+	e, ok := s.data[key]
+	if !ok {
+		return nil, 0, nil
+	}
+	return e.value, e.version, nil
+}
+
+// Set stores a value under the given key, incrementing the version counter.
 func (s *Store) Set(ctx context.Context, key string, value any) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("state/set: %w", err)
@@ -66,17 +93,62 @@ func (s *Store) Set(ctx context.Context, key string, value any) error {
 		return fmt.Errorf("state/set: store is closed")
 	}
 
-	oldValue := s.data[key]
-	s.data[key] = value
+	e := s.data[key]
+	oldValue := e.value
+	e.version++
+	e.value = value
+	s.data[key] = e
 
 	s.broadcast(state.StateChange{
 		Key:      key,
 		OldValue: oldValue,
 		Value:    value,
 		Op:       state.OpSet,
+		Version:  e.version,
 	})
 
 	return nil
+}
+
+// CompareAndSwap atomically sets the value for key only if the current version
+// matches expectedVersion. Returns the new version on success. For new keys,
+// expectedVersion must be 0.
+func (s *Store) CompareAndSwap(ctx context.Context, key string, expectedVersion uint64, value any) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, fmt.Errorf("state/cas: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return 0, fmt.Errorf("state/cas: store is closed")
+	}
+
+	e, exists := s.data[key]
+	currentVersion := e.version
+	if !exists {
+		currentVersion = 0
+	}
+
+	if currentVersion != expectedVersion {
+		return currentVersion, state.ErrVersionMismatch
+	}
+
+	oldValue := e.value
+	e.version = currentVersion + 1
+	e.value = value
+	s.data[key] = e
+
+	s.broadcast(state.StateChange{
+		Key:      key,
+		OldValue: oldValue,
+		Value:    value,
+		Op:       state.OpSet,
+		Version:  e.version,
+	})
+
+	return e.version, nil
 }
 
 // Delete removes the given key. Deleting a non-existent key is a no-op.
@@ -92,7 +164,7 @@ func (s *Store) Delete(ctx context.Context, key string) error {
 		return fmt.Errorf("state/delete: store is closed")
 	}
 
-	oldValue, exists := s.data[key]
+	e, exists := s.data[key]
 	if !exists {
 		return nil
 	}
@@ -101,9 +173,10 @@ func (s *Store) Delete(ctx context.Context, key string) error {
 
 	s.broadcast(state.StateChange{
 		Key:      key,
-		OldValue: oldValue,
+		OldValue: e.value,
 		Value:    nil,
 		Op:       state.OpDelete,
+		Version:  e.version + 1,
 	})
 
 	return nil
@@ -206,5 +279,6 @@ func (s *Store) removeWatcher(key string, target chan state.StateChange) {
 	}
 }
 
-// Ensure Store implements state.Store at compile time.
+// Compile-time checks.
 var _ state.Store = (*Store)(nil)
+var _ state.VersionedStore = (*Store)(nil)

--- a/state/providers/inmemory/inmemory_test.go
+++ b/state/providers/inmemory/inmemory_test.go
@@ -363,3 +363,210 @@ func TestVariousValueTypes(t *testing.T) {
 		})
 	}
 }
+
+// --- Versioned Store Tests ---
+
+func TestGetVersioned(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	// Non-existent key returns zero version.
+	val, ver, err := s.GetVersioned(ctx, "missing")
+	require.NoError(t, err)
+	assert.Nil(t, val)
+	assert.Equal(t, uint64(0), ver)
+
+	// Set increments version.
+	require.NoError(t, s.Set(ctx, "k", "v1"))
+	val, ver, err = s.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", val)
+	assert.Equal(t, uint64(1), ver)
+
+	// Second set increments again.
+	require.NoError(t, s.Set(ctx, "k", "v2"))
+	val, ver, err = s.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", val)
+	assert.Equal(t, uint64(2), ver)
+}
+
+func TestGetVersioned_ContextCancelled(t *testing.T) {
+	s := New()
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := s.GetVersioned(ctx, "k")
+	assert.Error(t, err)
+}
+
+func TestGetVersioned_StoreClosed(t *testing.T) {
+	s := New()
+	require.NoError(t, s.Close())
+
+	_, _, err := s.GetVersioned(context.Background(), "k")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
+}
+
+func TestCompareAndSwap_Success(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	// CAS on new key with expectedVersion=0.
+	newVer, err := s.CompareAndSwap(ctx, "k", 0, "first")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), newVer)
+
+	val, ver, err := s.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "first", val)
+	assert.Equal(t, uint64(1), ver)
+
+	// CAS with correct version.
+	newVer, err = s.CompareAndSwap(ctx, "k", 1, "second")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), newVer)
+
+	val, _, err = s.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "second", val)
+}
+
+func TestCompareAndSwap_VersionMismatch(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	require.NoError(t, s.Set(ctx, "k", "v1"))
+
+	// CAS with wrong version.
+	_, err := s.CompareAndSwap(ctx, "k", 0, "nope")
+	assert.ErrorIs(t, err, state.ErrVersionMismatch)
+
+	// Value should be unchanged.
+	val, _, err := s.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", val)
+}
+
+func TestCompareAndSwap_ContextCancelled(t *testing.T) {
+	s := New()
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.CompareAndSwap(ctx, "k", 0, "v")
+	assert.Error(t, err)
+}
+
+func TestCompareAndSwap_StoreClosed(t *testing.T) {
+	s := New()
+	require.NoError(t, s.Close())
+
+	_, err := s.CompareAndSwap(context.Background(), "k", 0, "v")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
+}
+
+func TestVersionInWatchNotification(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	ch, err := s.Watch(ctx, "k")
+	require.NoError(t, err)
+
+	require.NoError(t, s.Set(ctx, "k", "v1"))
+
+	select {
+	case change := <-ch:
+		assert.Equal(t, uint64(1), change.Version)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	require.NoError(t, s.Set(ctx, "k", "v2"))
+
+	select {
+	case change := <-ch:
+		assert.Equal(t, uint64(2), change.Version)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestCompareAndSwap_ConcurrentContention(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	// Initialize key.
+	require.NoError(t, s.Set(ctx, "counter", 0))
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	successes := make(chan bool, goroutines*100)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				val, ver, err := s.GetVersioned(ctx, "counter")
+				if err != nil {
+					continue
+				}
+				n, _ := val.(int)
+				_, err = s.CompareAndSwap(ctx, "counter", ver, n+1)
+				if err == nil {
+					successes <- true
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(successes)
+
+	successCount := 0
+	for range successes {
+		successCount++
+	}
+
+	// Final value should equal number of successful CAS operations.
+	val, _, err := s.GetVersioned(ctx, "counter")
+	require.NoError(t, err)
+	assert.Equal(t, successCount, val.(int))
+}
+
+func TestDeleteIncrementsVersion(t *testing.T) {
+	s := New()
+	defer s.Close()
+	ctx := context.Background()
+
+	ch, err := s.Watch(ctx, "k")
+	require.NoError(t, err)
+
+	require.NoError(t, s.Set(ctx, "k", "v1"))
+	<-ch // consume set notification
+
+	require.NoError(t, s.Delete(ctx, "k"))
+
+	select {
+	case change := <-ch:
+		assert.Equal(t, state.OpDelete, change.Op)
+		assert.Equal(t, uint64(2), change.Version) // version 1 from set + 1
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// Compile-time check for VersionedStore.
+var _ state.VersionedStore = (*Store)(nil)

--- a/state/reducer.go
+++ b/state/reducer.go
@@ -1,0 +1,130 @@
+package state
+
+import (
+	"context"
+	"sync"
+)
+
+// ReducerFunc merges an old value with a new value. The old value may be nil
+// if the key does not exist yet. The returned value replaces the stored value.
+type ReducerFunc func(old, new any) any
+
+// ReducerOption configures a ReducerStore.
+type ReducerOption func(*reducerOptions)
+
+type reducerOptions struct {
+	reducers       map[string]ReducerFunc
+	defaultReducer ReducerFunc
+}
+
+// WithReducer registers a per-key reducer function. When Set is called for
+// this key, the reducer merges the old and new values instead of overwriting.
+func WithReducer(key string, fn ReducerFunc) ReducerOption {
+	return func(o *reducerOptions) {
+		o.reducers[key] = fn
+	}
+}
+
+// WithDefaultReducer sets a default reducer applied to any key that does not
+// have a specific reducer registered. If nil (the default), keys without a
+// specific reducer use plain overwrite semantics.
+func WithDefaultReducer(fn ReducerFunc) ReducerOption {
+	return func(o *reducerOptions) {
+		o.defaultReducer = fn
+	}
+}
+
+// ReducerStore wraps a VersionedStore and applies per-key reducer functions
+// on Set. Reducers merge old and new values atomically using CompareAndSwap.
+type ReducerStore struct {
+	inner VersionedStore
+	mu    sync.RWMutex
+	opts  reducerOptions
+}
+
+// NewReducerStore creates a ReducerStore wrapping inner with the given options.
+func NewReducerStore(inner VersionedStore, opts ...ReducerOption) *ReducerStore {
+	o := reducerOptions{
+		reducers: make(map[string]ReducerFunc),
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &ReducerStore{inner: inner, opts: o}
+}
+
+// Get delegates to the inner store.
+func (rs *ReducerStore) Get(ctx context.Context, key string) (any, error) {
+	return rs.inner.Get(ctx, key)
+}
+
+// GetVersioned delegates to the inner store.
+func (rs *ReducerStore) GetVersioned(ctx context.Context, key string) (any, uint64, error) {
+	return rs.inner.GetVersioned(ctx, key)
+}
+
+// Set applies the reducer for the key (if any) to merge old and new values,
+// then writes the result atomically via CompareAndSwap. If no reducer is
+// registered for the key, a plain overwrite is performed.
+func (rs *ReducerStore) Set(ctx context.Context, key string, value any) error {
+	reducer := rs.reducerFor(key)
+	if reducer == nil {
+		return rs.inner.Set(ctx, key, value)
+	}
+
+	// Retry loop for CAS contention.
+	const maxRetries = 10
+	for i := 0; i < maxRetries; i++ {
+		old, version, err := rs.inner.GetVersioned(ctx, key)
+		if err != nil {
+			return err
+		}
+
+		merged := reducer(old, value)
+		_, casErr := rs.inner.CompareAndSwap(ctx, key, version, merged)
+		if casErr == nil {
+			return nil
+		}
+		if casErr != ErrVersionMismatch {
+			return casErr
+		}
+		// Version mismatch — retry.
+	}
+	return ErrVersionMismatch
+}
+
+// CompareAndSwap delegates to the inner store. Reducers are not applied
+// because CAS implies the caller is managing conflict resolution explicitly.
+func (rs *ReducerStore) CompareAndSwap(ctx context.Context, key string, expectedVersion uint64, value any) (uint64, error) {
+	return rs.inner.CompareAndSwap(ctx, key, expectedVersion, value)
+}
+
+// Delete delegates to the inner store.
+func (rs *ReducerStore) Delete(ctx context.Context, key string) error {
+	return rs.inner.Delete(ctx, key)
+}
+
+// Watch delegates to the inner store.
+func (rs *ReducerStore) Watch(ctx context.Context, key string) (<-chan StateChange, error) {
+	return rs.inner.Watch(ctx, key)
+}
+
+// Close delegates to the inner store.
+func (rs *ReducerStore) Close() error {
+	return rs.inner.Close()
+}
+
+// reducerFor returns the reducer for key, falling back to the default reducer.
+func (rs *ReducerStore) reducerFor(key string) ReducerFunc {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+
+	if fn, ok := rs.opts.reducers[key]; ok {
+		return fn
+	}
+	return rs.opts.defaultReducer
+}
+
+// Compile-time checks.
+var _ Store = (*ReducerStore)(nil)
+var _ VersionedStore = (*ReducerStore)(nil)

--- a/state/reducer.go
+++ b/state/reducer.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"sync"
 )
 
 // ReducerFunc merges an old value with a new value. The old value may be nil
@@ -36,9 +35,10 @@ func WithDefaultReducer(fn ReducerFunc) ReducerOption {
 
 // ReducerStore wraps a VersionedStore and applies per-key reducer functions
 // on Set. Reducers merge old and new values atomically using CompareAndSwap.
+// opts is set once at construction and treated as immutable thereafter, so
+// no lock is required around reducer lookups.
 type ReducerStore struct {
 	inner VersionedStore
-	mu    sync.RWMutex
 	opts  reducerOptions
 }
 
@@ -72,8 +72,10 @@ func (rs *ReducerStore) Set(ctx context.Context, key string, value any) error {
 		return rs.inner.Set(ctx, key, value)
 	}
 
-	// Retry loop for CAS contention.
-	const maxRetries = 10
+	// Retry loop for CAS contention. Bounded but generous: under heavy
+	// multi-writer contention we need enough headroom to avoid spurious
+	// ErrVersionMismatch failures on well-behaved workloads.
+	const maxRetries = 100
 	for i := 0; i < maxRetries; i++ {
 		old, version, err := rs.inner.GetVersioned(ctx, key)
 		if err != nil {
@@ -115,10 +117,9 @@ func (rs *ReducerStore) Close() error {
 }
 
 // reducerFor returns the reducer for key, falling back to the default reducer.
+// opts is constructed once in NewReducerStore and never mutated afterwards,
+// so no synchronization is needed.
 func (rs *ReducerStore) reducerFor(key string) ReducerFunc {
-	rs.mu.RLock()
-	defer rs.mu.RUnlock()
-
 	if fn, ok := rs.opts.reducers[key]; ok {
 		return fn
 	}

--- a/state/reducer_test.go
+++ b/state/reducer_test.go
@@ -1,0 +1,202 @@
+package state
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockVersionedStore is a minimal VersionedStore for testing reducers.
+type mockVersionedStore struct {
+	mu       sync.Mutex
+	data     map[string]any
+	versions map[string]uint64
+	watchCh  chan StateChange
+}
+
+func newMockVersionedStore() *mockVersionedStore {
+	return &mockVersionedStore{
+		data:     make(map[string]any),
+		versions: make(map[string]uint64),
+		watchCh:  make(chan StateChange, 16),
+	}
+}
+
+func (m *mockVersionedStore) Get(ctx context.Context, key string) (any, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data[key], nil
+}
+
+func (m *mockVersionedStore) Set(ctx context.Context, key string, value any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.versions[key]++
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockVersionedStore) Delete(ctx context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockVersionedStore) Watch(_ context.Context, _ string) (<-chan StateChange, error) {
+	return m.watchCh, nil
+}
+
+func (m *mockVersionedStore) Close() error { close(m.watchCh); return nil }
+
+func (m *mockVersionedStore) GetVersioned(ctx context.Context, key string) (any, uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data[key], m.versions[key], nil
+}
+
+func (m *mockVersionedStore) CompareAndSwap(ctx context.Context, key string, expectedVersion uint64, value any) (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.versions[key] != expectedVersion {
+		return m.versions[key], ErrVersionMismatch
+	}
+	m.versions[key]++
+	m.data[key] = value
+	return m.versions[key], nil
+}
+
+func TestReducerStore_WithReducer(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner,
+		WithReducer("counter", func(old, new any) any {
+			o, _ := old.(int)
+			n, _ := new.(int)
+			return o + n
+		}),
+	)
+	defer rs.Close()
+	ctx := context.Background()
+
+	// First set: old is nil, reducer gets (nil, 5) -> 0+5 = 5.
+	require.NoError(t, rs.Set(ctx, "counter", 5))
+	val, err := rs.Get(ctx, "counter")
+	require.NoError(t, err)
+	assert.Equal(t, 5, val)
+
+	// Second set: reducer gets (5, 3) -> 8.
+	require.NoError(t, rs.Set(ctx, "counter", 3))
+	val, err = rs.Get(ctx, "counter")
+	require.NoError(t, err)
+	assert.Equal(t, 8, val)
+}
+
+func TestReducerStore_NoReducerOverwrites(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner,
+		WithReducer("special", func(old, new any) any {
+			return "merged"
+		}),
+	)
+	defer rs.Close()
+	ctx := context.Background()
+
+	// Key without reducer — plain overwrite.
+	require.NoError(t, rs.Set(ctx, "plain", "v1"))
+	require.NoError(t, rs.Set(ctx, "plain", "v2"))
+	val, err := rs.Get(ctx, "plain")
+	require.NoError(t, err)
+	assert.Equal(t, "v2", val)
+}
+
+func TestReducerStore_DefaultReducer(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner,
+		WithDefaultReducer(func(old, new any) any {
+			// Append reducer: builds a slice.
+			var s []any
+			if old != nil {
+				s, _ = old.([]any)
+			}
+			return append(s, new)
+		}),
+	)
+	defer rs.Close()
+	ctx := context.Background()
+
+	require.NoError(t, rs.Set(ctx, "log", "entry1"))
+	require.NoError(t, rs.Set(ctx, "log", "entry2"))
+
+	val, err := rs.Get(ctx, "log")
+	require.NoError(t, err)
+	assert.Equal(t, []any{"entry1", "entry2"}, val)
+}
+
+func TestReducerStore_PerKeyOverridesDefault(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner,
+		WithDefaultReducer(func(old, new any) any {
+			return "default"
+		}),
+		WithReducer("special", func(old, new any) any {
+			return "specific"
+		}),
+	)
+	defer rs.Close()
+	ctx := context.Background()
+
+	require.NoError(t, rs.Set(ctx, "special", "x"))
+	val, err := rs.Get(ctx, "special")
+	require.NoError(t, err)
+	assert.Equal(t, "specific", val)
+
+	require.NoError(t, rs.Set(ctx, "other", "x"))
+	val, err = rs.Get(ctx, "other")
+	require.NoError(t, err)
+	assert.Equal(t, "default", val)
+}
+
+func TestReducerStore_CASPassthrough(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner)
+	ctx := context.Background()
+
+	newVer, err := rs.CompareAndSwap(ctx, "k", 0, "v1")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), newVer)
+
+	_, err = rs.CompareAndSwap(ctx, "k", 0, "v2")
+	assert.ErrorIs(t, err, ErrVersionMismatch)
+}
+
+func TestReducerStore_GetVersioned(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner)
+	ctx := context.Background()
+
+	require.NoError(t, rs.Set(ctx, "k", "v"))
+	val, ver, err := rs.GetVersioned(ctx, "k")
+	require.NoError(t, err)
+	assert.Equal(t, "v", val)
+	assert.Equal(t, uint64(1), ver)
+}
+
+func TestReducerStore_Delete(t *testing.T) {
+	inner := newMockVersionedStore()
+	rs := NewReducerStore(inner)
+	ctx := context.Background()
+
+	require.NoError(t, rs.Set(ctx, "k", "v"))
+	require.NoError(t, rs.Delete(ctx, "k"))
+
+	val, err := rs.Get(ctx, "k")
+	require.NoError(t, err)
+	assert.Nil(t, val)
+}
+
+// Compile-time checks.
+var _ Store = (*ReducerStore)(nil)
+var _ VersionedStore = (*ReducerStore)(nil)

--- a/state/state.go
+++ b/state/state.go
@@ -51,7 +51,33 @@ type StateChange struct {
 	Value any
 	// Op is the type of change.
 	Op ChangeOp
+	// Version is the monotonic revision counter for the key after the change.
+	// Zero means the store does not support versioning.
+	Version uint64
 }
+
+// VersionedStore extends Store with compare-and-swap semantics and per-key
+// version tracking. Implementations maintain a monotonic revision counter
+// per key, incremented on every mutation.
+type VersionedStore interface {
+	Store
+
+	// CompareAndSwap atomically sets the value for key only if the current
+	// version matches expectedVersion. It returns the new version on success.
+	// If the versions do not match, it returns ErrVersionMismatch.
+	CompareAndSwap(ctx context.Context, key string, expectedVersion uint64, value any) (newVersion uint64, err error)
+
+	// GetVersioned retrieves the value and current version for the given key.
+	// Returns (nil, 0, nil) if the key does not exist.
+	GetVersioned(ctx context.Context, key string) (value any, version uint64, err error)
+}
+
+// ErrVersionMismatch is returned by CompareAndSwap when the expected version
+// does not match the current version of the key.
+var ErrVersionMismatch = fmt.Errorf("state: version mismatch")
+
+// ErrStoreClosed is returned when an operation is attempted on a closed store.
+var ErrStoreClosed = fmt.Errorf("state: store is closed")
 
 // Scope defines the visibility level for state keys.
 type Scope string

--- a/state/watch.go
+++ b/state/watch.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"context"
+	"iter"
+)
+
+// WatchOption configures the behavior of WatchSeq.
+type WatchOption func(*watchOptions)
+
+type watchOptions struct {
+	bufSize int
+}
+
+func defaultWatchOptions() watchOptions {
+	return watchOptions{bufSize: 0}
+}
+
+// WithBufferSize sets the internal buffer size for the watch adapter.
+// A value of 0 (the default) uses the channel buffer provided by the store.
+func WithBufferSize(size int) WatchOption {
+	return func(o *watchOptions) {
+		if size >= 0 {
+			o.bufSize = size
+		}
+	}
+}
+
+// WatchSeq wraps Store.Watch as an iter.Seq2[StateChange, error] stream.
+// The returned iterator yields state changes until the context is cancelled,
+// the store is closed, or the consumer breaks out of the range loop.
+func WatchSeq(ctx context.Context, store Store, key string, opts ...WatchOption) iter.Seq2[StateChange, error] {
+	o := defaultWatchOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	_ = o // bufSize is informational; the store controls the channel buffer
+
+	return func(yield func(StateChange, error) bool) {
+		ch, err := store.Watch(ctx, key)
+		if err != nil {
+			yield(StateChange{}, err)
+			return
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				yield(StateChange{}, ctx.Err())
+				return
+			case change, ok := <-ch:
+				if !ok {
+					// Channel closed — store was closed or context cancelled.
+					return
+				}
+				if !yield(change, nil) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/state/watch.go
+++ b/state/watch.go
@@ -29,12 +29,16 @@ func WithBufferSize(size int) WatchOption {
 // WatchSeq wraps Store.Watch as an iter.Seq2[StateChange, error] stream.
 // The returned iterator yields state changes until the context is cancelled,
 // the store is closed, or the consumer breaks out of the range loop.
+//
+// If WithBufferSize(n) is provided with n > 0, events are relayed through
+// an internal n-slot buffer so that brief stalls in the consumer do not
+// back-pressure the store's watch channel. If n == 0 the store channel is
+// consumed directly.
 func WatchSeq(ctx context.Context, store Store, key string, opts ...WatchOption) iter.Seq2[StateChange, error] {
 	o := defaultWatchOptions()
 	for _, opt := range opts {
 		opt(&o)
 	}
-	_ = o // bufSize is informational; the store controls the channel buffer
 
 	return func(yield func(StateChange, error) bool) {
 		ch, err := store.Watch(ctx, key)
@@ -43,14 +47,55 @@ func WatchSeq(ctx context.Context, store Store, key string, opts ...WatchOption)
 			return
 		}
 
+		// Zero buffer: consume the store channel directly.
+		if o.bufSize <= 0 {
+			for {
+				select {
+				case <-ctx.Done():
+					yield(StateChange{}, ctx.Err())
+					return
+				case change, ok := <-ch:
+					if !ok {
+						return
+					}
+					if !yield(change, nil) {
+						return
+					}
+				}
+			}
+		}
+
+		// Relay events through an internal buffer to absorb brief consumer stalls.
+		relayCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		relay := make(chan StateChange, o.bufSize)
+		go func() {
+			defer close(relay)
+			for {
+				select {
+				case <-relayCtx.Done():
+					return
+				case change, ok := <-ch:
+					if !ok {
+						return
+					}
+					select {
+					case relay <- change:
+					case <-relayCtx.Done():
+						return
+					}
+				}
+			}
+		}()
+
 		for {
 			select {
 			case <-ctx.Done():
 				yield(StateChange{}, ctx.Err())
 				return
-			case change, ok := <-ch:
+			case change, ok := <-relay:
 				if !ok {
-					// Channel closed — store was closed or context cancelled.
 					return
 				}
 				if !yield(change, nil) {

--- a/state/watch_test.go
+++ b/state/watch_test.go
@@ -1,0 +1,109 @@
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// watchMockStore is a minimal Store for testing WatchSeq.
+type watchMockStore struct {
+	watchCh chan StateChange
+}
+
+func (m *watchMockStore) Get(context.Context, string) (any, error) { return nil, nil }
+func (m *watchMockStore) Set(context.Context, string, any) error   { return nil }
+func (m *watchMockStore) Delete(context.Context, string) error     { return nil }
+func (m *watchMockStore) Close() error                             { close(m.watchCh); return nil }
+func (m *watchMockStore) Watch(_ context.Context, _ string) (<-chan StateChange, error) {
+	return m.watchCh, nil
+}
+
+func TestWatchSeq_ReceivesChanges(t *testing.T) {
+	ch := make(chan StateChange, 4)
+	ms := &watchMockStore{watchCh: ch}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch <- StateChange{Key: "k", Value: "v1", Op: OpSet, Version: 1}
+	ch <- StateChange{Key: "k", Value: "v2", Op: OpSet, Version: 2}
+
+	var received []StateChange
+	count := 0
+	for change, err := range WatchSeq(ctx, ms, "k") {
+		assert.NoError(t, err)
+		received = append(received, change)
+		count++
+		if count >= 2 {
+			break
+		}
+	}
+
+	assert.Len(t, received, 2)
+	assert.Equal(t, "v1", received[0].Value)
+	assert.Equal(t, "v2", received[1].Value)
+}
+
+func TestWatchSeq_ContextCancellation(t *testing.T) {
+	ch := make(chan StateChange, 4)
+	ms := &watchMockStore{watchCh: ch}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	var lastErr error
+	for _, err := range WatchSeq(ctx, ms, "k") {
+		if err != nil {
+			lastErr = err
+			break
+		}
+	}
+
+	assert.ErrorIs(t, lastErr, context.Canceled)
+}
+
+func TestWatchSeq_ChannelClosed(t *testing.T) {
+	ch := make(chan StateChange, 4)
+	ms := &watchMockStore{watchCh: ch}
+
+	ctx := context.Background()
+
+	ch <- StateChange{Key: "k", Value: "v1", Op: OpSet, Version: 1}
+	close(ch)
+
+	var received []StateChange
+	for change, err := range WatchSeq(ctx, ms, "k") {
+		assert.NoError(t, err)
+		received = append(received, change)
+	}
+
+	assert.Len(t, received, 1)
+}
+
+func TestWatchSeq_ConsumerBreaks(t *testing.T) {
+	ch := make(chan StateChange, 4)
+	ms := &watchMockStore{watchCh: ch}
+
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		ch <- StateChange{Key: "k", Value: i, Op: OpSet, Version: uint64(i + 1)}
+	}
+
+	count := 0
+	for _, err := range WatchSeq(ctx, ms, "k") {
+		assert.NoError(t, err)
+		count++
+		if count == 1 {
+			break
+		}
+	}
+	assert.Equal(t, 1, count)
+}


### PR DESCRIPTION
## Summary
- VersionedStore with CAS, WatchSeq iter.Seq2 adapter, OwnershipMiddleware, ReducerStore, state/blackboard package

## Linear
- LOO-15: https://linear.app/lookatitude/issue/LOO-15

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)