### PR TITLE
LOO-25: Agentic RAG Orchestration

### DIFF
--- a/rag/retriever/crag.go
+++ b/rag/retriever/crag.go
@@ -146,6 +146,8 @@ func (r *CRAGRetriever) Retrieve(ctx context.Context, query string, opts ...Opti
 		return r.fallbackSearch(ctx, currentQuery, cfg)
 	}
 
+	// Unreachable under normal operation: every iteration of the loop
+	// either returns or continues. Left as a defensive safety net.
 	return r.fallbackSearch(ctx, currentQuery, cfg)
 }
 

--- a/rag/retriever/crag.go
+++ b/rag/retriever/crag.go
@@ -19,14 +19,15 @@ type WebSearcher interface {
 
 // CRAGRetriever implements Corrective RAG. After retrieving documents, it
 // evaluates their relevance to the query using an LLM. If documents score
-// below the threshold, it falls back to a web search for more relevant
-// content.
+// below the threshold, it optionally rewrites the query and retries before
+// falling back to a web search for more relevant content.
 type CRAGRetriever struct {
-	inner      Retriever
-	llm        llm.ChatModel
-	web        WebSearcher
-	threshold  float64
-	hooks      Hooks
+	inner       Retriever
+	llm         llm.ChatModel
+	web         WebSearcher
+	threshold   float64
+	maxAttempts int
+	hooks       Hooks
 }
 
 // CRAGOption configures a CRAGRetriever.
@@ -37,6 +38,19 @@ type CRAGOption func(*CRAGRetriever)
 func WithCRAGThreshold(t float64) CRAGOption {
 	return func(r *CRAGRetriever) {
 		r.threshold = t
+	}
+}
+
+// WithCRAGMaxAttempts sets the maximum number of retrieval attempts with
+// query rewriting before falling back to web search. When set to a value
+// greater than 1, the retriever rewrites the query using the LLM on
+// relevance failure and retries with the inner retriever. Defaults to 1
+// (no retries).
+func WithCRAGMaxAttempts(n int) CRAGOption {
+	return func(r *CRAGRetriever) {
+		if n > 0 {
+			r.maxAttempts = n
+		}
 	}
 }
 
@@ -52,10 +66,11 @@ func WithCRAGHooks(h Hooks) CRAGOption {
 // web search if relevance is low. If web is nil, no fallback is performed.
 func NewCRAGRetriever(inner Retriever, model llm.ChatModel, web WebSearcher, opts ...CRAGOption) *CRAGRetriever {
 	r := &CRAGRetriever{
-		inner:     inner,
-		llm:       model,
-		web:       web,
-		threshold: 0,
+		inner:       inner,
+		llm:         model,
+		web:         web,
+		threshold:   0,
+		maxAttempts: 1,
 	}
 	for _, o := range opts {
 		o(r)
@@ -63,8 +78,8 @@ func NewCRAGRetriever(inner Retriever, model llm.ChatModel, web WebSearcher, opt
 	return r
 }
 
-// Retrieve fetches documents, evaluates relevance, and optionally falls back
-// to web search.
+// Retrieve fetches documents, evaluates relevance, optionally rewrites the
+// query and retries, and falls back to web search if relevance remains low.
 func (r *CRAGRetriever) Retrieve(ctx context.Context, query string, opts ...Option) ([]schema.Document, error) {
 	cfg := ApplyOptions(opts...)
 
@@ -74,34 +89,64 @@ func (r *CRAGRetriever) Retrieve(ctx context.Context, query string, opts ...Opti
 		}
 	}
 
-	docs, err := r.inner.Retrieve(ctx, query, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("retriever: crag inner retrieve: %w", err)
-	}
-
-	if len(docs) == 0 {
-		return r.fallbackSearch(ctx, query, cfg)
-	}
-
-	// Evaluate relevance of retrieved documents.
-	relevant, err := r.evaluateRelevance(ctx, query, docs)
-	if err != nil {
-		return nil, fmt.Errorf("retriever: crag evaluate: %w", err)
-	}
-
-	// If enough relevant documents, return them.
-	if len(relevant) > 0 {
-		if cfg.TopK > 0 && len(relevant) > cfg.TopK {
-			relevant = relevant[:cfg.TopK]
+	currentQuery := query
+	for attempt := 0; attempt < r.maxAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
 		}
-		if r.hooks.AfterRetrieve != nil {
-			r.hooks.AfterRetrieve(ctx, relevant, nil)
+
+		docs, err := r.inner.Retrieve(ctx, currentQuery, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("retriever: crag inner retrieve: %w", err)
 		}
-		return relevant, nil
+
+		if len(docs) == 0 {
+			// No docs — try rewriting before web fallback.
+			if attempt < r.maxAttempts-1 {
+				rewritten, err := r.rewriteQuery(ctx, query, currentQuery)
+				if err != nil {
+					return nil, fmt.Errorf("retriever: crag rewrite: %w", err)
+				}
+				currentQuery = rewritten
+				continue
+			}
+			return r.fallbackSearch(ctx, currentQuery, cfg)
+		}
+
+		// Evaluate relevance of retrieved documents.
+		relevant, err := r.evaluateRelevance(ctx, currentQuery, docs)
+		if err != nil {
+			return nil, fmt.Errorf("retriever: crag evaluate: %w", err)
+		}
+
+		// If enough relevant documents, return them.
+		if len(relevant) > 0 {
+			if cfg.TopK > 0 && len(relevant) > cfg.TopK {
+				relevant = relevant[:cfg.TopK]
+			}
+			if r.hooks.AfterRetrieve != nil {
+				r.hooks.AfterRetrieve(ctx, relevant, nil)
+			}
+			return relevant, nil
+		}
+
+		// Relevance too low — rewrite and retry if attempts remain.
+		if attempt < r.maxAttempts-1 {
+			rewritten, err := r.rewriteQuery(ctx, query, currentQuery)
+			if err != nil {
+				return nil, fmt.Errorf("retriever: crag rewrite: %w", err)
+			}
+			currentQuery = rewritten
+			continue
+		}
+
+		// Final attempt — fall back to web search.
+		return r.fallbackSearch(ctx, currentQuery, cfg)
 	}
 
-	// Fall back to web search.
-	return r.fallbackSearch(ctx, query, cfg)
+	return r.fallbackSearch(ctx, currentQuery, cfg)
 }
 
 // evaluateRelevance uses the LLM to score each document's relevance to the
@@ -158,6 +203,33 @@ func (r *CRAGRetriever) scoreDocument(ctx context.Context, query string, doc sch
 	}
 
 	return score, nil
+}
+
+// rewriteQuery asks the LLM to reformulate the query for better retrieval.
+func (r *CRAGRetriever) rewriteQuery(ctx context.Context, originalQuery, currentQuery string) (string, error) {
+	prompt := fmt.Sprintf(
+		"The following search query did not return relevant documents.\n"+
+			"Original query: %s\n"+
+			"Current query: %s\n\n"+
+			"Reformulate this query to improve search results. "+
+			"Return ONLY the rewritten query, nothing else.",
+		originalQuery, currentQuery,
+	)
+
+	msgs := []schema.Message{
+		schema.NewHumanMessage(prompt),
+	}
+
+	resp, err := r.llm.Generate(ctx, msgs)
+	if err != nil {
+		return "", fmt.Errorf("crag rewrite generate: %w", err)
+	}
+
+	rewritten := strings.TrimSpace(resp.Text())
+	if rewritten == "" {
+		return currentQuery, nil
+	}
+	return rewritten, nil
 }
 
 // fallbackSearch performs web search when document relevance is low.

--- a/rag/retriever/doc.go
+++ b/rag/retriever/doc.go
@@ -51,6 +51,12 @@
 //     falls back to web search when relevance is low)
 //   - [NewMultiQueryRetriever] — generates query variations using an LLM for improved recall
 //   - [NewAdaptiveRetriever] — classifies query complexity and routes to appropriate strategy
+//   - [NewQueryRewriter] — rewrites low-relevance queries using an LLM and retries retrieval
+//   - [NewSubQuestionRetriever] — decomposes complex queries into sub-questions, routes each
+//     to named retrievers, and aggregates results
+//
+// Tool adapter:
+//   - [AsTool] — wraps a Retriever as a [tool.Tool] for agent integration
 //
 // Re-ranking:
 //   - [NewRerankRetriever] — wraps a retriever with a [Reranker] for two-stage

--- a/rag/retriever/rewrite.go
+++ b/rag/retriever/rewrite.go
@@ -1,0 +1,185 @@
+package retriever
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// QueryRewriter wraps an inner Retriever with LLM-driven query rewriting.
+// After the initial retrieval, it evaluates the relevance of returned documents.
+// If the average relevance score falls below a configurable threshold, the LLM
+// reformulates the query and retries retrieval, up to a maximum number of
+// rewrites.
+type QueryRewriter struct {
+	inner              Retriever
+	llm                llm.ChatModel
+	rewriteModel       llm.ChatModel
+	maxRewrites        int
+	relevanceThreshold float64
+	hooks              Hooks
+}
+
+// Compile-time interface check.
+var _ Retriever = (*QueryRewriter)(nil)
+
+// RewriteOption configures a QueryRewriter.
+type RewriteOption func(*QueryRewriter)
+
+// WithRewriteModel sets a separate LLM for query rewriting. If not set, the
+// main LLM is used for both relevance evaluation and rewriting.
+func WithRewriteModel(m llm.ChatModel) RewriteOption {
+	return func(r *QueryRewriter) {
+		r.rewriteModel = m
+	}
+}
+
+// WithMaxRewrites sets the maximum number of query rewrite attempts.
+// Defaults to 3.
+func WithMaxRewrites(n int) RewriteOption {
+	return func(r *QueryRewriter) {
+		if n > 0 {
+			r.maxRewrites = n
+		}
+	}
+}
+
+// WithRelevanceThreshold sets the minimum average relevance score (0 to 1)
+// for the retrieval to be considered successful. If the average score of
+// returned documents falls below this threshold, the query is rewritten.
+// Defaults to 0.7.
+func WithRelevanceThreshold(t float64) RewriteOption {
+	return func(r *QueryRewriter) {
+		r.relevanceThreshold = t
+	}
+}
+
+// WithRewriteHooks sets hooks on the QueryRewriter.
+func WithRewriteHooks(h Hooks) RewriteOption {
+	return func(r *QueryRewriter) {
+		r.hooks = h
+	}
+}
+
+// NewQueryRewriter creates a QueryRewriter that wraps the inner retriever.
+// The model is used for both relevance evaluation and query rewriting unless
+// a separate rewrite model is specified via WithRewriteModel.
+func NewQueryRewriter(inner Retriever, model llm.ChatModel, opts ...RewriteOption) *QueryRewriter {
+	r := &QueryRewriter{
+		inner:              inner,
+		llm:                model,
+		maxRewrites:        3,
+		relevanceThreshold: 0.7,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	if r.rewriteModel == nil {
+		r.rewriteModel = model
+	}
+	return r
+}
+
+// Retrieve fetches documents using the inner retriever. If the average
+// relevance score is below the threshold, the query is rewritten using the
+// LLM and retrieval is retried, up to maxRewrites times.
+func (r *QueryRewriter) Retrieve(ctx context.Context, query string, opts ...Option) ([]schema.Document, error) {
+	if r.hooks.BeforeRetrieve != nil {
+		if err := r.hooks.BeforeRetrieve(ctx, query); err != nil {
+			return nil, err
+		}
+	}
+
+	currentQuery := query
+	for attempt := 0; attempt <= r.maxRewrites; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		docs, err := r.inner.Retrieve(ctx, currentQuery, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("retriever: rewrite retrieve (attempt %d): %w", attempt, err)
+		}
+
+		if len(docs) == 0 && attempt < r.maxRewrites {
+			rewritten, err := r.rewriteQuery(ctx, query, currentQuery, attempt)
+			if err != nil {
+				return nil, fmt.Errorf("retriever: rewrite query: %w", err)
+			}
+			currentQuery = rewritten
+			continue
+		}
+
+		if len(docs) == 0 {
+			if r.hooks.AfterRetrieve != nil {
+				r.hooks.AfterRetrieve(ctx, nil, nil)
+			}
+			return nil, nil
+		}
+
+		avgScore := r.averageRelevance(docs)
+		if avgScore >= r.relevanceThreshold || attempt >= r.maxRewrites {
+			if r.hooks.AfterRetrieve != nil {
+				r.hooks.AfterRetrieve(ctx, docs, nil)
+			}
+			return docs, nil
+		}
+
+		// Relevance too low — rewrite the query.
+		rewritten, err := r.rewriteQuery(ctx, query, currentQuery, attempt)
+		if err != nil {
+			return nil, fmt.Errorf("retriever: rewrite query: %w", err)
+		}
+		currentQuery = rewritten
+	}
+
+	// Should not be reached, but return empty for safety.
+	if r.hooks.AfterRetrieve != nil {
+		r.hooks.AfterRetrieve(ctx, nil, nil)
+	}
+	return nil, nil
+}
+
+// averageRelevance computes the mean Score across docs.
+func (r *QueryRewriter) averageRelevance(docs []schema.Document) float64 {
+	if len(docs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, d := range docs {
+		sum += d.Score
+	}
+	return sum / float64(len(docs))
+}
+
+// rewriteQuery asks the LLM to reformulate the query for better retrieval.
+func (r *QueryRewriter) rewriteQuery(ctx context.Context, originalQuery, currentQuery string, attempt int) (string, error) {
+	prompt := fmt.Sprintf(
+		"The following search query did not return sufficiently relevant results.\n"+
+			"Original query: %s\n"+
+			"Current query (attempt %d): %s\n\n"+
+			"Please reformulate this query to improve search results. "+
+			"Return ONLY the rewritten query, nothing else.",
+		originalQuery, attempt+1, currentQuery,
+	)
+
+	msgs := []schema.Message{
+		schema.NewHumanMessage(prompt),
+	}
+
+	resp, err := r.rewriteModel.Generate(ctx, msgs)
+	if err != nil {
+		return "", fmt.Errorf("rewrite generate: %w", err)
+	}
+
+	rewritten := strings.TrimSpace(resp.Text())
+	if rewritten == "" {
+		return currentQuery, nil
+	}
+	return rewritten, nil
+}

--- a/rag/retriever/rewrite.go
+++ b/rag/retriever/rewrite.go
@@ -10,10 +10,18 @@ import (
 )
 
 // QueryRewriter wraps an inner Retriever with LLM-driven query rewriting.
-// After the initial retrieval, it evaluates the relevance of returned documents.
-// If the average relevance score falls below a configurable threshold, the LLM
-// reformulates the query and retries retrieval, up to a maximum number of
-// rewrites.
+//
+// It reads the pre-populated Score field on each returned document and
+// computes an average. If the average falls below the configured threshold
+// the LLM reformulates the query and retries, up to maxRewrites times.
+//
+// IMPORTANT: QueryRewriter relies on the inner retriever populating
+// Document.Score. Retrievers that do not emit scores (for example the
+// SubQuestionRetriever, or any retriever without explicit scoring) will
+// always yield an average of 0.0, which triggers rewrites on every call.
+// When wrapping an unscored retriever, set the relevance threshold to
+// 0.0 via WithRelevanceThreshold or use a different strategy such as
+// CRAGRetriever which performs active LLM-based relevance evaluation.
 type QueryRewriter struct {
 	inner              Retriever
 	llm                llm.ChatModel

--- a/rag/retriever/rewrite_test.go
+++ b/rag/retriever/rewrite_test.go
@@ -1,0 +1,281 @@
+package retriever_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/rag/retriever"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryRewriter_Defaults(t *testing.T) {
+	inner := &mockRetriever{}
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model)
+	require.NotNil(t, r)
+}
+
+func TestQueryRewriter_Retrieve_HighRelevance_NoRewrite(t *testing.T) {
+	// Documents with high scores should be returned without rewriting.
+	highScoreDocs := []schema.Document{
+		{ID: "d1", Content: "relevant", Score: 0.9},
+		{ID: "d2", Content: "also relevant", Score: 0.8},
+	}
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return highScoreDocs, nil
+		},
+	}
+
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model, retriever.WithRelevanceThreshold(0.7))
+	docs, err := r.Retrieve(context.Background(), "test query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 2)
+	assert.Equal(t, 0, model.calls, "LLM should not be called when relevance is high")
+}
+
+func TestQueryRewriter_Retrieve_LowRelevance_Rewrites(t *testing.T) {
+	callCount := 0
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			callCount++
+			if callCount == 1 {
+				// First attempt: low relevance docs.
+				return []schema.Document{
+					{ID: "d1", Content: "low", Score: 0.3},
+				}, nil
+			}
+			// After rewrite: high relevance docs.
+			return []schema.Document{
+				{ID: "d2", Content: "high", Score: 0.9},
+			}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("improved query"), nil
+		},
+	}
+
+	r := retriever.NewQueryRewriter(inner, model,
+		retriever.WithRelevanceThreshold(0.7),
+		retriever.WithMaxRewrites(3),
+	)
+	docs, err := r.Retrieve(context.Background(), "test query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 1)
+	assert.Equal(t, "d2", docs[0].ID)
+	assert.Equal(t, 2, callCount, "Should have retried after rewrite")
+	assert.Equal(t, 1, model.calls, "LLM should be called once for rewrite")
+}
+
+func TestQueryRewriter_Retrieve_MaxRewritesExhausted(t *testing.T) {
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			// Always return low relevance docs.
+			return []schema.Document{
+				{ID: "d1", Content: "low", Score: 0.2},
+			}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("rewritten query"), nil
+		},
+	}
+
+	r := retriever.NewQueryRewriter(inner, model,
+		retriever.WithRelevanceThreshold(0.7),
+		retriever.WithMaxRewrites(2),
+	)
+	docs, err := r.Retrieve(context.Background(), "test query")
+
+	require.NoError(t, err)
+	// Should return the last attempt's docs even though score is low.
+	assert.Len(t, docs, 1)
+	assert.Equal(t, "d1", docs[0].ID)
+}
+
+func TestQueryRewriter_Retrieve_EmptyResults_RewritesAndRetries(t *testing.T) {
+	callCount := 0
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			callCount++
+			if callCount < 3 {
+				return nil, nil // Empty results.
+			}
+			return []schema.Document{
+				{ID: "d1", Content: "found", Score: 0.9},
+			}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("better query"), nil
+		},
+	}
+
+	r := retriever.NewQueryRewriter(inner, model,
+		retriever.WithMaxRewrites(3),
+		retriever.WithRelevanceThreshold(0.5),
+	)
+	docs, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 1)
+	assert.Equal(t, 3, callCount)
+}
+
+func TestQueryRewriter_Retrieve_InnerError(t *testing.T) {
+	expectedErr := errors.New("inner failure")
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return nil, expectedErr
+		},
+	}
+
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model)
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rewrite retrieve")
+}
+
+func TestQueryRewriter_Retrieve_RewriteError(t *testing.T) {
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{
+				{ID: "d1", Content: "low", Score: 0.1},
+			}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return nil, errors.New("llm failure")
+		},
+	}
+
+	r := retriever.NewQueryRewriter(inner, model,
+		retriever.WithRelevanceThreshold(0.9),
+	)
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rewrite query")
+}
+
+func TestQueryRewriter_Retrieve_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{{ID: "d1", Score: 0.1}}, nil
+		},
+	}
+
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model, retriever.WithRelevanceThreshold(0.9))
+	_, err := r.Retrieve(ctx, "query")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryRewriter_Retrieve_WithRewriteModel(t *testing.T) {
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			if query == "rewritten" {
+				return []schema.Document{{ID: "d1", Score: 0.9}}, nil
+			}
+			return []schema.Document{{ID: "d1", Score: 0.1}}, nil
+		},
+	}
+
+	mainModel := &mockChatModel{}
+	rewriteModel := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("rewritten"), nil
+		},
+	}
+
+	r := retriever.NewQueryRewriter(inner, mainModel,
+		retriever.WithRewriteModel(rewriteModel),
+		retriever.WithRelevanceThreshold(0.5),
+	)
+	docs, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 1)
+	assert.Equal(t, 0, mainModel.calls, "Main model should not be called for rewrites")
+	assert.Equal(t, 1, rewriteModel.calls, "Rewrite model should be called")
+}
+
+func TestQueryRewriter_Retrieve_WithHooks(t *testing.T) {
+	var beforeCalled, afterCalled bool
+
+	hooks := retriever.Hooks{
+		BeforeRetrieve: func(ctx context.Context, query string) error {
+			beforeCalled = true
+			return nil
+		},
+		AfterRetrieve: func(ctx context.Context, docs []schema.Document, err error) {
+			afterCalled = true
+		},
+	}
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{{ID: "d1", Score: 0.9}}, nil
+		},
+	}
+
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model, retriever.WithRewriteHooks(hooks))
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.True(t, beforeCalled)
+	assert.True(t, afterCalled)
+}
+
+func TestQueryRewriter_Retrieve_BeforeHookError(t *testing.T) {
+	expectedErr := errors.New("hook error")
+	hooks := retriever.Hooks{
+		BeforeRetrieve: func(ctx context.Context, query string) error {
+			return expectedErr
+		},
+	}
+
+	inner := &mockRetriever{}
+	model := &mockChatModel{}
+
+	r := retriever.NewQueryRewriter(inner, model, retriever.WithRewriteHooks(hooks))
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+// Compile-time check.
+var _ retriever.Retriever = (*retriever.QueryRewriter)(nil)

--- a/rag/retriever/subquestion.go
+++ b/rag/retriever/subquestion.go
@@ -2,7 +2,10 @@ package retriever
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lookatitude/beluga-ai/llm"
@@ -190,6 +193,9 @@ func (r *SubQuestionRetriever) Retrieve(ctx context.Context, query string, opts 
 	for name := range r.retrievers {
 		available = append(available, name)
 	}
+	// Map iteration order is randomized; sort for deterministic prompts
+	// and reproducible routing decisions.
+	sort.Strings(available)
 
 	subQuestions, err := r.decomposer.Decompose(ctx, query, available)
 	if err != nil {
@@ -225,7 +231,10 @@ func (r *SubQuestionRetriever) Retrieve(ctx context.Context, query string, opts 
 		for _, doc := range docs {
 			key := doc.ID
 			if key == "" {
-				key = doc.Content
+				// Use a bounded content hash as the dedup key so that very
+				// large documents do not allocate oversized map keys.
+				sum := sha256.Sum256([]byte(doc.Content))
+				key = hex.EncodeToString(sum[:])
 			}
 			if _, exists := seen[key]; !exists {
 				seen[key] = struct{}{}

--- a/rag/retriever/subquestion.go
+++ b/rag/retriever/subquestion.go
@@ -1,0 +1,242 @@
+package retriever
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// Decomposer breaks a complex query into sub-questions. Each sub-question
+// includes a routing hint indicating which named retriever should handle it.
+type Decomposer interface {
+	// Decompose splits query into sub-questions, each tagged with a retriever
+	// name from the available set.
+	Decompose(ctx context.Context, query string, available []string) ([]SubQuestion, error)
+}
+
+// SubQuestion represents a single decomposed question with its routing target.
+type SubQuestion struct {
+	// Question is the decomposed sub-question text.
+	Question string
+	// Retriever is the name of the retriever to route this sub-question to.
+	Retriever string
+}
+
+// LLMDecomposer uses an LLM to decompose queries into sub-questions.
+type LLMDecomposer struct {
+	llm llm.ChatModel
+}
+
+// Compile-time interface check.
+var _ Decomposer = (*LLMDecomposer)(nil)
+
+// NewLLMDecomposer creates a Decomposer backed by the given LLM.
+func NewLLMDecomposer(model llm.ChatModel) *LLMDecomposer {
+	return &LLMDecomposer{llm: model}
+}
+
+// Decompose uses the LLM to break the query into sub-questions, each tagged
+// with a retriever name from the available set.
+func (d *LLMDecomposer) Decompose(ctx context.Context, query string, available []string) ([]SubQuestion, error) {
+	prompt := fmt.Sprintf(
+		"Break the following complex query into simpler sub-questions.\n"+
+			"For each sub-question, specify which retriever should handle it.\n\n"+
+			"Available retrievers: %s\n\n"+
+			"Format each line as: retriever_name|sub-question\n"+
+			"Return ONLY the formatted lines, nothing else.\n\n"+
+			"Query: %s",
+		strings.Join(available, ", "), query,
+	)
+
+	msgs := []schema.Message{
+		schema.NewHumanMessage(prompt),
+	}
+
+	resp, err := d.llm.Generate(ctx, msgs)
+	if err != nil {
+		return nil, fmt.Errorf("decompose query: %w", err)
+	}
+
+	return parseSubQuestions(resp.Text(), available), nil
+}
+
+// parseSubQuestions extracts SubQuestion values from LLM output lines of the
+// form "retriever_name|question". Lines that don't match the format or
+// reference unknown retrievers fall back to the first available retriever.
+func parseSubQuestions(text string, available []string) []SubQuestion {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+
+	availSet := make(map[string]struct{}, len(available))
+	for _, a := range available {
+		availSet[a] = struct{}{}
+	}
+
+	fallback := ""
+	if len(available) > 0 {
+		fallback = available[0]
+	}
+
+	var questions []SubQuestion
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) == 2 {
+			name := strings.TrimSpace(parts[0])
+			q := strings.TrimSpace(parts[1])
+			if _, ok := availSet[name]; !ok {
+				name = fallback
+			}
+			if q != "" {
+				questions = append(questions, SubQuestion{Question: q, Retriever: name})
+			}
+		} else {
+			// No pipe — treat whole line as a question routed to fallback.
+			if fallback != "" {
+				questions = append(questions, SubQuestion{Question: line, Retriever: fallback})
+			}
+		}
+	}
+
+	return questions
+}
+
+// SubQuestionRetriever decomposes complex queries into sub-questions, routes
+// each to a named retriever, retrieves results, and aggregates them into a
+// deduplicated result set.
+type SubQuestionRetriever struct {
+	decomposer      Decomposer
+	retrievers      map[string]Retriever
+	maxSubQuestions int
+	hooks           Hooks
+}
+
+// Compile-time interface check.
+var _ Retriever = (*SubQuestionRetriever)(nil)
+
+// SubQuestionOption configures a SubQuestionRetriever.
+type SubQuestionOption func(*SubQuestionRetriever)
+
+// WithDecomposer sets the Decomposer used to split queries. If not set,
+// a default LLMDecomposer must be provided at construction time.
+func WithDecomposer(d Decomposer) SubQuestionOption {
+	return func(r *SubQuestionRetriever) {
+		r.decomposer = d
+	}
+}
+
+// WithRetrievers sets the named retrievers map for sub-question routing.
+func WithRetrievers(m map[string]Retriever) SubQuestionOption {
+	return func(r *SubQuestionRetriever) {
+		r.retrievers = m
+	}
+}
+
+// WithMaxSubQuestions limits the number of sub-questions generated.
+// Defaults to 5.
+func WithMaxSubQuestions(n int) SubQuestionOption {
+	return func(r *SubQuestionRetriever) {
+		if n > 0 {
+			r.maxSubQuestions = n
+		}
+	}
+}
+
+// WithSubQuestionHooks sets hooks on the SubQuestionRetriever.
+func WithSubQuestionHooks(h Hooks) SubQuestionOption {
+	return func(r *SubQuestionRetriever) {
+		r.hooks = h
+	}
+}
+
+// NewSubQuestionRetriever creates a SubQuestionRetriever with the given
+// options. A Decomposer and at least one named retriever must be provided
+// via options.
+func NewSubQuestionRetriever(opts ...SubQuestionOption) *SubQuestionRetriever {
+	r := &SubQuestionRetriever{
+		maxSubQuestions: 5,
+		retrievers:      make(map[string]Retriever),
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+// Retrieve decomposes the query into sub-questions, routes each to the
+// appropriate named retriever, and returns aggregated, deduplicated results.
+func (r *SubQuestionRetriever) Retrieve(ctx context.Context, query string, opts ...Option) ([]schema.Document, error) {
+	if r.hooks.BeforeRetrieve != nil {
+		if err := r.hooks.BeforeRetrieve(ctx, query); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.decomposer == nil {
+		return nil, fmt.Errorf("retriever: subquestion: decomposer not configured")
+	}
+
+	if len(r.retrievers) == 0 {
+		return nil, fmt.Errorf("retriever: subquestion: no retrievers configured")
+	}
+
+	available := make([]string, 0, len(r.retrievers))
+	for name := range r.retrievers {
+		available = append(available, name)
+	}
+
+	subQuestions, err := r.decomposer.Decompose(ctx, query, available)
+	if err != nil {
+		return nil, fmt.Errorf("retriever: subquestion decompose: %w", err)
+	}
+
+	// Limit sub-questions.
+	if len(subQuestions) > r.maxSubQuestions {
+		subQuestions = subQuestions[:r.maxSubQuestions]
+	}
+
+	seen := make(map[string]struct{})
+	var results []schema.Document
+
+	for _, sq := range subQuestions {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		ret, ok := r.retrievers[sq.Retriever]
+		if !ok {
+			// Skip sub-questions targeting unknown retrievers.
+			continue
+		}
+
+		docs, err := ret.Retrieve(ctx, sq.Question, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("retriever: subquestion retrieve %q via %q: %w", sq.Question, sq.Retriever, err)
+		}
+
+		for _, doc := range docs {
+			key := doc.ID
+			if key == "" {
+				key = doc.Content
+			}
+			if _, exists := seen[key]; !exists {
+				seen[key] = struct{}{}
+				results = append(results, doc)
+			}
+		}
+	}
+
+	if r.hooks.AfterRetrieve != nil {
+		r.hooks.AfterRetrieve(ctx, results, nil)
+	}
+
+	return results, nil
+}

--- a/rag/retriever/subquestion_test.go
+++ b/rag/retriever/subquestion_test.go
@@ -1,0 +1,333 @@
+package retriever_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/rag/retriever"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSubQuestionRetriever_Defaults(t *testing.T) {
+	r := retriever.NewSubQuestionRetriever()
+	require.NotNil(t, r)
+}
+
+func TestSubQuestionRetriever_Retrieve_DecomposesAndRoutes(t *testing.T) {
+	docsA := []schema.Document{{ID: "a1", Content: "doc A"}}
+	docsB := []schema.Document{{ID: "b1", Content: "doc B"}}
+
+	retA := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return docsA, nil
+		},
+	}
+	retB := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return docsB, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("alpha|What is A?\nbeta|What is B?"), nil
+		},
+	}
+
+	decomposer := retriever.NewLLMDecomposer(model)
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(decomposer),
+		retriever.WithRetrievers(map[string]retriever.Retriever{
+			"alpha": retA,
+			"beta":  retB,
+		}),
+	)
+
+	docs, err := r.Retrieve(context.Background(), "complex query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 2)
+
+	ids := make(map[string]bool)
+	for _, d := range docs {
+		ids[d.ID] = true
+	}
+	assert.True(t, ids["a1"])
+	assert.True(t, ids["b1"])
+}
+
+func TestSubQuestionRetriever_Retrieve_Deduplicates(t *testing.T) {
+	sharedDoc := schema.Document{ID: "shared", Content: "shared doc"}
+
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{sharedDoc}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("alpha|Q1\nalpha|Q2"), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+	)
+
+	docs, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.Len(t, docs, 1, "Duplicate docs should be deduplicated")
+}
+
+func TestSubQuestionRetriever_Retrieve_MaxSubQuestions(t *testing.T) {
+	var queriesSeen []string
+
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			queriesSeen = append(queriesSeen, query)
+			return []schema.Document{{ID: query, Content: query}}, nil
+		},
+	}
+
+	// Generate many sub-questions.
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			lines := make([]string, 10)
+			for i := range lines {
+				lines[i] = fmt.Sprintf("alpha|Question %d", i+1)
+			}
+			return schema.NewAIMessage(strings.Join(lines, "\n")), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+		retriever.WithMaxSubQuestions(3),
+	)
+
+	docs, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.Len(t, queriesSeen, 3, "Should limit to 3 sub-questions")
+	assert.Len(t, docs, 3)
+}
+
+func TestSubQuestionRetriever_Retrieve_NoDecomposer(t *testing.T) {
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithRetrievers(map[string]retriever.Retriever{
+			"alpha": &mockRetriever{},
+		}),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decomposer not configured")
+}
+
+func TestSubQuestionRetriever_Retrieve_NoRetrievers(t *testing.T) {
+	model := &mockChatModel{}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no retrievers configured")
+}
+
+func TestSubQuestionRetriever_Retrieve_DecomposeError(t *testing.T) {
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return nil, errors.New("llm failure")
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{
+			"alpha": &mockRetriever{},
+		}),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subquestion decompose")
+}
+
+func TestSubQuestionRetriever_Retrieve_InnerRetrieverError(t *testing.T) {
+	expectedErr := errors.New("retriever failure")
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return nil, expectedErr
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("alpha|What is it?"), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subquestion retrieve")
+}
+
+func TestSubQuestionRetriever_Retrieve_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	callCount := 0
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			callCount++
+			if callCount == 1 {
+				cancel() // Cancel after first sub-question.
+			}
+			return []schema.Document{{ID: "d1"}}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("alpha|Q1\nalpha|Q2\nalpha|Q3"), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+	)
+
+	_, err := r.Retrieve(ctx, "query")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSubQuestionRetriever_Retrieve_UnknownRetrieverSkipped(t *testing.T) {
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{{ID: "d1", Content: "found"}}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("unknown_retriever|Q1\nalpha|Q2"), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+	)
+
+	docs, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	// The "unknown_retriever" sub-question gets routed to fallback "alpha" by the decomposer,
+	// so both sub-questions hit "alpha". Dedup means we get 1 doc.
+	assert.Len(t, docs, 1)
+}
+
+func TestSubQuestionRetriever_Retrieve_WithHooks(t *testing.T) {
+	var beforeCalled, afterCalled bool
+
+	hooks := retriever.Hooks{
+		BeforeRetrieve: func(ctx context.Context, query string) error {
+			beforeCalled = true
+			return nil
+		},
+		AfterRetrieve: func(ctx context.Context, docs []schema.Document, err error) {
+			afterCalled = true
+		},
+	}
+
+	ret := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return []schema.Document{{ID: "d1"}}, nil
+		},
+	}
+
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("alpha|Q1"), nil
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(model)),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": ret}),
+		retriever.WithSubQuestionHooks(hooks),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.NoError(t, err)
+	assert.True(t, beforeCalled)
+	assert.True(t, afterCalled)
+}
+
+func TestSubQuestionRetriever_Retrieve_BeforeHookError(t *testing.T) {
+	expectedErr := errors.New("hook error")
+	hooks := retriever.Hooks{
+		BeforeRetrieve: func(ctx context.Context, query string) error {
+			return expectedErr
+		},
+	}
+
+	r := retriever.NewSubQuestionRetriever(
+		retriever.WithDecomposer(retriever.NewLLMDecomposer(&mockChatModel{})),
+		retriever.WithRetrievers(map[string]retriever.Retriever{"alpha": &mockRetriever{}}),
+		retriever.WithSubQuestionHooks(hooks),
+	)
+
+	_, err := r.Retrieve(context.Background(), "query")
+
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestLLMDecomposer_FallbackRetriever(t *testing.T) {
+	// Lines without pipes should use the first available retriever.
+	model := &mockChatModel{
+		generateFn: func(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+			return schema.NewAIMessage("Just a plain question"), nil
+		},
+	}
+
+	decomposer := retriever.NewLLMDecomposer(model)
+	subs, err := decomposer.Decompose(context.Background(), "query", []string{"default", "other"})
+
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, "default", subs[0].Retriever)
+	assert.Equal(t, "Just a plain question", subs[0].Question)
+}
+
+// Compile-time checks.
+var (
+	_ retriever.Retriever  = (*retriever.SubQuestionRetriever)(nil)
+	_ retriever.Decomposer = (*retriever.LLMDecomposer)(nil)
+)

--- a/rag/retriever/tool_adapter.go
+++ b/rag/retriever/tool_adapter.go
@@ -1,0 +1,114 @@
+package retriever
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// retrieverTool adapts a Retriever as a tool.Tool so that agents can invoke
+// document retrieval as a tool call.
+type retrieverTool struct {
+	retriever   Retriever
+	name        string
+	description string
+	topK        int
+}
+
+// Compile-time interface check.
+var _ tool.Tool = (*retrieverTool)(nil)
+
+// AsTool wraps a Retriever as a tool.Tool with the given name and description.
+// The tool accepts a JSON input with a "query" field and returns matching
+// document contents as text. An optional topK limits results (default 10).
+func AsTool(r Retriever, name, description string, opts ...ToolAdapterOption) tool.Tool {
+	t := &retrieverTool{
+		retriever:   r,
+		name:        name,
+		description: description,
+		topK:        10,
+	}
+	for _, o := range opts {
+		o(t)
+	}
+	return t
+}
+
+// ToolAdapterOption configures the retriever tool adapter.
+type ToolAdapterOption func(*retrieverTool)
+
+// WithToolTopK sets the default top-k for the retriever tool.
+func WithToolTopK(k int) ToolAdapterOption {
+	return func(t *retrieverTool) {
+		if k > 0 {
+			t.topK = k
+		}
+	}
+}
+
+// Name returns the tool name.
+func (t *retrieverTool) Name() string { return t.name }
+
+// Description returns the tool description.
+func (t *retrieverTool) Description() string { return t.description }
+
+// InputSchema returns the JSON Schema for the tool input.
+func (t *retrieverTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "The search query to retrieve documents for",
+			},
+		},
+		"required": []string{"query"},
+	}
+}
+
+// Execute runs the retriever with the query from the input map and returns
+// document contents as a text result.
+func (t *retrieverTool) Execute(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	queryRaw, ok := input["query"]
+	if !ok {
+		return nil, fmt.Errorf("retriever tool %s: missing required field \"query\"", t.name)
+	}
+
+	query, ok := queryRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("retriever tool %s: \"query\" must be a string", t.name)
+	}
+
+	if query == "" {
+		return nil, fmt.Errorf("retriever tool %s: \"query\" must not be empty", t.name)
+	}
+
+	docs, err := t.retriever.Retrieve(ctx, query, WithTopK(t.topK))
+	if err != nil {
+		return tool.ErrorResult(fmt.Errorf("retriever tool %s: %w", t.name, err)), nil
+	}
+
+	if len(docs) == 0 {
+		return tool.TextResult("No documents found."), nil
+	}
+
+	return tool.TextResult(formatDocs(docs)), nil
+}
+
+// formatDocs renders documents as a numbered list for LLM consumption.
+func formatDocs(docs []schema.Document) string {
+	var b strings.Builder
+	for i, doc := range docs {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "[%d] %s", i+1, doc.Content)
+		if doc.Score > 0 {
+			fmt.Fprintf(&b, " (score: %.2f)", doc.Score)
+		}
+	}
+	return b.String()
+}

--- a/rag/retriever/tool_adapter_test.go
+++ b/rag/retriever/tool_adapter_test.go
@@ -1,0 +1,164 @@
+package retriever_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/rag/retriever"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsTool_Name(t *testing.T) {
+	inner := &mockRetriever{}
+	tl := retriever.AsTool(inner, "search_docs", "Search documents")
+
+	assert.Equal(t, "search_docs", tl.Name())
+	assert.Equal(t, "Search documents", tl.Description())
+}
+
+func TestAsTool_InputSchema(t *testing.T) {
+	inner := &mockRetriever{}
+	tl := retriever.AsTool(inner, "search", "Search")
+
+	schema := tl.InputSchema()
+	require.NotNil(t, schema)
+	assert.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	queryProp, ok := props["query"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "string", queryProp["type"])
+
+	required, ok := schema["required"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, required, "query")
+}
+
+func TestAsTool_Execute_HappyPath(t *testing.T) {
+	docs := []schema.Document{
+		{ID: "d1", Content: "First document", Score: 0.9},
+		{ID: "d2", Content: "Second document", Score: 0.7},
+	}
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			assert.Equal(t, "test query", query)
+			return docs, nil
+		},
+	}
+
+	tl := retriever.AsTool(inner, "search", "Search")
+	result, err := tl.Execute(context.Background(), map[string]any{
+		"query": "test query",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	assert.Len(t, result.Content, 1)
+
+	text := result.Content[0].(schema.TextPart).Text
+	assert.Contains(t, text, "First document")
+	assert.Contains(t, text, "Second document")
+	assert.Contains(t, text, "0.90")
+}
+
+func TestAsTool_Execute_EmptyResults(t *testing.T) {
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return nil, nil
+		},
+	}
+
+	tl := retriever.AsTool(inner, "search", "Search")
+	result, err := tl.Execute(context.Background(), map[string]any{
+		"query": "test",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	text := result.Content[0].(schema.TextPart).Text
+	assert.Equal(t, "No documents found.", text)
+}
+
+func TestAsTool_Execute_RetrieverError(t *testing.T) {
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			return nil, errors.New("search failed")
+		},
+	}
+
+	tl := retriever.AsTool(inner, "search", "Search")
+	result, err := tl.Execute(context.Background(), map[string]any{
+		"query": "test",
+	})
+
+	// Error is returned as an error result, not a Go error.
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestAsTool_Execute_MissingQuery(t *testing.T) {
+	inner := &mockRetriever{}
+	tl := retriever.AsTool(inner, "search", "Search")
+
+	_, err := tl.Execute(context.Background(), map[string]any{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required field")
+}
+
+func TestAsTool_Execute_InvalidQueryType(t *testing.T) {
+	inner := &mockRetriever{}
+	tl := retriever.AsTool(inner, "search", "Search")
+
+	_, err := tl.Execute(context.Background(), map[string]any{
+		"query": 42,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a string")
+}
+
+func TestAsTool_Execute_EmptyQuery(t *testing.T) {
+	inner := &mockRetriever{}
+	tl := retriever.AsTool(inner, "search", "Search")
+
+	_, err := tl.Execute(context.Background(), map[string]any{
+		"query": "",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty")
+}
+
+func TestAsTool_WithToolTopK(t *testing.T) {
+	var capturedOpts []retriever.Option
+
+	inner := &mockRetriever{
+		retrieveFn: func(ctx context.Context, query string, opts ...retriever.Option) ([]schema.Document, error) {
+			capturedOpts = opts
+			return nil, nil
+		},
+	}
+
+	tl := retriever.AsTool(inner, "search", "Search", retriever.WithToolTopK(5))
+	_, err := tl.Execute(context.Background(), map[string]any{
+		"query": "test",
+	})
+
+	require.NoError(t, err)
+	// Verify TopK was passed through options.
+	cfg := retriever.ApplyOptions(capturedOpts...)
+	assert.Equal(t, 5, cfg.TopK)
+}
+
+// Compile-time check.
+var _ tool.Tool = retriever.AsTool(&mockRetriever{}, "test", "test")


### PR DESCRIPTION
## Summary
- QueryRewriter, SubQuestionRetriever, AsTool bridge, CRAG extension with WithMaxAttempts and query rewriting

## Linear
- LOO-25: https://linear.app/lookatitude/issue/LOO-25

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)