### PR TITLE
LOO-18: Memory Consolidation with Intentional Forgetting

### DIFF
--- a/memory/consolidation/compressor.go
+++ b/memory/consolidation/compressor.go
@@ -50,10 +50,13 @@ func (c *SummaryCompressor) Compress(ctx context.Context, records []Record) ([]R
 
 		out := r
 		out.Content = summary
-		if out.Metadata == nil {
-			out.Metadata = make(map[string]any)
+		// Deep-copy Metadata to avoid mutating the caller's map.
+		newMeta := make(map[string]any, len(r.Metadata)+1)
+		for k, v := range r.Metadata {
+			newMeta[k] = v
 		}
-		out.Metadata["compressed"] = true
+		newMeta["compressed"] = true
+		out.Metadata = newMeta
 		compressed[i] = out
 	}
 	return compressed, nil

--- a/memory/consolidation/compressor.go
+++ b/memory/consolidation/compressor.go
@@ -1,0 +1,83 @@
+package consolidation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// Compressor reduces the size of memory records while preserving their
+// essential information. Implementations must be safe for concurrent use.
+type Compressor interface {
+	// Compress takes a set of records and returns compressed versions.
+	// The returned slice must have the same length as the input.
+	Compress(ctx context.Context, records []Record) ([]Record, error)
+}
+
+// SummaryCompressor uses an LLM ChatModel to summarise record content into
+// a shorter form.
+type SummaryCompressor struct {
+	model llm.ChatModel
+}
+
+// Compile-time interface check.
+var _ Compressor = (*SummaryCompressor)(nil)
+
+// NewSummaryCompressor creates a compressor backed by the given ChatModel.
+func NewSummaryCompressor(model llm.ChatModel) *SummaryCompressor {
+	return &SummaryCompressor{model: model}
+}
+
+// Compress summarises each record's content using the configured LLM. Each
+// record is processed independently. The original record ID, metadata, and
+// utility scores are preserved; only the content is replaced.
+func (c *SummaryCompressor) Compress(ctx context.Context, records []Record) ([]Record, error) {
+	compressed := make([]Record, len(records))
+	for i, r := range records {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		summary, err := c.summarise(ctx, r.Content)
+		if err != nil {
+			return nil, fmt.Errorf("consolidation: compress record %q: %w", r.ID, err)
+		}
+
+		out := r
+		out.Content = summary
+		if out.Metadata == nil {
+			out.Metadata = make(map[string]any)
+		}
+		out.Metadata["compressed"] = true
+		compressed[i] = out
+	}
+	return compressed, nil
+}
+
+// summarise calls the LLM to produce a concise summary of the given text.
+func (c *SummaryCompressor) summarise(ctx context.Context, text string) (string, error) {
+	msgs := []schema.Message{
+		schema.NewSystemMessage(
+			"You are a memory consolidation assistant. Summarise the following memory " +
+				"into a concise form that preserves the key facts, decisions, and context. " +
+				"Output only the summary, no preamble.",
+		),
+		schema.NewHumanMessage(text),
+	}
+
+	resp, err := c.model.Generate(ctx, msgs)
+	if err != nil {
+		return "", err
+	}
+
+	summary := strings.TrimSpace(resp.Text())
+	if summary == "" {
+		return text, nil // fall back to original if LLM returned empty
+	}
+	return summary, nil
+}

--- a/memory/consolidation/compressor_test.go
+++ b/memory/consolidation/compressor_test.go
@@ -1,0 +1,105 @@
+package consolidation
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChatModel is a minimal llm.ChatModel for testing the compressor.
+type mockChatModel struct {
+	response string
+	err      error
+}
+
+var _ llm.ChatModel = (*mockChatModel)(nil)
+
+func (m *mockChatModel) Generate(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) (*schema.AIMessage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return schema.NewAIMessage(m.response), nil
+}
+
+func (m *mockChatModel) Stream(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
+	return func(_ func(schema.StreamChunk, error) bool) {}
+}
+
+func (m *mockChatModel) BindTools(_ []schema.ToolDefinition) llm.ChatModel {
+	return m
+}
+
+func (m *mockChatModel) ModelID() string { return "mock" }
+
+func TestSummaryCompressor_Compress(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *mockChatModel
+		records  []Record
+		wantErr  bool
+		wantText string
+	}{
+		{
+			name:  "successful compression",
+			model: &mockChatModel{response: "summary of content"},
+			records: []Record{
+				{ID: "1", Content: "a very long memory about things"},
+			},
+			wantText: "summary of content",
+		},
+		{
+			name:  "empty LLM response falls back to original",
+			model: &mockChatModel{response: ""},
+			records: []Record{
+				{ID: "1", Content: "original content"},
+			},
+			wantText: "original content",
+		},
+		{
+			name:    "LLM error propagates",
+			model:   &mockChatModel{err: errors.New("llm failure")},
+			records: []Record{{ID: "1", Content: "content"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewSummaryCompressor(tt.model)
+			got, err := c.Compress(context.Background(), tt.records)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.records))
+			assert.Equal(t, tt.wantText, got[0].Content)
+			assert.Equal(t, tt.records[0].ID, got[0].ID)
+		})
+	}
+}
+
+func TestSummaryCompressor_CompressedMetadata(t *testing.T) {
+	c := NewSummaryCompressor(&mockChatModel{response: "short"})
+	records := []Record{{ID: "1", Content: "long"}}
+
+	got, err := c.Compress(context.Background(), records)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, true, got[0].Metadata["compressed"])
+}
+
+func TestSummaryCompressor_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := NewSummaryCompressor(&mockChatModel{response: "x"})
+	_, err := c.Compress(ctx, []Record{{ID: "1", Content: "text"}})
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/memory/consolidation/doc.go
+++ b/memory/consolidation/doc.go
@@ -1,0 +1,14 @@
+// Package consolidation implements memory consolidation with intentional
+// forgetting for the Beluga AI memory subsystem.
+//
+// It provides a background worker that periodically evaluates stored memory
+// records using configurable policies (threshold-based, frequency-based, or
+// composite) and either prunes low-utility records or compresses them via an
+// LLM-backed summarisation step. Utility scoring combines recency (exponential
+// half-life decay), importance, relevance, and emotional salience into a
+// single composite score.
+//
+// The consolidation loop follows a ticker-plus-jitter pattern for distributed
+// friendliness and implements the core.Lifecycle interface (Start/Stop/Health)
+// for integration with the application lifecycle manager.
+package consolidation

--- a/memory/consolidation/policy.go
+++ b/memory/consolidation/policy.go
@@ -1,0 +1,157 @@
+package consolidation
+
+import (
+	"context"
+	"time"
+)
+
+// ConsolidationPolicy evaluates a set of records and returns a decision for
+// each one. Implementations must be safe for concurrent use.
+type ConsolidationPolicy interface {
+	// Evaluate scores the given records and returns a decision (keep, prune,
+	// or compress) for each record. The returned slice must have the same
+	// length as the input.
+	Evaluate(ctx context.Context, records []Record) ([]Decision, error)
+}
+
+// ThresholdPolicy prunes records whose composite utility score falls below
+// a configurable threshold (default 0.25).
+type ThresholdPolicy struct {
+	// Threshold is the minimum composite score to keep a record.
+	// Records scoring below this value are marked for pruning.
+	Threshold float64
+
+	// CompressThreshold is the score below which records are compressed
+	// rather than pruned. Records scoring between CompressThreshold and
+	// Threshold are compressed. If zero, compression is disabled.
+	CompressThreshold float64
+
+	// Weights controls the composite score computation.
+	Weights Weights
+
+	// HalfLife controls recency decay. Zero means DefaultHalfLife.
+	HalfLife time.Duration
+}
+
+// Compile-time interface check.
+var _ ConsolidationPolicy = (*ThresholdPolicy)(nil)
+
+// NewThresholdPolicy creates a ThresholdPolicy with the default threshold of
+// 0.25, no compression, and default weights.
+func NewThresholdPolicy() *ThresholdPolicy {
+	return &ThresholdPolicy{
+		Threshold: 0.25,
+		Weights:   DefaultWeights(),
+	}
+}
+
+// Evaluate scores each record and returns prune/compress/keep decisions based
+// on the configured thresholds.
+func (p *ThresholdPolicy) Evaluate(ctx context.Context, records []Record) ([]Decision, error) {
+	now := time.Now()
+	decisions := make([]Decision, len(records))
+	for i, r := range records {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Update recency from creation time.
+		r.Utility.Recency = RecencyScore(r.CreatedAt, now, p.HalfLife)
+		score := CompositeScore(r.Utility, p.Weights)
+
+		action := ActionKeep
+		if score < p.Threshold {
+			if p.CompressThreshold > 0 && score >= p.CompressThreshold {
+				action = ActionCompress
+			} else {
+				action = ActionPrune
+			}
+		}
+		decisions[i] = Decision{Record: r, Action: action}
+	}
+	return decisions, nil
+}
+
+// FrequencyPolicy prunes records that have never been accessed after a
+// configurable time-to-live (TTL) has elapsed since creation.
+type FrequencyPolicy struct {
+	// TTL is the duration after creation beyond which zero-access records
+	// are pruned. Zero means 30 days.
+	TTL time.Duration
+}
+
+// Compile-time interface check.
+var _ ConsolidationPolicy = (*FrequencyPolicy)(nil)
+
+// NewFrequencyPolicy creates a FrequencyPolicy with a default TTL of 30 days.
+func NewFrequencyPolicy() *FrequencyPolicy {
+	return &FrequencyPolicy{TTL: 30 * 24 * time.Hour}
+}
+
+// Evaluate checks each record and prunes those with AccessCount == 0 whose
+// age exceeds the TTL.
+func (p *FrequencyPolicy) Evaluate(ctx context.Context, records []Record) ([]Decision, error) {
+	ttl := p.TTL
+	if ttl <= 0 {
+		ttl = 30 * 24 * time.Hour
+	}
+	now := time.Now()
+	decisions := make([]Decision, len(records))
+	for i, r := range records {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		action := ActionKeep
+		if r.Utility.AccessCount == 0 && now.Sub(r.CreatedAt) > ttl {
+			action = ActionPrune
+		}
+		decisions[i] = Decision{Record: r, Action: action}
+	}
+	return decisions, nil
+}
+
+// CompositePolicy applies multiple policies in sequence. A more severe action
+// from any policy wins (Prune > Compress > Keep).
+type CompositePolicy struct {
+	policies []ConsolidationPolicy
+}
+
+// Compile-time interface check.
+var _ ConsolidationPolicy = (*CompositePolicy)(nil)
+
+// NewCompositePolicy creates a policy that combines the given policies.
+// An empty composite always returns ActionKeep for all records.
+func NewCompositePolicy(policies ...ConsolidationPolicy) *CompositePolicy {
+	return &CompositePolicy{policies: policies}
+}
+
+// Evaluate runs all inner policies and merges decisions. The most severe
+// action for each record wins.
+func (c *CompositePolicy) Evaluate(ctx context.Context, records []Record) ([]Decision, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	merged := make([]Decision, len(records))
+	for i, r := range records {
+		merged[i] = Decision{Record: r, Action: ActionKeep}
+	}
+
+	for _, pol := range c.policies {
+		decisions, err := pol.Evaluate(ctx, records)
+		if err != nil {
+			return nil, err
+		}
+		for i, d := range decisions {
+			if d.Action > merged[i].Action {
+				merged[i].Action = d.Action
+			}
+		}
+	}
+	return merged, nil
+}

--- a/memory/consolidation/policy_test.go
+++ b/memory/consolidation/policy_test.go
@@ -1,0 +1,213 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThresholdPolicy_Evaluate(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		policy  *ThresholdPolicy
+		records []Record
+		want    []Action
+	}{
+		{
+			name:   "high utility kept",
+			policy: NewThresholdPolicy(),
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now,
+					Utility: UtilityScore{Importance: 1.0, Relevance: 1.0, EmotionalSalience: 1.0},
+				},
+			},
+			want: []Action{ActionKeep},
+		},
+		{
+			name:   "low utility pruned",
+			policy: NewThresholdPolicy(),
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now.Add(-365 * 24 * time.Hour),
+					Utility: UtilityScore{Importance: 0.0, Relevance: 0.0, EmotionalSalience: 0.0},
+				},
+			},
+			want: []Action{ActionPrune},
+		},
+		{
+			name: "mid utility compressed",
+			policy: &ThresholdPolicy{
+				Threshold:         0.5,
+				CompressThreshold: 0.2,
+				Weights:           DefaultWeights(),
+			},
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now,
+					Utility: UtilityScore{Importance: 0.1, Relevance: 0.1, EmotionalSalience: 0.1},
+				},
+			},
+			want: []Action{ActionCompress},
+		},
+		{
+			name:    "empty records",
+			policy:  NewThresholdPolicy(),
+			records: nil,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decisions, err := tt.policy.Evaluate(context.Background(), tt.records)
+			require.NoError(t, err)
+			if tt.want == nil {
+				assert.Empty(t, decisions)
+				return
+			}
+			require.Len(t, decisions, len(tt.want))
+			for i, d := range decisions {
+				assert.Equal(t, tt.want[i], d.Action, "record %d", i)
+			}
+		})
+	}
+}
+
+func TestThresholdPolicy_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	records := make([]Record, 100)
+	for i := range records {
+		records[i] = Record{ID: "r"}
+	}
+
+	_, err := NewThresholdPolicy().Evaluate(ctx, records)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFrequencyPolicy_Evaluate(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name    string
+		policy  *FrequencyPolicy
+		records []Record
+		want    []Action
+	}{
+		{
+			name:   "accessed record kept",
+			policy: NewFrequencyPolicy(),
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now.Add(-60 * 24 * time.Hour),
+					Utility: UtilityScore{AccessCount: 5},
+				},
+			},
+			want: []Action{ActionKeep},
+		},
+		{
+			name:   "never accessed old record pruned",
+			policy: NewFrequencyPolicy(),
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now.Add(-60 * 24 * time.Hour),
+					Utility: UtilityScore{AccessCount: 0},
+				},
+			},
+			want: []Action{ActionPrune},
+		},
+		{
+			name:   "never accessed recent record kept",
+			policy: NewFrequencyPolicy(),
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now.Add(-time.Hour),
+					Utility: UtilityScore{AccessCount: 0},
+				},
+			},
+			want: []Action{ActionKeep},
+		},
+		{
+			name:   "zero TTL uses default 30 days",
+			policy: &FrequencyPolicy{TTL: 0},
+			records: []Record{
+				{
+					ID: "1", CreatedAt: now.Add(-31 * 24 * time.Hour),
+					Utility: UtilityScore{AccessCount: 0},
+				},
+			},
+			want: []Action{ActionPrune},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decisions, err := tt.policy.Evaluate(context.Background(), tt.records)
+			require.NoError(t, err)
+			require.Len(t, decisions, len(tt.want))
+			for i, d := range decisions {
+				assert.Equal(t, tt.want[i], d.Action, "record %d", i)
+			}
+		})
+	}
+}
+
+func TestFrequencyPolicy_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	records := make([]Record, 100)
+	for i := range records {
+		records[i] = Record{ID: "r"}
+	}
+
+	_, err := NewFrequencyPolicy().Evaluate(ctx, records)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCompositePolicy_Evaluate(t *testing.T) {
+	now := time.Now()
+
+	t.Run("most severe action wins", func(t *testing.T) {
+		// ThresholdPolicy will keep (high utility), FrequencyPolicy will prune (old, no access).
+		threshold := NewThresholdPolicy()
+		freq := &FrequencyPolicy{TTL: 24 * time.Hour}
+
+		composite := NewCompositePolicy(threshold, freq)
+		records := []Record{
+			{
+				ID: "1", CreatedAt: now.Add(-48 * time.Hour),
+				Utility: UtilityScore{
+					Importance: 1.0, Relevance: 1.0, EmotionalSalience: 1.0,
+					AccessCount: 0,
+				},
+			},
+		}
+
+		decisions, err := composite.Evaluate(context.Background(), records)
+		require.NoError(t, err)
+		require.Len(t, decisions, 1)
+		assert.Equal(t, ActionPrune, decisions[0].Action)
+	})
+
+	t.Run("empty records", func(t *testing.T) {
+		composite := NewCompositePolicy(NewThresholdPolicy())
+		decisions, err := composite.Evaluate(context.Background(), nil)
+		require.NoError(t, err)
+		assert.Nil(t, decisions)
+	})
+
+	t.Run("no policies keeps all", func(t *testing.T) {
+		composite := NewCompositePolicy()
+		records := []Record{{ID: "1", CreatedAt: now}}
+		decisions, err := composite.Evaluate(context.Background(), records)
+		require.NoError(t, err)
+		require.Len(t, decisions, 1)
+		assert.Equal(t, ActionKeep, decisions[0].Action)
+	})
+}

--- a/memory/consolidation/scoring.go
+++ b/memory/consolidation/scoring.go
@@ -1,0 +1,52 @@
+package consolidation
+
+import (
+	"math"
+	"time"
+)
+
+// DefaultHalfLife is the default half-life for recency decay: 7 days.
+const DefaultHalfLife = 7 * 24 * time.Hour
+
+// RecencyScore computes an exponential decay score for a record based on
+// elapsed time since creation and a configurable half-life. The returned
+// value is in [0, 1], where 1 means "just created" and values approach 0
+// as age increases.
+//
+//	score = exp(-ln(2) * elapsed / halfLife)
+func RecencyScore(createdAt time.Time, now time.Time, halfLife time.Duration) float64 {
+	if halfLife <= 0 {
+		halfLife = DefaultHalfLife
+	}
+	elapsed := now.Sub(createdAt)
+	if elapsed <= 0 {
+		return 1.0
+	}
+	return math.Exp(-math.Ln2 * float64(elapsed) / float64(halfLife))
+}
+
+// CompositeScore computes a weighted sum of the utility dimensions using the
+// given weights. Weights are normalised so the result is in [0, 1] when all
+// individual dimensions are in [0, 1].
+func CompositeScore(u UtilityScore, w Weights) float64 {
+	total := w.Recency + w.Importance + w.Relevance + w.EmotionalSalience
+	if total <= 0 {
+		return 0
+	}
+	score := (w.Recency*u.Recency +
+		w.Importance*u.Importance +
+		w.Relevance*u.Relevance +
+		w.EmotionalSalience*u.EmotionalSalience) / total
+	return clamp01(score)
+}
+
+// clamp01 restricts v to the range [0, 1].
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/memory/consolidation/scoring_test.go
+++ b/memory/consolidation/scoring_test.go
@@ -1,0 +1,163 @@
+package consolidation
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecencyScore(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name     string
+		created  time.Time
+		halfLife time.Duration
+		wantMin  float64
+		wantMax  float64
+	}{
+		{
+			name:     "just created",
+			created:  now,
+			halfLife: DefaultHalfLife,
+			wantMin:  0.99,
+			wantMax:  1.0,
+		},
+		{
+			name:     "one half-life ago",
+			created:  now.Add(-DefaultHalfLife),
+			halfLife: DefaultHalfLife,
+			wantMin:  0.49,
+			wantMax:  0.51,
+		},
+		{
+			name:     "two half-lives ago",
+			created:  now.Add(-2 * DefaultHalfLife),
+			halfLife: DefaultHalfLife,
+			wantMin:  0.24,
+			wantMax:  0.26,
+		},
+		{
+			name:     "future timestamp returns 1",
+			created:  now.Add(time.Hour),
+			halfLife: DefaultHalfLife,
+			wantMin:  1.0,
+			wantMax:  1.0,
+		},
+		{
+			name:     "zero half-life uses default",
+			created:  now.Add(-DefaultHalfLife),
+			halfLife: 0,
+			wantMin:  0.49,
+			wantMax:  0.51,
+		},
+		{
+			name:     "negative half-life uses default",
+			created:  now.Add(-DefaultHalfLife),
+			halfLife: -time.Hour,
+			wantMin:  0.49,
+			wantMax:  0.51,
+		},
+		{
+			name:     "very old record approaches zero",
+			created:  now.Add(-100 * DefaultHalfLife),
+			halfLife: DefaultHalfLife,
+			wantMin:  0.0,
+			wantMax:  1e-10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RecencyScore(tt.created, now, tt.halfLife)
+			assert.GreaterOrEqual(t, got, tt.wantMin, "score too low")
+			assert.LessOrEqual(t, got, tt.wantMax, "score too high")
+		})
+	}
+}
+
+func TestCompositeScore(t *testing.T) {
+	tests := []struct {
+		name    string
+		utility UtilityScore
+		weights Weights
+		want    float64
+		epsilon float64
+	}{
+		{
+			name: "all ones with default weights",
+			utility: UtilityScore{
+				Recency: 1.0, Importance: 1.0,
+				Relevance: 1.0, EmotionalSalience: 1.0,
+			},
+			weights: DefaultWeights(),
+			want:    1.0,
+			epsilon: 1e-9,
+		},
+		{
+			name: "all zeros",
+			utility: UtilityScore{
+				Recency: 0, Importance: 0,
+				Relevance: 0, EmotionalSalience: 0,
+			},
+			weights: DefaultWeights(),
+			want:    0.0,
+			epsilon: 1e-9,
+		},
+		{
+			name: "only recency with default weights",
+			utility: UtilityScore{
+				Recency: 1.0, Importance: 0,
+				Relevance: 0, EmotionalSalience: 0,
+			},
+			weights: DefaultWeights(),
+			want:    0.4,
+			epsilon: 1e-9,
+		},
+		{
+			name: "zero total weight returns zero",
+			utility: UtilityScore{
+				Recency: 1.0, Importance: 1.0,
+				Relevance: 1.0, EmotionalSalience: 1.0,
+			},
+			weights: Weights{0, 0, 0, 0},
+			want:    0.0,
+			epsilon: 1e-9,
+		},
+		{
+			name: "custom weights",
+			utility: UtilityScore{
+				Recency: 0.5, Importance: 0.8,
+				Relevance: 0.3, EmotionalSalience: 0.9,
+			},
+			weights: Weights{1, 1, 1, 1},
+			want:    0.625, // (0.5+0.8+0.3+0.9)/4
+			epsilon: 1e-9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompositeScore(tt.utility, tt.weights)
+			assert.InDelta(t, tt.want, got, tt.epsilon)
+		})
+	}
+}
+
+func TestClamp01(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want float64
+	}{
+		{-1, 0},
+		{0, 0},
+		{0.5, 0.5},
+		{1.0, 1.0},
+		{2.0, 1.0},
+		{math.Inf(1), 1.0},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, clamp01(tt.in))
+	}
+}

--- a/memory/consolidation/store.go
+++ b/memory/consolidation/store.go
@@ -1,0 +1,149 @@
+package consolidation
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ConsolidationStore is the storage interface used by the consolidation
+// worker to read, update, and delete memory records. Implementations must
+// be safe for concurrent use.
+type ConsolidationStore interface {
+	// ListRecords returns up to limit records starting from offset.
+	ListRecords(ctx context.Context, offset, limit int) ([]Record, error)
+
+	// DeleteRecords removes the records with the given IDs.
+	DeleteRecords(ctx context.Context, ids []string) error
+
+	// UpdateRecords persists changes to the given records.
+	UpdateRecords(ctx context.Context, records []Record) error
+
+	// RecordAccess increments the access counter and updates the last
+	// accessed timestamp for the given record ID.
+	RecordAccess(ctx context.Context, id string) error
+}
+
+// InMemoryConsolidationStore is a thread-safe, in-memory implementation of
+// ConsolidationStore suitable for testing and lightweight use cases.
+type InMemoryConsolidationStore struct {
+	mu      sync.RWMutex
+	records map[string]Record
+	order   []string // insertion order for deterministic listing
+}
+
+// Compile-time interface check.
+var _ ConsolidationStore = (*InMemoryConsolidationStore)(nil)
+
+// NewInMemoryConsolidationStore creates an empty in-memory store.
+func NewInMemoryConsolidationStore() *InMemoryConsolidationStore {
+	return &InMemoryConsolidationStore{
+		records: make(map[string]Record),
+	}
+}
+
+// Add inserts a record into the store. If a record with the same ID already
+// exists it is overwritten.
+func (s *InMemoryConsolidationStore) Add(record Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[record.ID]; !exists {
+		s.order = append(s.order, record.ID)
+	}
+	s.records[record.ID] = record
+}
+
+// Len returns the number of records in the store.
+func (s *InMemoryConsolidationStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.records)
+}
+
+// ListRecords returns up to limit records starting from offset, in insertion
+// order.
+func (s *InMemoryConsolidationStore) ListRecords(ctx context.Context, offset, limit int) ([]Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(s.order) {
+		return nil, nil
+	}
+
+	end := offset + limit
+	if end > len(s.order) {
+		end = len(s.order)
+	}
+
+	result := make([]Record, 0, end-offset)
+	for _, id := range s.order[offset:end] {
+		if r, ok := s.records[id]; ok {
+			result = append(result, r)
+		}
+	}
+	return result, nil
+}
+
+// DeleteRecords removes records by ID.
+func (s *InMemoryConsolidationStore) DeleteRecords(ctx context.Context, ids []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+		delete(s.records, id)
+	}
+
+	// Compact the order slice.
+	n := 0
+	for _, id := range s.order {
+		if _, removed := idSet[id]; !removed {
+			s.order[n] = id
+			n++
+		}
+	}
+	s.order = s.order[:n]
+	return nil
+}
+
+// UpdateRecords overwrites existing records. Records that do not exist are
+// silently ignored.
+func (s *InMemoryConsolidationStore) UpdateRecords(ctx context.Context, records []Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range records {
+		if _, exists := s.records[r.ID]; exists {
+			s.records[r.ID] = r
+		}
+	}
+	return nil
+}
+
+// RecordAccess increments the access counter and updates LastAccessedAt for
+// the given record ID.
+func (s *InMemoryConsolidationStore) RecordAccess(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return fmt.Errorf("consolidation: record %q not found", id)
+	}
+	r.Utility.AccessCount++
+	r.Utility.LastAccessedAt = time.Now()
+	s.records[id] = r
+	return nil
+}
+
+// Get retrieves a single record by ID. It returns false if the record does
+// not exist.
+func (s *InMemoryConsolidationStore) Get(id string) (Record, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.records[id]
+	return r, ok
+}

--- a/memory/consolidation/store_test.go
+++ b/memory/consolidation/store_test.go
@@ -1,0 +1,129 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(records ...Record) *InMemoryConsolidationStore {
+	s := NewInMemoryConsolidationStore()
+	for _, r := range records {
+		s.Add(r)
+	}
+	return s
+}
+
+func TestInMemoryConsolidationStore_ListRecords(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	s := newTestStore(
+		Record{ID: "a", CreatedAt: now},
+		Record{ID: "b", CreatedAt: now},
+		Record{ID: "c", CreatedAt: now},
+	)
+
+	tests := []struct {
+		name   string
+		offset int
+		limit  int
+		want   []string
+	}{
+		{"all", 0, 10, []string{"a", "b", "c"}},
+		{"first two", 0, 2, []string{"a", "b"}},
+		{"skip first", 1, 2, []string{"b", "c"}},
+		{"offset beyond length", 10, 5, nil},
+		{"negative offset clamped", -1, 10, []string{"a", "b", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records, err := s.ListRecords(ctx, tt.offset, tt.limit)
+			require.NoError(t, err)
+			var ids []string
+			for _, r := range records {
+				ids = append(ids, r.ID)
+			}
+			assert.Equal(t, tt.want, ids)
+		})
+	}
+}
+
+func TestInMemoryConsolidationStore_DeleteRecords(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(
+		Record{ID: "a"},
+		Record{ID: "b"},
+		Record{ID: "c"},
+	)
+
+	err := s.DeleteRecords(ctx, []string{"a", "c"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, s.Len())
+	records, err := s.ListRecords(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "b", records[0].ID)
+}
+
+func TestInMemoryConsolidationStore_UpdateRecords(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(Record{ID: "a", Content: "original"})
+
+	err := s.UpdateRecords(ctx, []Record{{ID: "a", Content: "updated"}})
+	require.NoError(t, err)
+
+	r, ok := s.Get("a")
+	require.True(t, ok)
+	assert.Equal(t, "updated", r.Content)
+}
+
+func TestInMemoryConsolidationStore_UpdateRecords_NonExistent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	// Should not error, just silently ignore.
+	err := s.UpdateRecords(ctx, []Record{{ID: "missing", Content: "x"}})
+	require.NoError(t, err)
+	assert.Equal(t, 0, s.Len())
+}
+
+func TestInMemoryConsolidationStore_RecordAccess(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(Record{ID: "a"})
+
+	err := s.RecordAccess(ctx, "a")
+	require.NoError(t, err)
+
+	r, ok := s.Get("a")
+	require.True(t, ok)
+	assert.Equal(t, 1, r.Utility.AccessCount)
+	assert.False(t, r.Utility.LastAccessedAt.IsZero())
+
+	err = s.RecordAccess(ctx, "a")
+	require.NoError(t, err)
+	r, _ = s.Get("a")
+	assert.Equal(t, 2, r.Utility.AccessCount)
+}
+
+func TestInMemoryConsolidationStore_RecordAccess_NotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+
+	err := s.RecordAccess(ctx, "missing")
+	assert.Error(t, err)
+}
+
+func TestInMemoryConsolidationStore_Add_Overwrite(t *testing.T) {
+	s := newTestStore(Record{ID: "a", Content: "v1"})
+	s.Add(Record{ID: "a", Content: "v2"})
+
+	assert.Equal(t, 1, s.Len())
+	r, ok := s.Get("a")
+	require.True(t, ok)
+	assert.Equal(t, "v2", r.Content)
+}

--- a/memory/consolidation/types.go
+++ b/memory/consolidation/types.go
@@ -70,11 +70,11 @@ const (
 	// ActionKeep means the record should be retained as-is.
 	ActionKeep Action = iota
 
-	// ActionPrune means the record should be deleted.
-	ActionPrune
-
 	// ActionCompress means the record should be summarised/compressed.
 	ActionCompress
+
+	// ActionPrune means the record should be deleted.
+	ActionPrune
 )
 
 // Decision pairs a record with the action the policy chose for it.

--- a/memory/consolidation/types.go
+++ b/memory/consolidation/types.go
@@ -1,0 +1,146 @@
+package consolidation
+
+import "time"
+
+// UtilityScore holds the individual dimensions that contribute to a memory
+// record's overall utility. Each dimension is normalised to [0, 1].
+type UtilityScore struct {
+	// Recency is the time-decay component, computed via exponential half-life.
+	Recency float64
+
+	// Importance captures the intrinsic significance of the memory content.
+	Importance float64
+
+	// Relevance measures how related the memory is to current context.
+	Relevance float64
+
+	// EmotionalSalience captures the emotional weight of the memory.
+	EmotionalSalience float64
+
+	// AccessCount is the total number of times this record has been accessed.
+	AccessCount int
+
+	// LastAccessedAt is the most recent time this record was read.
+	LastAccessedAt time.Time
+}
+
+// Weights controls how the individual UtilityScore dimensions are combined
+// into a single composite score. All weights should sum to 1.0 but this is
+// not enforced — they are normalised at scoring time.
+type Weights struct {
+	Recency           float64
+	Importance        float64
+	Relevance         float64
+	EmotionalSalience float64
+}
+
+// DefaultWeights returns the recommended weighting: Recency 0.4,
+// Importance 0.3, Relevance 0.2, EmotionalSalience 0.1.
+func DefaultWeights() Weights {
+	return Weights{
+		Recency:           0.4,
+		Importance:        0.3,
+		Relevance:         0.2,
+		EmotionalSalience: 0.1,
+	}
+}
+
+// Record is a memory entry subject to consolidation evaluation.
+type Record struct {
+	// ID uniquely identifies the record within the store.
+	ID string
+
+	// Content is the textual content of the memory.
+	Content string
+
+	// Utility holds the scoring dimensions for this record.
+	Utility UtilityScore
+
+	// CreatedAt is when the record was first persisted.
+	CreatedAt time.Time
+
+	// Metadata carries arbitrary key-value pairs.
+	Metadata map[string]any
+}
+
+// Action describes what a consolidation policy decided for a record.
+type Action int
+
+const (
+	// ActionKeep means the record should be retained as-is.
+	ActionKeep Action = iota
+
+	// ActionPrune means the record should be deleted.
+	ActionPrune
+
+	// ActionCompress means the record should be summarised/compressed.
+	ActionCompress
+)
+
+// Decision pairs a record with the action the policy chose for it.
+type Decision struct {
+	Record Record
+	Action Action
+}
+
+// CycleMetrics captures statistics for a single consolidation cycle.
+type CycleMetrics struct {
+	// CycleStart is when the cycle began.
+	CycleStart time.Time
+
+	// CycleEnd is when the cycle finished.
+	CycleEnd time.Time
+
+	// RecordsEvaluated is the total number of records scored.
+	RecordsEvaluated int
+
+	// RecordsPruned is how many records were deleted.
+	RecordsPruned int
+
+	// RecordsCompressed is how many records were summarised.
+	RecordsCompressed int
+
+	// Errors collects any non-fatal errors encountered during the cycle.
+	Errors []error
+}
+
+// Hooks provides optional callbacks that fire during consolidation.
+// A nil function field is silently skipped.
+type Hooks struct {
+	// OnPruned is called after records have been pruned in a cycle.
+	OnPruned func(records []Record)
+
+	// OnCompressed is called after records have been compressed in a cycle.
+	OnCompressed func(original, compressed []Record)
+
+	// OnCycleComplete is called at the end of every consolidation cycle.
+	OnCycleComplete func(metrics CycleMetrics)
+}
+
+// ComposeHooks merges multiple Hooks into one. Each hook function chains
+// through all non-nil implementations in order.
+func ComposeHooks(hooks ...Hooks) Hooks {
+	return Hooks{
+		OnPruned: func(records []Record) {
+			for _, h := range hooks {
+				if h.OnPruned != nil {
+					h.OnPruned(records)
+				}
+			}
+		},
+		OnCompressed: func(original, compressed []Record) {
+			for _, h := range hooks {
+				if h.OnCompressed != nil {
+					h.OnCompressed(original, compressed)
+				}
+			}
+		},
+		OnCycleComplete: func(metrics CycleMetrics) {
+			for _, h := range hooks {
+				if h.OnCycleComplete != nil {
+					h.OnCycleComplete(metrics)
+				}
+			}
+		},
+	}
+}

--- a/memory/consolidation/types_test.go
+++ b/memory/consolidation/types_test.go
@@ -1,0 +1,44 @@
+package consolidation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultWeights(t *testing.T) {
+	w := DefaultWeights()
+	assert.Equal(t, 0.4, w.Recency)
+	assert.Equal(t, 0.3, w.Importance)
+	assert.Equal(t, 0.2, w.Relevance)
+	assert.Equal(t, 0.1, w.EmotionalSalience)
+
+	sum := w.Recency + w.Importance + w.Relevance + w.EmotionalSalience
+	assert.InDelta(t, 1.0, sum, 1e-9, "weights should sum to 1.0")
+}
+
+func TestComposeHooks(t *testing.T) {
+	var prunedCalls, compressedCalls, cycleCalls int
+
+	h1 := Hooks{
+		OnPruned:        func(_ []Record) { prunedCalls++ },
+		OnCompressed:    func(_, _ []Record) { compressedCalls++ },
+		OnCycleComplete: func(_ CycleMetrics) { cycleCalls++ },
+	}
+	h2 := Hooks{
+		OnPruned:        func(_ []Record) { prunedCalls++ },
+		OnCycleComplete: func(_ CycleMetrics) { cycleCalls++ },
+	}
+	h3 := Hooks{} // all nil
+
+	composed := ComposeHooks(h1, h2, h3)
+
+	composed.OnPruned(nil)
+	assert.Equal(t, 2, prunedCalls)
+
+	composed.OnCompressed(nil, nil)
+	assert.Equal(t, 1, compressedCalls)
+
+	composed.OnCycleComplete(CycleMetrics{})
+	assert.Equal(t, 2, cycleCalls)
+}

--- a/memory/consolidation/worker.go
+++ b/memory/consolidation/worker.go
@@ -1,0 +1,304 @@
+package consolidation
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+const (
+	// defaultInterval is the default consolidation cycle interval.
+	defaultInterval = 1 * time.Hour
+
+	// defaultMaxRecords is the default maximum records processed per cycle.
+	defaultMaxRecords = 1000
+)
+
+// workerOptions holds configurable parameters for the Worker.
+type workerOptions struct {
+	interval           time.Duration
+	maxRecordsPerCycle int
+	policy             ConsolidationPolicy
+	compressor         Compressor
+	hooks              Hooks
+}
+
+// Option configures a Worker.
+type Option func(*workerOptions)
+
+// WithInterval sets the consolidation cycle interval. The minimum is 1 second;
+// smaller values are clamped.
+func WithInterval(d time.Duration) Option {
+	return func(o *workerOptions) {
+		if d < time.Second {
+			d = time.Second
+		}
+		o.interval = d
+	}
+}
+
+// WithPolicy sets the consolidation policy used to evaluate records.
+func WithPolicy(p ConsolidationPolicy) Option {
+	return func(o *workerOptions) { o.policy = p }
+}
+
+// WithCompressor sets the compressor used for records marked ActionCompress.
+// If nil, records marked for compression are pruned instead.
+func WithCompressor(c Compressor) Option {
+	return func(o *workerOptions) { o.compressor = c }
+}
+
+// WithMaxRecordsPerCycle limits the number of records evaluated per cycle.
+func WithMaxRecordsPerCycle(n int) Option {
+	return func(o *workerOptions) {
+		if n > 0 {
+			o.maxRecordsPerCycle = n
+		}
+	}
+}
+
+// WithHooks attaches lifecycle hooks to the worker.
+func WithHooks(h Hooks) Option {
+	return func(o *workerOptions) { o.hooks = h }
+}
+
+// Worker runs periodic consolidation cycles against a ConsolidationStore.
+// It implements core.Lifecycle for integration with the application lifecycle
+// manager.
+type Worker struct {
+	store ConsolidationStore
+	opts  workerOptions
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	running bool
+	health  core.HealthStatus
+}
+
+// Compile-time interface check.
+var _ core.Lifecycle = (*Worker)(nil)
+
+// NewWorker creates a consolidation worker that operates on the given store.
+// A default ThresholdPolicy is used if none is provided via WithPolicy.
+func NewWorker(store ConsolidationStore, opts ...Option) *Worker {
+	o := workerOptions{
+		interval:           defaultInterval,
+		maxRecordsPerCycle: defaultMaxRecords,
+		policy:             NewThresholdPolicy(),
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return &Worker{
+		store: store,
+		opts:  o,
+		health: core.HealthStatus{
+			Status:    core.HealthUnhealthy,
+			Message:   "not started",
+			Timestamp: time.Now(),
+		},
+	}
+}
+
+// Start begins the consolidation loop. It blocks until the worker is ready
+// and returns immediately; the loop runs in a background goroutine.
+func (w *Worker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.running {
+		return fmt.Errorf("consolidation: worker already running")
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	w.done = make(chan struct{})
+	w.running = true
+	w.health = core.HealthStatus{
+		Status:    core.HealthHealthy,
+		Message:   "running",
+		Timestamp: time.Now(),
+	}
+
+	go w.loop(loopCtx)
+	return nil
+}
+
+// Stop gracefully shuts down the worker and waits for the current cycle
+// to finish.
+func (w *Worker) Stop(ctx context.Context) error {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	w.cancel()
+	done := w.done
+	w.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	w.mu.Lock()
+	w.running = false
+	w.health = core.HealthStatus{
+		Status:    core.HealthUnhealthy,
+		Message:   "stopped",
+		Timestamp: time.Now(),
+	}
+	w.mu.Unlock()
+	return nil
+}
+
+// Health returns the current health status of the worker.
+func (w *Worker) Health() core.HealthStatus {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.health
+}
+
+// loop runs the ticker+jitter consolidation cycle until ctx is cancelled.
+func (w *Worker) loop(ctx context.Context) {
+	defer close(w.done)
+
+	ticker := time.NewTicker(w.opts.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Add jitter: up to 10% of interval.
+			jitter := w.jitter(w.opts.interval / 10)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(jitter):
+			}
+
+			metrics := w.runCycle(ctx)
+
+			w.mu.Lock()
+			if len(metrics.Errors) > 0 {
+				w.health = core.HealthStatus{
+					Status:    core.HealthDegraded,
+					Message:   fmt.Sprintf("cycle completed with %d errors", len(metrics.Errors)),
+					Timestamp: time.Now(),
+				}
+			} else {
+				w.health = core.HealthStatus{
+					Status:    core.HealthHealthy,
+					Message:   fmt.Sprintf("cycle ok: evaluated=%d pruned=%d compressed=%d", metrics.RecordsEvaluated, metrics.RecordsPruned, metrics.RecordsCompressed),
+					Timestamp: time.Now(),
+				}
+			}
+			w.mu.Unlock()
+
+			if w.opts.hooks.OnCycleComplete != nil {
+				w.opts.hooks.OnCycleComplete(metrics)
+			}
+		}
+	}
+}
+
+// runCycle executes a single consolidation cycle.
+func (w *Worker) runCycle(ctx context.Context) CycleMetrics {
+	metrics := CycleMetrics{CycleStart: time.Now()}
+
+	records, err := w.store.ListRecords(ctx, 0, w.opts.maxRecordsPerCycle)
+	if err != nil {
+		metrics.Errors = append(metrics.Errors, fmt.Errorf("list records: %w", err))
+		metrics.CycleEnd = time.Now()
+		return metrics
+	}
+
+	if len(records) == 0 {
+		metrics.CycleEnd = time.Now()
+		return metrics
+	}
+
+	metrics.RecordsEvaluated = len(records)
+
+	decisions, err := w.opts.policy.Evaluate(ctx, records)
+	if err != nil {
+		metrics.Errors = append(metrics.Errors, fmt.Errorf("evaluate: %w", err))
+		metrics.CycleEnd = time.Now()
+		return metrics
+	}
+
+	var toPrune []Record
+	var toCompress []Record
+	for _, d := range decisions {
+		switch d.Action {
+		case ActionPrune:
+			toPrune = append(toPrune, d.Record)
+		case ActionCompress:
+			toCompress = append(toCompress, d.Record)
+		}
+	}
+
+	// Compress records if a compressor is available; otherwise prune them.
+	if len(toCompress) > 0 {
+		if w.opts.compressor != nil {
+			compressed, err := w.opts.compressor.Compress(ctx, toCompress)
+			if err != nil {
+				metrics.Errors = append(metrics.Errors, fmt.Errorf("compress: %w", err))
+				// Fall back to pruning on compression failure.
+				toPrune = append(toPrune, toCompress...)
+			} else {
+				if err := w.store.UpdateRecords(ctx, compressed); err != nil {
+					metrics.Errors = append(metrics.Errors, fmt.Errorf("update compressed: %w", err))
+				} else {
+					metrics.RecordsCompressed = len(compressed)
+					if w.opts.hooks.OnCompressed != nil {
+						w.opts.hooks.OnCompressed(toCompress, compressed)
+					}
+				}
+			}
+		} else {
+			toPrune = append(toPrune, toCompress...)
+		}
+	}
+
+	// Prune records.
+	if len(toPrune) > 0 {
+		ids := make([]string, len(toPrune))
+		for i, r := range toPrune {
+			ids[i] = r.ID
+		}
+		if err := w.store.DeleteRecords(ctx, ids); err != nil {
+			metrics.Errors = append(metrics.Errors, fmt.Errorf("delete: %w", err))
+		} else {
+			metrics.RecordsPruned = len(toPrune)
+			if w.opts.hooks.OnPruned != nil {
+				w.opts.hooks.OnPruned(toPrune)
+			}
+		}
+	}
+
+	metrics.CycleEnd = time.Now()
+	return metrics
+}
+
+// jitter returns a random duration in [0, max) using crypto/rand.
+func (w *Worker) jitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return max / 2 // fallback to half on error
+	}
+	return time.Duration(n.Int64())
+}

--- a/memory/consolidation/worker.go
+++ b/memory/consolidation/worker.go
@@ -117,7 +117,12 @@ func (w *Worker) Start(ctx context.Context) error {
 		return fmt.Errorf("consolidation: worker already running")
 	}
 
-	loopCtx, cancel := context.WithCancel(ctx)
+	// The worker daemon runs until Stop() is explicitly called. The ctx
+	// parameter is only valid for Start initialisation; we derive the loop
+	// context from context.Background() so request-scoped or timed
+	// contexts cannot prematurely terminate the background loop.
+	_ = ctx
+	loopCtx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	w.done = make(chan struct{})
 	w.running = true
@@ -181,10 +186,12 @@ func (w *Worker) loop(ctx context.Context) {
 		case <-ticker.C:
 			// Add jitter: up to 10% of interval.
 			jitter := w.jitter(w.opts.interval / 10)
+			jitterTimer := time.NewTimer(jitter)
 			select {
 			case <-ctx.Done():
+				jitterTimer.Stop()
 				return
-			case <-time.After(jitter):
+			case <-jitterTimer.C:
 			}
 
 			metrics := w.runCycle(ctx)

--- a/memory/consolidation/worker_test.go
+++ b/memory/consolidation/worker_test.go
@@ -1,0 +1,242 @@
+package consolidation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorker_StartStop(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+	w := NewWorker(store, WithInterval(time.Second))
+
+	ctx := context.Background()
+	err := w.Start(ctx)
+	require.NoError(t, err)
+
+	health := w.Health()
+	assert.Equal(t, core.HealthHealthy, health.Status)
+
+	err = w.Stop(ctx)
+	require.NoError(t, err)
+
+	health = w.Health()
+	assert.Equal(t, core.HealthUnhealthy, health.Status)
+	assert.Equal(t, "stopped", health.Message)
+}
+
+func TestWorker_DoubleStart(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+	w := NewWorker(store, WithInterval(time.Second))
+
+	ctx := context.Background()
+	require.NoError(t, w.Start(ctx))
+	defer func() { _ = w.Stop(ctx) }()
+
+	err := w.Start(ctx)
+	assert.Error(t, err)
+}
+
+func TestWorker_StopWithoutStart(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+	w := NewWorker(store)
+
+	err := w.Stop(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWorker_RunCycle_Prune(t *testing.T) {
+	now := time.Now()
+	store := newTestStore(
+		Record{ID: "keep", CreatedAt: now, Utility: UtilityScore{Importance: 1.0, Relevance: 1.0, EmotionalSalience: 1.0}},
+		Record{ID: "prune", CreatedAt: now.Add(-365 * 24 * time.Hour), Utility: UtilityScore{}},
+	)
+
+	var prunedIDs []string
+	hooks := Hooks{
+		OnPruned: func(records []Record) {
+			for _, r := range records {
+				prunedIDs = append(prunedIDs, r.ID)
+			}
+		},
+	}
+
+	w := NewWorker(store, WithHooks(hooks))
+	metrics := w.runCycle(context.Background())
+
+	assert.Equal(t, 2, metrics.RecordsEvaluated)
+	assert.GreaterOrEqual(t, metrics.RecordsPruned, 1)
+	assert.Contains(t, prunedIDs, "prune")
+	assert.NotContains(t, prunedIDs, "keep")
+	assert.Empty(t, metrics.Errors)
+
+	// Verify pruned record is gone from store.
+	assert.Equal(t, 1, store.Len())
+	_, ok := store.Get("keep")
+	assert.True(t, ok)
+	_, ok = store.Get("prune")
+	assert.False(t, ok)
+}
+
+func TestWorker_RunCycle_Compress(t *testing.T) {
+	now := time.Now()
+	store := newTestStore(
+		Record{ID: "compress-me", CreatedAt: now, Content: "long content", Utility: UtilityScore{
+			Importance: 0.1, Relevance: 0.1, EmotionalSalience: 0.1,
+		}},
+	)
+
+	policy := &ThresholdPolicy{
+		Threshold:         0.5,
+		CompressThreshold: 0.2,
+		Weights:           DefaultWeights(),
+	}
+
+	compressor := NewSummaryCompressor(&mockChatModel{response: "compressed"})
+
+	var compressedCount int
+	hooks := Hooks{
+		OnCompressed: func(_, _ []Record) {
+			compressedCount++
+		},
+	}
+
+	w := NewWorker(store,
+		WithPolicy(policy),
+		WithCompressor(compressor),
+		WithHooks(hooks),
+	)
+
+	metrics := w.runCycle(context.Background())
+	assert.Equal(t, 1, metrics.RecordsEvaluated)
+	assert.Equal(t, 1, metrics.RecordsCompressed)
+	assert.Equal(t, 1, compressedCount)
+	assert.Empty(t, metrics.Errors)
+
+	// Verify content was updated in store.
+	r, ok := store.Get("compress-me")
+	require.True(t, ok)
+	assert.Equal(t, "compressed", r.Content)
+}
+
+func TestWorker_RunCycle_CompressFallbackToPrune(t *testing.T) {
+	now := time.Now()
+	store := newTestStore(
+		Record{ID: "no-compressor", CreatedAt: now, Utility: UtilityScore{
+			Importance: 0.1, Relevance: 0.1, EmotionalSalience: 0.1,
+		}},
+	)
+
+	policy := &ThresholdPolicy{
+		Threshold:         0.5,
+		CompressThreshold: 0.2,
+		Weights:           DefaultWeights(),
+	}
+
+	// No compressor set, so compress actions should fall back to prune.
+	w := NewWorker(store, WithPolicy(policy))
+	metrics := w.runCycle(context.Background())
+
+	assert.Equal(t, 1, metrics.RecordsPruned)
+	assert.Equal(t, 0, metrics.RecordsCompressed)
+	assert.Equal(t, 0, store.Len())
+}
+
+func TestWorker_RunCycle_EmptyStore(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+	w := NewWorker(store)
+
+	metrics := w.runCycle(context.Background())
+	assert.Equal(t, 0, metrics.RecordsEvaluated)
+	assert.Empty(t, metrics.Errors)
+}
+
+func TestWorker_RunCycle_ContextCancelled(t *testing.T) {
+	now := time.Now()
+	store := newTestStore(
+		Record{ID: "a", CreatedAt: now},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	w := NewWorker(store)
+	metrics := w.runCycle(ctx)
+
+	// Should get an error from the cancelled context.
+	assert.NotEmpty(t, metrics.Errors)
+}
+
+func TestWorker_ContextCancelledStopsLoop(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+	w := NewWorker(store, WithInterval(time.Second))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, w.Start(ctx))
+	cancel()
+
+	// Give the goroutine time to exit.
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop should work cleanly even after context cancellation.
+	err := w.Stop(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestWorker_Options(t *testing.T) {
+	store := NewInMemoryConsolidationStore()
+
+	t.Run("WithInterval clamps minimum", func(t *testing.T) {
+		w := NewWorker(store, WithInterval(time.Millisecond))
+		assert.Equal(t, time.Second, w.opts.interval)
+	})
+
+	t.Run("WithMaxRecordsPerCycle", func(t *testing.T) {
+		w := NewWorker(store, WithMaxRecordsPerCycle(42))
+		assert.Equal(t, 42, w.opts.maxRecordsPerCycle)
+	})
+
+	t.Run("WithMaxRecordsPerCycle ignores zero", func(t *testing.T) {
+		w := NewWorker(store, WithMaxRecordsPerCycle(0))
+		assert.Equal(t, defaultMaxRecords, w.opts.maxRecordsPerCycle)
+	})
+}
+
+func TestWorker_LifecycleInterface(t *testing.T) {
+	var lc core.Lifecycle = NewWorker(NewInMemoryConsolidationStore())
+	_ = lc
+}
+
+func TestWorker_HooksIntegration(t *testing.T) {
+	now := time.Now()
+	store := newTestStore(
+		Record{ID: "old", CreatedAt: now.Add(-365 * 24 * time.Hour), Utility: UtilityScore{}},
+	)
+
+	var cycleMetrics CycleMetrics
+	hooks := Hooks{
+		OnCycleComplete: func(m CycleMetrics) {
+			cycleMetrics = m
+		},
+	}
+
+	w := NewWorker(store, WithHooks(hooks))
+
+	// runCycle calls OnCycleComplete via the hook in the worker loop,
+	// but runCycle itself does not call it. We call it manually here
+	// to test the hook mechanism.
+	metrics := w.runCycle(context.Background())
+
+	// OnCycleComplete is called from the loop, not runCycle directly,
+	// so we invoke it ourselves.
+	if w.opts.hooks.OnCycleComplete != nil {
+		w.opts.hooks.OnCycleComplete(metrics)
+	}
+
+	assert.Equal(t, 1, cycleMetrics.RecordsEvaluated)
+	assert.GreaterOrEqual(t, cycleMetrics.RecordsPruned, 1)
+}


### PR DESCRIPTION
## Summary
- memory/consolidation package, UtilityScore composite, Threshold/Frequency/Composite policies, core.Lifecycle Worker with jitter

## Linear
- LOO-18: https://linear.app/lookatitude/issue/LOO-18

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)