### PR TITLE
LOO-23: Late Interaction Retrieval Models (ColBERT/ColPali)

### DIFF
--- a/rag/embedding/multivector.go
+++ b/rag/embedding/multivector.go
@@ -1,0 +1,72 @@
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/config"
+)
+
+// MultiVectorEmbedder produces per-token embeddings for late interaction
+// retrieval models such as ColBERT and ColPali. Unlike [Embedder], which
+// produces a single vector per text, MultiVectorEmbedder returns a slice of
+// token-level vectors for each input text.
+//
+// Implementations must be safe for concurrent use.
+type MultiVectorEmbedder interface {
+	// EmbedMulti produces per-token embeddings for a batch of texts. The
+	// returned slice has the same length as texts, where each element is a
+	// slice of token-level float32 vectors.
+	EmbedMulti(ctx context.Context, texts []string) ([][][]float32, error)
+
+	// TokenDimensions returns the dimensionality of the per-token embedding
+	// vectors produced by this embedder.
+	TokenDimensions() int
+}
+
+// MultiVectorFactory creates a MultiVectorEmbedder from a ProviderConfig.
+// Each provider registers a MultiVectorFactory via RegisterMultiVector in its
+// init() function.
+type MultiVectorFactory func(cfg config.ProviderConfig) (MultiVectorEmbedder, error)
+
+var (
+	mvRegistryMu sync.RWMutex
+	mvRegistry   = make(map[string]MultiVectorFactory)
+)
+
+// RegisterMultiVector adds a multi-vector embedder factory to the global
+// registry. It is intended to be called from provider init() functions.
+// Duplicate registrations for the same name silently overwrite the previous
+// factory.
+func RegisterMultiVector(name string, f MultiVectorFactory) {
+	mvRegistryMu.Lock()
+	defer mvRegistryMu.Unlock()
+	mvRegistry[name] = f
+}
+
+// NewMultiVector creates a MultiVectorEmbedder by looking up the provider name
+// in the registry and calling its factory with the given configuration.
+func NewMultiVector(name string, cfg config.ProviderConfig) (MultiVectorEmbedder, error) {
+	mvRegistryMu.RLock()
+	f, ok := mvRegistry[name]
+	mvRegistryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("embedding: unknown multi-vector provider %q (registered: %v)", name, ListMultiVector())
+	}
+	return f(cfg)
+}
+
+// ListMultiVector returns the names of all registered multi-vector embedding
+// providers, sorted alphabetically.
+func ListMultiVector() []string {
+	mvRegistryMu.RLock()
+	defer mvRegistryMu.RUnlock()
+	names := make([]string, 0, len(mvRegistry))
+	for name := range mvRegistry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/rag/embedding/multivector_test.go
+++ b/rag/embedding/multivector_test.go
@@ -1,0 +1,89 @@
+package embedding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/config"
+)
+
+func TestMultiVectorRegistry(t *testing.T) {
+	// Clean up after test to avoid polluting other tests.
+	origRegistry := make(map[string]MultiVectorFactory)
+	mvRegistryMu.Lock()
+	for k, v := range mvRegistry {
+		origRegistry[k] = v
+	}
+	mvRegistryMu.Unlock()
+	t.Cleanup(func() {
+		mvRegistryMu.Lock()
+		mvRegistry = origRegistry
+		mvRegistryMu.Unlock()
+	})
+
+	t.Run("register and list", func(t *testing.T) {
+		RegisterMultiVector("test-mv", func(_ config.ProviderConfig) (MultiVectorEmbedder, error) {
+			return nil, nil
+		})
+		names := ListMultiVector()
+		found := false
+		for _, n := range names {
+			if n == "test-mv" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("registered provider 'test-mv' not found in List(): %v", names)
+		}
+	})
+
+	t.Run("new unknown provider", func(t *testing.T) {
+		_, err := NewMultiVector("nonexistent", config.ProviderConfig{})
+		if err == nil {
+			t.Fatal("expected error for unknown provider")
+		}
+	})
+
+	t.Run("new known provider", func(t *testing.T) {
+		RegisterMultiVector("test-mv-ok", func(_ config.ProviderConfig) (MultiVectorEmbedder, error) {
+			return &stubMultiVectorEmbedder{}, nil
+		})
+		emb, err := NewMultiVector("test-mv-ok", config.ProviderConfig{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if emb == nil {
+			t.Fatal("expected non-nil embedder")
+		}
+	})
+
+	t.Run("list is sorted", func(t *testing.T) {
+		RegisterMultiVector("zzz", func(_ config.ProviderConfig) (MultiVectorEmbedder, error) {
+			return nil, nil
+		})
+		RegisterMultiVector("aaa", func(_ config.ProviderConfig) (MultiVectorEmbedder, error) {
+			return nil, nil
+		})
+		names := ListMultiVector()
+		for i := 1; i < len(names); i++ {
+			if names[i] < names[i-1] {
+				t.Errorf("list not sorted: %v", names)
+				break
+			}
+		}
+	})
+}
+
+// stubMultiVectorEmbedder is a minimal test stub.
+type stubMultiVectorEmbedder struct{}
+
+func (s *stubMultiVectorEmbedder) EmbedMulti(_ context.Context, texts []string) ([][][]float32, error) {
+	result := make([][][]float32, len(texts))
+	for i := range texts {
+		result[i] = [][]float32{{1, 0, 0}}
+	}
+	return result, nil
+}
+
+func (s *stubMultiVectorEmbedder) TokenDimensions() int { return 3 }

--- a/rag/retriever/colbert/doc.go
+++ b/rag/retriever/colbert/doc.go
@@ -1,0 +1,42 @@
+// Package colbert implements a ColBERT-style late interaction retriever for
+// the Beluga AI RAG pipeline.
+//
+// Late interaction models like ColBERT and ColPali produce per-token embeddings
+// and compute relevance via MaxSim: for each query token, the maximum cosine
+// similarity across all document tokens is found, then these per-token
+// maximums are summed to produce the final score. This preserves fine-grained
+// token-level matching while remaining efficient through pre-computed document
+// embeddings.
+//
+// # Architecture
+//
+// The package provides three components:
+//
+//   - [MaxSimScorer] — computes the MaxSim score between query and document
+//     token embeddings.
+//   - [ColBERTIndex] — stores pre-computed per-token document embeddings and
+//     supports search by MaxSim scoring. [NewInMemoryIndex] provides a
+//     brute-force thread-safe implementation.
+//   - [ColBERTRetriever] — implements [retriever.Retriever] by encoding queries
+//     with a [embedding.MultiVectorEmbedder] and searching a [ColBERTIndex].
+//
+// # Registry
+//
+// The retriever is registered as "colbert" with the retriever registry. Import
+// this package with a blank import to make it available:
+//
+//	import _ "github.com/lookatitude/beluga-ai/rag/retriever/colbert"
+//
+// # Usage
+//
+//	idx := colbert.NewInMemoryIndex()
+//	_ = idx.Add(ctx, "doc1", doc1TokenVecs)
+//	_ = idx.Add(ctx, "doc2", doc2TokenVecs)
+//
+//	r := colbert.NewColBERTRetriever(
+//	    colbert.WithEmbedder(multiVecEmbedder),
+//	    colbert.WithIndex(idx),
+//	    colbert.WithTopK(5),
+//	)
+//	docs, err := r.Retrieve(ctx, "what is late interaction?")
+package colbert

--- a/rag/retriever/colbert/doc.go
+++ b/rag/retriever/colbert/doc.go
@@ -33,10 +33,13 @@
 //	_ = idx.Add(ctx, "doc1", doc1TokenVecs)
 //	_ = idx.Add(ctx, "doc2", doc2TokenVecs)
 //
-//	r := colbert.NewColBERTRetriever(
+//	r, err := colbert.NewColBERTRetriever(
 //	    colbert.WithEmbedder(multiVecEmbedder),
 //	    colbert.WithIndex(idx),
 //	    colbert.WithTopK(5),
 //	)
+//	if err != nil {
+//	    // handle error
+//	}
 //	docs, err := r.Retrieve(ctx, "what is late interaction?")
 package colbert

--- a/rag/retriever/colbert/index.go
+++ b/rag/retriever/colbert/index.go
@@ -1,0 +1,125 @@
+package colbert
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// IndexResult represents a document match from a ColBERT index search,
+// carrying the document ID and its MaxSim relevance score.
+type IndexResult struct {
+	// ID is the unique identifier of the matched document.
+	ID string
+	// Score is the MaxSim score for this document against the query.
+	Score float64
+}
+
+// ColBERTIndex stores pre-computed per-token document embeddings and supports
+// search by MaxSim scoring. Implementations must be safe for concurrent use.
+type ColBERTIndex interface {
+	// Add stores per-token embeddings for a document. If a document with the
+	// same ID already exists, its embeddings are replaced.
+	Add(ctx context.Context, id string, tokenVecs [][]float32) error
+
+	// Search finds the top-k documents most similar to the query token
+	// vectors, scored by MaxSim. Results are ordered by decreasing score.
+	Search(ctx context.Context, queryVecs [][]float32, k int) ([]IndexResult, error)
+}
+
+// indexEntry holds a document's pre-computed token embeddings.
+type indexEntry struct {
+	id        string
+	tokenVecs [][]float32
+}
+
+// InMemoryIndex is a brute-force ColBERTIndex that stores all document token
+// embeddings in memory and computes MaxSim over every document at search time.
+// It is thread-safe and intended for testing and small-scale usage.
+type InMemoryIndex struct {
+	mu      sync.RWMutex
+	entries map[string]*indexEntry
+}
+
+// Compile-time check that InMemoryIndex implements ColBERTIndex.
+var _ ColBERTIndex = (*InMemoryIndex)(nil)
+
+// NewInMemoryIndex creates a new empty InMemoryIndex.
+func NewInMemoryIndex() *InMemoryIndex {
+	return &InMemoryIndex{
+		entries: make(map[string]*indexEntry),
+	}
+}
+
+// Add stores per-token embeddings for a document. If a document with the same
+// ID already exists, its embeddings are replaced. Returns an error if id is
+// empty or tokenVecs is nil.
+func (idx *InMemoryIndex) Add(ctx context.Context, id string, tokenVecs [][]float32) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if id == "" {
+		return fmt.Errorf("colbert: index: document ID must not be empty")
+	}
+	if tokenVecs == nil {
+		return fmt.Errorf("colbert: index: tokenVecs must not be nil for document %q", id)
+	}
+
+	// Deep copy to avoid caller mutations.
+	copied := make([][]float32, len(tokenVecs))
+	for i, tv := range tokenVecs {
+		c := make([]float32, len(tv))
+		copy(c, tv)
+		copied[i] = c
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.entries[id] = &indexEntry{id: id, tokenVecs: copied}
+	return nil
+}
+
+// Search finds the top-k documents most similar to queryVecs by MaxSim score.
+// Results are ordered by decreasing score. Returns at most k results.
+func (idx *InMemoryIndex) Search(ctx context.Context, queryVecs [][]float32, k int) ([]IndexResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+
+	idx.mu.RLock()
+	// Snapshot entries under lock.
+	snapshot := make([]*indexEntry, 0, len(idx.entries))
+	for _, e := range idx.entries {
+		snapshot = append(snapshot, e)
+	}
+	idx.mu.RUnlock()
+
+	results := make([]IndexResult, 0, len(snapshot))
+	for _, e := range snapshot {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		score := MaxSim(queryVecs, e.tokenVecs)
+		results = append(results, IndexResult{ID: e.id, Score: score})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	if k < len(results) {
+		results = results[:k]
+	}
+	return results, nil
+}
+
+// Len returns the number of documents in the index.
+func (idx *InMemoryIndex) Len() int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return len(idx.entries)
+}

--- a/rag/retriever/colbert/index_test.go
+++ b/rag/retriever/colbert/index_test.go
@@ -1,0 +1,242 @@
+package colbert
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestInMemoryIndex_Add(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		id        string
+		tokenVecs [][]float32
+		wantErr   bool
+	}{
+		{
+			name:      "valid add",
+			id:        "doc1",
+			tokenVecs: [][]float32{{1, 0, 0}, {0, 1, 0}},
+		},
+		{
+			name:      "empty token vecs slice",
+			id:        "doc2",
+			tokenVecs: [][]float32{},
+		},
+		{
+			name:    "empty id",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:    "nil token vecs",
+			id:      "doc3",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := NewInMemoryIndex()
+			err := idx.Add(ctx, tt.id, tt.tokenVecs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if idx.Len() != 1 {
+				t.Errorf("Len() = %d, want 1", idx.Len())
+			}
+		})
+	}
+}
+
+func TestInMemoryIndex_AddReplace(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	if err := idx.Add(ctx, "doc1", [][]float32{{1, 0}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idx.Add(ctx, "doc1", [][]float32{{0, 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if idx.Len() != 1 {
+		t.Errorf("Len() = %d after replace, want 1", idx.Len())
+	}
+}
+
+func TestInMemoryIndex_AddDeepCopy(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	vecs := [][]float32{{1, 2, 3}}
+	if err := idx.Add(ctx, "doc1", vecs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate the original — should not affect stored data.
+	vecs[0][0] = 999
+
+	results, err := idx.Search(ctx, [][]float32{{1, 2, 3}}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	// Score should reflect the original {1,2,3} not the mutated {999,2,3}.
+	resultsOriginal, _ := idx.Search(ctx, [][]float32{{999, 2, 3}}, 1)
+	if results[0].Score <= resultsOriginal[0].Score {
+		t.Error("deep copy failed: mutation affected stored data")
+	}
+}
+
+func TestInMemoryIndex_Search(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	// Add three documents with distinct token embeddings.
+	_ = idx.Add(ctx, "docA", [][]float32{{1, 0, 0}})
+	_ = idx.Add(ctx, "docB", [][]float32{{0, 1, 0}})
+	_ = idx.Add(ctx, "docC", [][]float32{{0, 0, 1}})
+
+	tests := []struct {
+		name     string
+		query    [][]float32
+		k        int
+		wantIDs  []string
+		wantLen  int
+		wantZero bool
+	}{
+		{
+			name:    "exact match returns top doc",
+			query:   [][]float32{{1, 0, 0}},
+			k:       1,
+			wantIDs: []string{"docA"},
+			wantLen: 1,
+		},
+		{
+			name:    "top 2",
+			query:   [][]float32{{1, 0, 0}},
+			k:       2,
+			wantLen: 2,
+		},
+		{
+			name:    "k larger than index",
+			query:   [][]float32{{1, 0, 0}},
+			k:       10,
+			wantLen: 3,
+		},
+		{
+			name:     "k zero returns nil",
+			query:    [][]float32{{1, 0, 0}},
+			k:        0,
+			wantZero: true,
+		},
+		{
+			name:     "k negative returns nil",
+			query:    [][]float32{{1, 0, 0}},
+			k:        -1,
+			wantZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := idx.Search(ctx, tt.query, tt.k)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantZero {
+				if results != nil {
+					t.Errorf("expected nil results, got %v", results)
+				}
+				return
+			}
+			if len(results) != tt.wantLen {
+				t.Fatalf("got %d results, want %d", len(results), tt.wantLen)
+			}
+			for i, wantID := range tt.wantIDs {
+				if results[i].ID != wantID {
+					t.Errorf("result[%d].ID = %q, want %q", i, results[i].ID, wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestInMemoryIndex_SearchOrdering(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	_ = idx.Add(ctx, "best", [][]float32{{1, 0, 0}})
+	_ = idx.Add(ctx, "mid", [][]float32{{0.7, 0.7, 0}})
+	_ = idx.Add(ctx, "worst", [][]float32{{0, 1, 0}})
+
+	results, err := idx.Search(ctx, [][]float32{{1, 0, 0}}, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	// Scores should be in descending order.
+	for i := 1; i < len(results); i++ {
+		if results[i].Score > results[i-1].Score {
+			t.Errorf("results not in descending order: [%d].Score=%f > [%d].Score=%f",
+				i, results[i].Score, i-1, results[i-1].Score)
+		}
+	}
+	if results[0].ID != "best" {
+		t.Errorf("best match ID = %q, want %q", results[0].ID, "best")
+	}
+}
+
+func TestInMemoryIndex_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	idx := NewInMemoryIndex()
+
+	// Add should fail with cancelled context.
+	if err := idx.Add(ctx, "doc1", [][]float32{{1, 0}}); err == nil {
+		t.Error("expected error from cancelled context on Add")
+	}
+
+	// Search should fail with cancelled context.
+	if _, err := idx.Search(ctx, [][]float32{{1, 0}}, 1); err == nil {
+		t.Error("expected error from cancelled context on Search")
+	}
+}
+
+func TestInMemoryIndex_ConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	var wg sync.WaitGroup
+	// Concurrent writes.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := string(rune('A' + i%26))
+			_ = idx.Add(ctx, id, [][]float32{{float32(i), 0, 0}})
+		}(i)
+	}
+	// Concurrent reads.
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = idx.Search(ctx, [][]float32{{1, 0, 0}}, 5)
+		}()
+	}
+	wg.Wait()
+}

--- a/rag/retriever/colbert/retriever.go
+++ b/rag/retriever/colbert/retriever.go
@@ -87,13 +87,18 @@ func NewColBERTRetriever(opts ...ColBERTOption) (*ColBERTRetriever, error) {
 // returned in decreasing order of relevance.
 func (r *ColBERTRetriever) Retrieve(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
 	cfg := retriever.ApplyOptions(opts...)
-	topK := cfg.TopK
-	if topK == 0 || topK > r.topK {
-		topK = r.topK
+	// Prefer the per-call TopK when explicitly positive; only fall back to the
+	// retriever's configured default when no usable value was provided.
+	topK := r.topK
+	if cfg.TopK > 0 {
+		topK = cfg.TopK
 	}
 
 	if r.hooks.BeforeRetrieve != nil {
 		if err := r.hooks.BeforeRetrieve(ctx, query); err != nil {
+			if r.hooks.AfterRetrieve != nil {
+				r.hooks.AfterRetrieve(ctx, nil, err)
+			}
 			return nil, err
 		}
 	}
@@ -101,17 +106,29 @@ func (r *ColBERTRetriever) Retrieve(ctx context.Context, query string, opts ...r
 	// Encode query into per-token embeddings.
 	queryEmbeddings, err := r.embedder.EmbedMulti(ctx, []string{query})
 	if err != nil {
-		return nil, fmt.Errorf("colbert: embed query: %w", err)
+		err = fmt.Errorf("colbert: embed query: %w", err)
+		if r.hooks.AfterRetrieve != nil {
+			r.hooks.AfterRetrieve(ctx, nil, err)
+		}
+		return nil, err
 	}
 	if len(queryEmbeddings) == 0 {
-		return nil, fmt.Errorf("colbert: embedder returned no embeddings for query")
+		err := fmt.Errorf("colbert: embedder returned no embeddings for query")
+		if r.hooks.AfterRetrieve != nil {
+			r.hooks.AfterRetrieve(ctx, nil, err)
+		}
+		return nil, err
 	}
 	queryVecs := queryEmbeddings[0]
 
 	// Search the index.
 	results, err := r.index.Search(ctx, queryVecs, topK)
 	if err != nil {
-		return nil, fmt.Errorf("colbert: index search: %w", err)
+		err = fmt.Errorf("colbert: index search: %w", err)
+		if r.hooks.AfterRetrieve != nil {
+			r.hooks.AfterRetrieve(ctx, nil, err)
+		}
+		return nil, err
 	}
 
 	// Convert index results to schema.Document. The index only stores IDs

--- a/rag/retriever/colbert/retriever.go
+++ b/rag/retriever/colbert/retriever.go
@@ -1,0 +1,136 @@
+package colbert
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/config"
+	"github.com/lookatitude/beluga-ai/rag/embedding"
+	"github.com/lookatitude/beluga-ai/rag/retriever"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+func init() {
+	retriever.Register("colbert", func(_ config.ProviderConfig) (retriever.Retriever, error) {
+		return nil, fmt.Errorf("colbert: use colbert.NewColBERTRetriever() with WithEmbedder and WithIndex options")
+	})
+}
+
+// ColBERTRetriever implements [retriever.Retriever] using late interaction
+// retrieval. It encodes queries into per-token embeddings via a
+// [embedding.MultiVectorEmbedder] and searches a [ColBERTIndex] using MaxSim
+// scoring.
+type ColBERTRetriever struct {
+	embedder embedding.MultiVectorEmbedder
+	index    ColBERTIndex
+	topK     int
+	hooks    retriever.Hooks
+}
+
+// Compile-time check that ColBERTRetriever implements retriever.Retriever.
+var _ retriever.Retriever = (*ColBERTRetriever)(nil)
+
+// ColBERTOption configures a ColBERTRetriever.
+type ColBERTOption func(*ColBERTRetriever)
+
+// WithEmbedder sets the multi-vector embedder used to encode queries into
+// per-token embeddings.
+func WithEmbedder(e embedding.MultiVectorEmbedder) ColBERTOption {
+	return func(r *ColBERTRetriever) {
+		r.embedder = e
+	}
+}
+
+// WithIndex sets the ColBERT index used to search pre-indexed document
+// embeddings.
+func WithIndex(idx ColBERTIndex) ColBERTOption {
+	return func(r *ColBERTRetriever) {
+		r.index = idx
+	}
+}
+
+// WithTopK sets the default maximum number of documents to return. This can be
+// overridden per-call via [retriever.WithTopK].
+func WithTopK(k int) ColBERTOption {
+	return func(r *ColBERTRetriever) {
+		r.topK = k
+	}
+}
+
+// WithHooks sets retriever hooks on the ColBERTRetriever.
+func WithHooks(h retriever.Hooks) ColBERTOption {
+	return func(r *ColBERTRetriever) {
+		r.hooks = h
+	}
+}
+
+// NewColBERTRetriever creates a new ColBERT-style late interaction retriever.
+// At minimum, [WithEmbedder] and [WithIndex] must be provided.
+func NewColBERTRetriever(opts ...ColBERTOption) (*ColBERTRetriever, error) {
+	r := &ColBERTRetriever{
+		topK: 10,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	if r.embedder == nil {
+		return nil, fmt.Errorf("colbert: embedder is required (use WithEmbedder)")
+	}
+	if r.index == nil {
+		return nil, fmt.Errorf("colbert: index is required (use WithIndex)")
+	}
+	return r, nil
+}
+
+// Retrieve encodes the query into per-token embeddings and searches the
+// ColBERT index for the most similar documents by MaxSim score. Results are
+// returned in decreasing order of relevance.
+func (r *ColBERTRetriever) Retrieve(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+	cfg := retriever.ApplyOptions(opts...)
+	topK := cfg.TopK
+	if topK == 0 || topK > r.topK {
+		topK = r.topK
+	}
+
+	if r.hooks.BeforeRetrieve != nil {
+		if err := r.hooks.BeforeRetrieve(ctx, query); err != nil {
+			return nil, err
+		}
+	}
+
+	// Encode query into per-token embeddings.
+	queryEmbeddings, err := r.embedder.EmbedMulti(ctx, []string{query})
+	if err != nil {
+		return nil, fmt.Errorf("colbert: embed query: %w", err)
+	}
+	if len(queryEmbeddings) == 0 {
+		return nil, fmt.Errorf("colbert: embedder returned no embeddings for query")
+	}
+	queryVecs := queryEmbeddings[0]
+
+	// Search the index.
+	results, err := r.index.Search(ctx, queryVecs, topK)
+	if err != nil {
+		return nil, fmt.Errorf("colbert: index search: %w", err)
+	}
+
+	// Convert index results to schema.Document. The index only stores IDs
+	// and scores; content must be populated by a downstream enrichment step
+	// or by the caller.
+	docs := make([]schema.Document, 0, len(results))
+	for _, res := range results {
+		if cfg.Threshold > 0 && res.Score < cfg.Threshold {
+			continue
+		}
+		docs = append(docs, schema.Document{
+			ID:    res.ID,
+			Score: res.Score,
+		})
+	}
+
+	if r.hooks.AfterRetrieve != nil {
+		r.hooks.AfterRetrieve(ctx, docs, nil)
+	}
+
+	return docs, nil
+}

--- a/rag/retriever/colbert/retriever_test.go
+++ b/rag/retriever/colbert/retriever_test.go
@@ -109,7 +109,7 @@ func TestColBERTRetriever_Retrieve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	docs, err := r.Retrieve(ctx, "what is Go?")
+	docs, err := r.Retrieve(ctx, "what is Go?", retriever.WithTopK(2))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -247,6 +247,79 @@ func TestColBERTRetriever_Hooks(t *testing.T) {
 	}
 	if !afterCalled {
 		t.Error("AfterRetrieve hook was not called")
+	}
+}
+
+func TestColBERTRetriever_PerCallTopKOverride(t *testing.T) {
+	ctx := context.Background()
+
+	idx := NewInMemoryIndex()
+	for i, id := range []string{"a", "b", "c", "d", "e"} {
+		_ = idx.Add(ctx, id, [][]float32{{float32(i + 1), 0, 0}})
+	}
+
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, _ []string) ([][][]float32, error) {
+			return [][][]float32{{{1, 0, 0}}}, nil
+		},
+	}
+
+	// Retriever configured with TopK=2 but caller requests 4.
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+		WithTopK(2),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	docs, err := r.Retrieve(ctx, "query", retriever.WithTopK(4))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 4 {
+		t.Fatalf("per-call topK override: got %d docs, want 4", len(docs))
+	}
+}
+
+func TestColBERTRetriever_AfterHookOnErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	embErr := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, _ []string) ([][][]float32, error) {
+			return nil, fmt.Errorf("embed boom")
+		},
+	}
+
+	var afterErr error
+	var afterCalled bool
+	r, err := NewColBERTRetriever(
+		WithEmbedder(embErr),
+		WithIndex(idx),
+		WithHooks(retriever.Hooks{
+			AfterRetrieve: func(_ context.Context, _ []schema.Document, e error) {
+				afterCalled = true
+				afterErr = e
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Retrieve(ctx, "q")
+	if err == nil {
+		t.Fatal("expected error from embedder failure")
+	}
+	if !afterCalled {
+		t.Error("AfterRetrieve must be called on embed error path")
+	}
+	if afterErr == nil {
+		t.Error("AfterRetrieve must receive the error")
 	}
 }
 

--- a/rag/retriever/colbert/retriever_test.go
+++ b/rag/retriever/colbert/retriever_test.go
@@ -1,0 +1,276 @@
+package colbert
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/rag/embedding"
+	"github.com/lookatitude/beluga-ai/rag/retriever"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// mockMultiVectorEmbedder is a test double for embedding.MultiVectorEmbedder.
+type mockMultiVectorEmbedder struct {
+	embedMultiFn    func(ctx context.Context, texts []string) ([][][]float32, error)
+	tokenDimensions int
+}
+
+var _ embedding.MultiVectorEmbedder = (*mockMultiVectorEmbedder)(nil)
+
+func (m *mockMultiVectorEmbedder) EmbedMulti(ctx context.Context, texts []string) ([][][]float32, error) {
+	if m.embedMultiFn != nil {
+		return m.embedMultiFn(ctx, texts)
+	}
+	// Default: return single token per text, identity-like vectors.
+	result := make([][][]float32, len(texts))
+	for i := range texts {
+		result[i] = [][]float32{{1, 0, 0}}
+	}
+	return result, nil
+}
+
+func (m *mockMultiVectorEmbedder) TokenDimensions() int {
+	return m.tokenDimensions
+}
+
+func TestNewColBERTRetriever(t *testing.T) {
+	emb := &mockMultiVectorEmbedder{tokenDimensions: 3}
+	idx := NewInMemoryIndex()
+
+	tests := []struct {
+		name    string
+		opts    []ColBERTOption
+		wantErr bool
+	}{
+		{
+			name:    "missing embedder",
+			opts:    []ColBERTOption{WithIndex(idx)},
+			wantErr: true,
+		},
+		{
+			name:    "missing index",
+			opts:    []ColBERTOption{WithEmbedder(emb)},
+			wantErr: true,
+		},
+		{
+			name:    "missing both",
+			opts:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid config",
+			opts: []ColBERTOption{WithEmbedder(emb), WithIndex(idx), WithTopK(5)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewColBERTRetriever(tt.opts...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r == nil {
+				t.Fatal("expected non-nil retriever")
+			}
+		})
+	}
+}
+
+func TestColBERTRetriever_Retrieve(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up index with known documents.
+	idx := NewInMemoryIndex()
+	_ = idx.Add(ctx, "doc-go", [][]float32{{1, 0, 0}, {0.5, 0.5, 0}})
+	_ = idx.Add(ctx, "doc-rust", [][]float32{{0, 1, 0}, {0, 0.5, 0.5}})
+	_ = idx.Add(ctx, "doc-python", [][]float32{{0, 0, 1}, {0.5, 0, 0.5}})
+
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, texts []string) ([][][]float32, error) {
+			// Query embedding: token vectors pointing toward doc-go.
+			return [][][]float32{{{1, 0, 0}}}, nil
+		},
+	}
+
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+		WithTopK(2),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	docs, err := r.Retrieve(ctx, "what is Go?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2", len(docs))
+	}
+	if docs[0].ID != "doc-go" {
+		t.Errorf("top doc = %q, want %q", docs[0].ID, "doc-go")
+	}
+	if docs[0].Score <= docs[1].Score {
+		t.Errorf("expected descending scores: %f <= %f", docs[0].Score, docs[1].Score)
+	}
+}
+
+func TestColBERTRetriever_RetrieveWithThreshold(t *testing.T) {
+	ctx := context.Background()
+
+	idx := NewInMemoryIndex()
+	_ = idx.Add(ctx, "good", [][]float32{{1, 0, 0}})
+	_ = idx.Add(ctx, "bad", [][]float32{{0, 1, 0}}) // orthogonal -> score = 0
+
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, _ []string) ([][][]float32, error) {
+			return [][][]float32{{{1, 0, 0}}}, nil
+		},
+	}
+
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+		WithTopK(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	docs, err := r.Retrieve(ctx, "query", retriever.WithThreshold(0.5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1 (threshold should filter orthogonal)", len(docs))
+	}
+	if docs[0].ID != "good" {
+		t.Errorf("got doc %q, want %q", docs[0].ID, "good")
+	}
+}
+
+func TestColBERTRetriever_EmbedError(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, _ []string) ([][][]float32, error) {
+			return nil, fmt.Errorf("embed failed")
+		},
+	}
+
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Retrieve(ctx, "query")
+	if err == nil {
+		t.Fatal("expected error from embedder failure")
+	}
+}
+
+func TestColBERTRetriever_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	idx := NewInMemoryIndex()
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(ctx context.Context, _ []string) ([][][]float32, error) {
+			return nil, ctx.Err()
+		},
+	}
+
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Retrieve(ctx, "query")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestColBERTRetriever_Hooks(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+	_ = idx.Add(ctx, "doc1", [][]float32{{1, 0, 0}})
+
+	emb := &mockMultiVectorEmbedder{tokenDimensions: 3}
+
+	var beforeCalled, afterCalled bool
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+		WithHooks(retriever.Hooks{
+			BeforeRetrieve: func(_ context.Context, query string) error {
+				beforeCalled = true
+				if query != "test" {
+					return fmt.Errorf("unexpected query: %s", query)
+				}
+				return nil
+			},
+			AfterRetrieve: func(_ context.Context, _ []schema.Document, _ error) {
+				afterCalled = true
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Retrieve(ctx, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !beforeCalled {
+		t.Error("BeforeRetrieve hook was not called")
+	}
+	if !afterCalled {
+		t.Error("AfterRetrieve hook was not called")
+	}
+}
+
+func TestColBERTRetriever_EmptyEmbeddings(t *testing.T) {
+	ctx := context.Background()
+	idx := NewInMemoryIndex()
+
+	emb := &mockMultiVectorEmbedder{
+		tokenDimensions: 3,
+		embedMultiFn: func(_ context.Context, _ []string) ([][][]float32, error) {
+			return [][][]float32{}, nil
+		},
+	}
+
+	r, err := NewColBERTRetriever(
+		WithEmbedder(emb),
+		WithIndex(idx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = r.Retrieve(ctx, "query")
+	if err == nil {
+		t.Fatal("expected error when embedder returns empty embeddings")
+	}
+}

--- a/rag/retriever/colbert/scorer.go
+++ b/rag/retriever/colbert/scorer.go
@@ -1,0 +1,47 @@
+package colbert
+
+import "math"
+
+// MaxSim computes the MaxSim score between query token vectors and document
+// token vectors, as defined in the ColBERT paper. For each query token vector,
+// the maximum cosine similarity across all document token vectors is computed.
+// These per-query-token maximums are then summed to produce the final score.
+//
+// Returns 0 if either queryVecs or docVecs is empty.
+func MaxSim(queryVecs, docVecs [][]float32) float64 {
+	if len(queryVecs) == 0 || len(docVecs) == 0 {
+		return 0
+	}
+	var total float64
+	for _, qv := range queryVecs {
+		var maxSim float64 = -math.MaxFloat64
+		for _, dv := range docVecs {
+			sim := cosineSimilarity(qv, dv)
+			if sim > maxSim {
+				maxSim = sim
+			}
+		}
+		total += maxSim
+	}
+	return total
+}
+
+// cosineSimilarity computes the cosine similarity between two vectors.
+// Returns 0 if either vector has zero magnitude or the vectors have different
+// lengths.
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		ai, bi := float64(a[i]), float64(b[i])
+		dot += ai * bi
+		normA += ai * ai
+		normB += bi * bi
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}

--- a/rag/retriever/colbert/scorer_test.go
+++ b/rag/retriever/colbert/scorer_test.go
@@ -1,0 +1,185 @@
+package colbert
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMaxSim(t *testing.T) {
+	tests := []struct {
+		name      string
+		queryVecs [][]float32
+		docVecs   [][]float32
+		want      float64
+		tolerance float64
+	}{
+		{
+			name:      "empty query vectors",
+			queryVecs: nil,
+			docVecs:   [][]float32{{1, 0, 0}},
+			want:      0,
+		},
+		{
+			name:      "empty doc vectors",
+			queryVecs: [][]float32{{1, 0, 0}},
+			docVecs:   nil,
+			want:      0,
+		},
+		{
+			name:      "both empty",
+			queryVecs: nil,
+			docVecs:   nil,
+			want:      0,
+		},
+		{
+			name:      "identical single token",
+			queryVecs: [][]float32{{1, 0, 0}},
+			docVecs:   [][]float32{{1, 0, 0}},
+			want:      1.0,
+			tolerance: 1e-9,
+		},
+		{
+			name:      "orthogonal single token",
+			queryVecs: [][]float32{{1, 0, 0}},
+			docVecs:   [][]float32{{0, 1, 0}},
+			want:      0.0,
+			tolerance: 1e-9,
+		},
+		{
+			name:      "opposite single token",
+			queryVecs: [][]float32{{1, 0, 0}},
+			docVecs:   [][]float32{{-1, 0, 0}},
+			want:      -1.0,
+			tolerance: 1e-9,
+		},
+		{
+			name: "two query tokens pick best doc token each",
+			queryVecs: [][]float32{
+				{1, 0, 0}, // best match: doc token {1, 0, 0} -> sim=1.0
+				{0, 1, 0}, // best match: doc token {0, 1, 0} -> sim=1.0
+			},
+			docVecs: [][]float32{
+				{1, 0, 0},
+				{0, 1, 0},
+				{0, 0, 1},
+			},
+			want:      2.0, // 1.0 + 1.0
+			tolerance: 1e-9,
+		},
+		{
+			name: "query token matches partial doc token",
+			queryVecs: [][]float32{
+				{1, 1, 0}, // should match {1, 0, 0} or {0, 1, 0} partially
+			},
+			docVecs: [][]float32{
+				{1, 0, 0},
+				{0, 1, 0},
+			},
+			// cos({1,1,0}, {1,0,0}) = 1/sqrt(2) ~ 0.7071
+			// cos({1,1,0}, {0,1,0}) = 1/sqrt(2) ~ 0.7071
+			// max = 0.7071
+			want:      1.0 / math.Sqrt(2),
+			tolerance: 1e-6,
+		},
+		{
+			name: "scaled vectors same direction",
+			queryVecs: [][]float32{
+				{2, 0, 0},
+			},
+			docVecs: [][]float32{
+				{5, 0, 0},
+			},
+			want:      1.0, // cosine similarity is scale-invariant
+			tolerance: 1e-9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MaxSim(tt.queryVecs, tt.docVecs)
+			if tt.tolerance == 0 {
+				if got != tt.want {
+					t.Errorf("MaxSim() = %v, want %v", got, tt.want)
+				}
+			} else {
+				if math.Abs(got-tt.want) > tt.tolerance {
+					t.Errorf("MaxSim() = %v, want %v (tolerance %v)", got, tt.want, tt.tolerance)
+				}
+			}
+		})
+	}
+}
+
+func TestCosineSimilarity(t *testing.T) {
+	tests := []struct {
+		name      string
+		a, b      []float32
+		want      float64
+		tolerance float64
+	}{
+		{
+			name: "different lengths",
+			a:    []float32{1, 0},
+			b:    []float32{1, 0, 0},
+			want: 0,
+		},
+		{
+			name: "empty vectors",
+			a:    nil,
+			b:    nil,
+			want: 0,
+		},
+		{
+			name: "zero vector a",
+			a:    []float32{0, 0, 0},
+			b:    []float32{1, 0, 0},
+			want: 0,
+		},
+		{
+			name:      "unit vectors identical",
+			a:         []float32{0, 1, 0},
+			b:         []float32{0, 1, 0},
+			want:      1.0,
+			tolerance: 1e-9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cosineSimilarity(tt.a, tt.b)
+			if tt.tolerance == 0 {
+				if got != tt.want {
+					t.Errorf("cosineSimilarity() = %v, want %v", got, tt.want)
+				}
+			} else {
+				if math.Abs(got-tt.want) > tt.tolerance {
+					t.Errorf("cosineSimilarity() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMaxSim(b *testing.B) {
+	// Simulate 32 query tokens x 128 doc tokens x 128 dimensions.
+	queryVecs := makeVecs(32, 128)
+	docVecs := makeVecs(128, 128)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		MaxSim(queryVecs, docVecs)
+	}
+}
+
+func makeVecs(n, dim int) [][]float32 {
+	vecs := make([][]float32, n)
+	for i := range vecs {
+		v := make([]float32, dim)
+		for j := range v {
+			v[j] = float32(i+j+1) * 0.01
+		}
+		vecs[i] = v
+	}
+	return vecs
+}

--- a/schema/document.go
+++ b/schema/document.go
@@ -17,4 +17,8 @@ type Document struct {
 	// Embedding is the vector embedding of the document content.
 	// May be nil if the document has not been embedded.
 	Embedding []float32
+	// MultiVectorEmbedding holds per-token embeddings for late interaction
+	// models such as ColBERT. Each element is a token-level vector. Nil for
+	// single-vector documents.
+	MultiVectorEmbedding [][]float32
 }


### PR DESCRIPTION
## Summary
- MultiVectorEmbedder interface, MaxSim scorer, rag/retriever/colbert package, InMemoryIndex

## Linear
- LOO-23: https://linear.app/lookatitude/issue/LOO-23

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)