### PR TITLE
LOO-28: Sandboxed Code Execution (E2B-Style)

### DIFF
--- a/tool/sandbox/doc.go
+++ b/tool/sandbox/doc.go
@@ -1,0 +1,73 @@
+// Package sandbox provides sandboxed code execution for the Beluga AI framework.
+//
+// It defines the [Sandbox] interface for executing code in isolated environments,
+// a registry for sandbox providers ([RegisterSandbox], [NewSandbox], [ListSandboxes]),
+// a process-based implementation for development ([ProcessSandbox]),
+// a pool for reusing sandbox instances ([SandboxPool]),
+// a [SandboxTool] adapter that wraps a Sandbox as an agent-callable [tool.Tool],
+// and composable lifecycle [Hooks].
+//
+// # Sandbox Interface
+//
+// The Sandbox interface is the core abstraction:
+//
+//	type Sandbox interface {
+//	    Execute(ctx context.Context, code string, cfg SandboxConfig) (ExecutionResult, error)
+//	    Close(ctx context.Context) error
+//	}
+//
+// Implementations may range from local process execution (for development) to
+// remote container-based sandboxes (for production).
+//
+// # ProcessSandbox (Development Only)
+//
+// [ProcessSandbox] executes code via os/exec in a temporary directory. It enforces
+// timeouts via context but does NOT provide kernel-level isolation (no seccomp,
+// no namespaces, no cgroups). It is suitable for development and testing only.
+//
+//	sb := sandbox.NewProcessSandbox(
+//	    sandbox.WithWorkDir("/tmp/sandbox"),
+//	    sandbox.WithEnv([]string{"PATH=/usr/bin"}),
+//	)
+//	result, err := sb.Execute(ctx, "print('hello')", sandbox.SandboxConfig{
+//	    Language: "python",
+//	    Timeout:  5 * time.Second,
+//	})
+//
+// # SandboxPool
+//
+// [SandboxPool] pre-creates N sandbox instances for fast reuse via checkout/checkin:
+//
+//	pool := sandbox.NewSandboxPool("process",
+//	    sandbox.WithPoolSize(4),
+//	    sandbox.WithWarmup(true),
+//	)
+//	sb, err := pool.Checkout(ctx)
+//	defer pool.Checkin(sb)
+//
+// # SandboxTool
+//
+// [SandboxTool] wraps a Sandbox as a [tool.Tool] for use by agents:
+//
+//	t := sandbox.NewSandboxTool(sb)
+//	result, err := t.Execute(ctx, map[string]any{
+//	    "code":     "print('hello')",
+//	    "language": "python",
+//	})
+//
+// # Hooks
+//
+// [Hooks] provide lifecycle callbacks: BeforeExecute, AfterExecute, OnTimeout, OnError.
+// Compose multiple hooks with [ComposeHooks].
+//
+// # Registry
+//
+// Sandbox providers register via [RegisterSandbox] (typically in init()) and are
+// instantiated via [NewSandbox]. [ListSandboxes] returns all registered provider names.
+//
+//	func init() {
+//	    sandbox.RegisterSandbox("process", func() (sandbox.Sandbox, error) {
+//	        return sandbox.NewProcessSandbox(), nil
+//	    })
+//	}
+package sandbox

--- a/tool/sandbox/hooks.go
+++ b/tool/sandbox/hooks.go
@@ -1,0 +1,50 @@
+package sandbox
+
+import (
+	"context"
+
+	"github.com/lookatitude/beluga-ai/internal/hookutil"
+)
+
+// Hooks provides lifecycle callbacks for sandbox execution. All fields are
+// optional — nil hooks are skipped. Hooks can be composed using ComposeHooks.
+type Hooks struct {
+	// BeforeExecute is called before code execution starts. It receives the
+	// code and config. Returning an error aborts execution.
+	BeforeExecute func(ctx context.Context, code string, cfg SandboxConfig) error
+
+	// AfterExecute is called after code execution completes (successfully or
+	// not). It receives the result and any error from execution.
+	AfterExecute func(ctx context.Context, result ExecutionResult, err error)
+
+	// OnTimeout is called when execution exceeds its deadline. It receives
+	// the code and config of the timed-out execution.
+	OnTimeout func(ctx context.Context, code string, cfg SandboxConfig)
+
+	// OnError is called when execution fails with an error (not including
+	// non-zero exit codes, which are reported via AfterExecute). Returning
+	// a non-nil error propagates it; returning nil suppresses the original.
+	OnError func(ctx context.Context, err error) error
+}
+
+// ComposeHooks merges multiple Hooks into a single Hooks struct.
+// BeforeExecute hooks run in order; if any returns an error, subsequent hooks
+// are skipped. AfterExecute and OnTimeout hooks run in order unconditionally.
+// OnError hooks run in order; the first non-nil return wins.
+func ComposeHooks(hooks ...Hooks) Hooks {
+	h := append([]Hooks{}, hooks...)
+	return Hooks{
+		BeforeExecute: hookutil.ComposeError2(h, func(hk Hooks) func(context.Context, string, SandboxConfig) error {
+			return hk.BeforeExecute
+		}),
+		AfterExecute: hookutil.ComposeVoid2(h, func(hk Hooks) func(context.Context, ExecutionResult, error) {
+			return hk.AfterExecute
+		}),
+		OnTimeout: hookutil.ComposeVoid2(h, func(hk Hooks) func(context.Context, string, SandboxConfig) {
+			return hk.OnTimeout
+		}),
+		OnError: hookutil.ComposeErrorPassthrough(h, func(hk Hooks) func(context.Context, error) error {
+			return hk.OnError
+		}),
+	}
+}

--- a/tool/sandbox/pool.go
+++ b/tool/sandbox/pool.go
@@ -1,0 +1,158 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// poolOptions holds configuration for SandboxPool.
+type poolOptions struct {
+	size   int
+	warmup bool
+}
+
+// PoolOption configures a SandboxPool.
+type PoolOption func(*poolOptions)
+
+// WithPoolSize sets the number of sandbox instances in the pool. Default is 4.
+func WithPoolSize(n int) PoolOption {
+	return func(o *poolOptions) { o.size = n }
+}
+
+// WithWarmup enables pre-creation of all sandbox instances when the pool is
+// created. When false (the default), sandboxes are created lazily on first checkout.
+func WithWarmup(warmup bool) PoolOption {
+	return func(o *poolOptions) { o.warmup = warmup }
+}
+
+// SandboxPool manages a bounded pool of reusable Sandbox instances. It supports
+// checkout/checkin for fast reuse, avoiding the overhead of creating a new
+// sandbox for each execution.
+type SandboxPool struct {
+	mu       sync.Mutex
+	provider string
+	opts     poolOptions
+	pool     chan Sandbox
+	closed   bool
+}
+
+// NewSandboxPool creates a new pool that uses the named sandbox provider.
+// The pool pre-allocates a buffered channel of the configured size. If warmup
+// is enabled, all instances are created immediately.
+func NewSandboxPool(provider string, opts ...PoolOption) (*SandboxPool, error) {
+	o := poolOptions{size: 4}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.size <= 0 {
+		return nil, core.NewError("sandbox.pool", core.ErrInvalidInput, "pool size must be positive", nil)
+	}
+
+	p := &SandboxPool{
+		provider: provider,
+		opts:     o,
+		pool:     make(chan Sandbox, o.size),
+	}
+
+	if o.warmup {
+		for i := 0; i < o.size; i++ {
+			sb, err := NewSandbox(provider)
+			if err != nil {
+				// Close any already-created sandboxes.
+				p.closeAll(context.Background())
+				return nil, fmt.Errorf("sandbox.pool: warmup failed at instance %d: %w", i, err)
+			}
+			p.pool <- sb
+		}
+	}
+
+	return p, nil
+}
+
+// Checkout retrieves a sandbox from the pool. If the pool is empty and has not
+// reached capacity, a new instance is created. If the pool is empty and at
+// capacity, Checkout blocks until a sandbox is returned via Checkin or the
+// context is cancelled.
+func (p *SandboxPool) Checkout(ctx context.Context) (Sandbox, error) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, core.NewError("sandbox.pool", core.ErrToolFailed, "pool is closed", nil)
+	}
+	p.mu.Unlock()
+
+	// Try non-blocking first.
+	select {
+	case sb := <-p.pool:
+		return sb, nil
+	default:
+	}
+
+	// Try to create a new one (best-effort — we don't track total created
+	// since sandboxes may be discarded on error).
+	sb, err := NewSandbox(p.provider)
+	if err == nil {
+		return sb, nil
+	}
+
+	// Fall back to blocking wait.
+	select {
+	case sb := <-p.pool:
+		return sb, nil
+	case <-ctx.Done():
+		return nil, core.NewError("sandbox.pool", core.ErrTimeout, "checkout timed out", ctx.Err())
+	}
+}
+
+// Checkin returns a sandbox to the pool. If the pool buffer is full, the
+// sandbox is closed and discarded.
+func (p *SandboxPool) Checkin(sb Sandbox) {
+	if sb == nil {
+		return
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		_ = sb.Close(context.Background())
+		return
+	}
+	p.mu.Unlock()
+
+	select {
+	case p.pool <- sb:
+	default:
+		// Pool full — discard.
+		_ = sb.Close(context.Background())
+	}
+}
+
+// Close closes the pool and all sandboxes currently in it. After Close,
+// Checkout returns an error and Checkin closes returned sandboxes.
+func (p *SandboxPool) Close(ctx context.Context) error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	p.mu.Unlock()
+
+	p.closeAll(ctx)
+	return nil
+}
+
+// closeAll drains and closes all sandboxes currently in the pool channel.
+func (p *SandboxPool) closeAll(ctx context.Context) {
+	for {
+		select {
+		case sb := <-p.pool:
+			_ = sb.Close(ctx)
+		default:
+			return
+		}
+	}
+}

--- a/tool/sandbox/pool.go
+++ b/tool/sandbox/pool.go
@@ -31,11 +31,16 @@ func WithWarmup(warmup bool) PoolOption {
 // SandboxPool manages a bounded pool of reusable Sandbox instances. It supports
 // checkout/checkin for fast reuse, avoiding the overhead of creating a new
 // sandbox for each execution.
+//
+// The pool size bounds the maximum number of concurrently-live sandboxes:
+// callers that request a sandbox when all slots are checked out will block
+// until one is returned or the context is cancelled.
 type SandboxPool struct {
 	mu       sync.Mutex
 	provider string
 	opts     poolOptions
 	pool     chan Sandbox
+	sem      chan struct{} // capacity-bounded semaphore
 	closed   bool
 }
 
@@ -55,6 +60,7 @@ func NewSandboxPool(provider string, opts ...PoolOption) (*SandboxPool, error) {
 		provider: provider,
 		opts:     o,
 		pool:     make(chan Sandbox, o.size),
+		sem:      make(chan struct{}, o.size),
 	}
 
 	if o.warmup {
@@ -72,10 +78,10 @@ func NewSandboxPool(provider string, opts ...PoolOption) (*SandboxPool, error) {
 	return p, nil
 }
 
-// Checkout retrieves a sandbox from the pool. If the pool is empty and has not
-// reached capacity, a new instance is created. If the pool is empty and at
-// capacity, Checkout blocks until a sandbox is returned via Checkin or the
-// context is cancelled.
+// Checkout retrieves a sandbox from the pool. The total number of
+// concurrently live sandboxes is bounded by the pool size: if all slots are
+// checked out, Checkout blocks until a sandbox is returned via Checkin or
+// the context is cancelled.
 func (p *SandboxPool) Checkout(ctx context.Context) (Sandbox, error) {
 	p.mu.Lock()
 	if p.closed {
@@ -84,31 +90,37 @@ func (p *SandboxPool) Checkout(ctx context.Context) (Sandbox, error) {
 	}
 	p.mu.Unlock()
 
-	// Try non-blocking first.
+	// Acquire a slot from the semaphore first. This enforces the hard
+	// concurrency cap — at most opts.size sandboxes are ever live.
+	select {
+	case p.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, core.NewError("sandbox.pool", core.ErrTimeout, "checkout timed out", ctx.Err())
+	}
+
+	// Try to reuse an idle sandbox.
 	select {
 	case sb := <-p.pool:
 		return sb, nil
 	default:
 	}
 
-	// Try to create a new one (best-effort — we don't track total created
-	// since sandboxes may be discarded on error).
+	// No idle sandbox — create a new one. If creation fails, release the
+	// slot so that another caller can make progress.
 	sb, err := NewSandbox(p.provider)
-	if err == nil {
-		return sb, nil
+	if err != nil {
+		<-p.sem
+		return nil, fmt.Errorf("sandbox.pool: create sandbox: %w", err)
 	}
-
-	// Fall back to blocking wait.
-	select {
-	case sb := <-p.pool:
-		return sb, nil
-	case <-ctx.Done():
-		return nil, core.NewError("sandbox.pool", core.ErrTimeout, "checkout timed out", ctx.Err())
-	}
+	return sb, nil
 }
 
-// Checkin returns a sandbox to the pool. If the pool buffer is full, the
-// sandbox is closed and discarded.
+// Checkin returns a sandbox to the pool and releases the semaphore slot
+// previously acquired by Checkout. If the pool has been closed
+// concurrently, the sandbox is closed and dropped. The deposit into the
+// channel is performed while holding the pool mutex so that Close/closeAll
+// and Checkin are mutually exclusive, eliminating the window where a
+// sandbox could be leaked after Close has already drained the pool.
 func (p *SandboxPool) Checkin(sb Sandbox) {
 	if sb == nil {
 		return
@@ -118,15 +130,25 @@ func (p *SandboxPool) Checkin(sb Sandbox) {
 	if p.closed {
 		p.mu.Unlock()
 		_ = sb.Close(context.Background())
+		p.releaseSlot()
 		return
 	}
-	p.mu.Unlock()
-
 	select {
 	case p.pool <- sb:
+		p.mu.Unlock()
+		p.releaseSlot()
 	default:
-		// Pool full — discard.
+		p.mu.Unlock()
 		_ = sb.Close(context.Background())
+		p.releaseSlot()
+	}
+}
+
+// releaseSlot frees one semaphore slot, if one is held.
+func (p *SandboxPool) releaseSlot() {
+	select {
+	case <-p.sem:
+	default:
 	}
 }
 

--- a/tool/sandbox/process.go
+++ b/tool/sandbox/process.go
@@ -19,6 +19,7 @@ var _ Sandbox = (*ProcessSandbox)(nil)
 type processOptions struct {
 	workDir string
 	env     []string
+	hooks   Hooks
 }
 
 // ProcessOption configures a ProcessSandbox.
@@ -36,6 +37,13 @@ func WithWorkDir(dir string) ProcessOption {
 // a minimal environment.
 func WithEnv(env []string) ProcessOption {
 	return func(o *processOptions) { o.env = env }
+}
+
+// WithProcessHooks sets lifecycle hooks on the ProcessSandbox. Hooks fire
+// around each Execute call — BeforeExecute, AfterExecute, OnTimeout and
+// OnError — and are composable via ComposeHooks.
+func WithProcessHooks(h Hooks) ProcessOption {
+	return func(o *processOptions) { o.hooks = h }
 }
 
 // ProcessSandbox executes code as a child process in a temporary directory.
@@ -66,8 +74,31 @@ func (s *ProcessSandbox) Execute(ctx context.Context, code string, cfg SandboxCo
 		return ExecutionResult{}, core.NewError("sandbox.execute", core.ErrInvalidInput, "code must not be empty", nil)
 	}
 
+	// ProcessSandbox cannot enforce network isolation. Reject any non-
+	// unrestricted network policy to prevent silent misconfiguration.
+	if cfg.NetworkPolicy != "" && cfg.NetworkPolicy != NetworkUnrestricted {
+		return ExecutionResult{}, core.NewError(
+			"sandbox.execute",
+			core.ErrInvalidInput,
+			fmt.Sprintf("ProcessSandbox cannot enforce NetworkPolicy %q; use a container-based provider", cfg.NetworkPolicy),
+			nil,
+		)
+	}
+
+	if h := s.opts.hooks.BeforeExecute; h != nil {
+		if err := h(ctx, code, cfg); err != nil {
+			if oh := s.opts.hooks.OnError; oh != nil {
+				err = oh(ctx, err)
+			}
+			return ExecutionResult{}, err
+		}
+	}
+
 	lang, err := resolveLanguage(cfg.Language)
 	if err != nil {
+		if oh := s.opts.hooks.OnError; oh != nil {
+			err = oh(ctx, err)
+		}
 		return ExecutionResult{}, err
 	}
 
@@ -103,7 +134,11 @@ func (s *ProcessSandbox) Execute(ctx context.Context, code string, cfg SandboxCo
 	defer cancel()
 
 	args := append(lang.args, filename)
-	cmd := exec.CommandContext(execCtx, lang.interpreter, args...)
+	// The interpreter is selected from a fixed allowlist (supportedLanguages),
+	// args are fixed per language, and filename is a server-generated path
+	// inside a freshly created temp directory. The user-supplied code is
+	// written to the file and never passed as a command argument.
+	cmd := exec.CommandContext(execCtx, lang.interpreter, args...) //#nosec G204 -- interpreter from static allowlist, filename is server-generated
 	cmd.Dir = tmpDir
 
 	if len(s.opts.env) > 0 {
@@ -129,12 +164,29 @@ func (s *ProcessSandbox) Execute(ctx context.Context, code string, cfg SandboxCo
 	if runErr != nil {
 		if execCtx.Err() == context.DeadlineExceeded {
 			result.ExitCode = -1
-			return result, core.NewError("sandbox.execute", core.ErrTimeout,
+			if th := s.opts.hooks.OnTimeout; th != nil {
+				th(ctx, code, cfg)
+			}
+			var timeoutErr error = core.NewError("sandbox.execute", core.ErrTimeout,
 				fmt.Sprintf("execution timed out after %s", timeout), execCtx.Err())
+			if oh := s.opts.hooks.OnError; oh != nil {
+				timeoutErr = oh(ctx, timeoutErr)
+			}
+			if ah := s.opts.hooks.AfterExecute; ah != nil {
+				ah(ctx, result, timeoutErr)
+			}
+			return result, timeoutErr
 		}
 		if ctx.Err() != nil {
 			result.ExitCode = -1
-			return result, core.NewError("sandbox.execute", core.ErrTimeout, "execution cancelled", ctx.Err())
+			var cancelErr error = core.NewError("sandbox.execute", core.ErrTimeout, "execution cancelled", ctx.Err())
+			if oh := s.opts.hooks.OnError; oh != nil {
+				cancelErr = oh(ctx, cancelErr)
+			}
+			if ah := s.opts.hooks.AfterExecute; ah != nil {
+				ah(ctx, result, cancelErr)
+			}
+			return result, cancelErr
 		}
 		// Extract exit code if available.
 		if exitErr, ok := runErr.(*exec.ExitError); ok {
@@ -143,9 +195,15 @@ func (s *ProcessSandbox) Execute(ctx context.Context, code string, cfg SandboxCo
 			result.ExitCode = -1
 		}
 		// Non-zero exit is not a Go error — it means the code ran but failed.
+		if ah := s.opts.hooks.AfterExecute; ah != nil {
+			ah(ctx, result, nil)
+		}
 		return result, nil
 	}
 
+	if ah := s.opts.hooks.AfterExecute; ah != nil {
+		ah(ctx, result, nil)
+	}
 	return result, nil
 }
 

--- a/tool/sandbox/process.go
+++ b/tool/sandbox/process.go
@@ -1,0 +1,207 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// Compile-time interface check.
+var _ Sandbox = (*ProcessSandbox)(nil)
+
+// processOptions holds configuration for ProcessSandbox.
+type processOptions struct {
+	workDir string
+	env     []string
+}
+
+// ProcessOption configures a ProcessSandbox.
+type ProcessOption func(*processOptions)
+
+// WithWorkDir sets the base working directory for process execution.
+// A unique temporary subdirectory is created under this path for each
+// execution. If empty, os.TempDir() is used.
+func WithWorkDir(dir string) ProcessOption {
+	return func(o *processOptions) { o.workDir = dir }
+}
+
+// WithEnv sets the environment variables for the executed process.
+// Each entry is in the form "KEY=VALUE". If nil, the process inherits
+// a minimal environment.
+func WithEnv(env []string) ProcessOption {
+	return func(o *processOptions) { o.env = env }
+}
+
+// ProcessSandbox executes code as a child process in a temporary directory.
+//
+// WARNING: This implementation is for DEVELOPMENT AND TESTING ONLY. It does NOT
+// provide kernel-level isolation (no seccomp, no namespaces, no cgroups). The
+// executed code runs with the same privileges as the parent process. Do NOT use
+// this in production with untrusted code. For production use, register a
+// container-based sandbox provider.
+type ProcessSandbox struct {
+	opts processOptions
+}
+
+// NewProcessSandbox creates a new ProcessSandbox with the given options.
+func NewProcessSandbox(opts ...ProcessOption) *ProcessSandbox {
+	o := processOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &ProcessSandbox{opts: o}
+}
+
+// Execute runs code as a child process. It creates a temporary directory,
+// writes the code to a file, and executes it with the appropriate interpreter
+// for the configured language. Timeout is enforced via context.
+func (s *ProcessSandbox) Execute(ctx context.Context, code string, cfg SandboxConfig) (ExecutionResult, error) {
+	if code == "" {
+		return ExecutionResult{}, core.NewError("sandbox.execute", core.ErrInvalidInput, "code must not be empty", nil)
+	}
+
+	lang, err := resolveLanguage(cfg.Language)
+	if err != nil {
+		return ExecutionResult{}, err
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	maxOutput := cfg.Resources.MaxOutputBytes
+	if maxOutput == 0 {
+		maxOutput = defaultMaxOutputBytes
+	}
+
+	// Create isolated temp directory.
+	baseDir := s.opts.workDir
+	if baseDir == "" {
+		baseDir = os.TempDir()
+	}
+	tmpDir, err := os.MkdirTemp(baseDir, "beluga-sandbox-*")
+	if err != nil {
+		return ExecutionResult{}, core.NewError("sandbox.execute", core.ErrToolFailed, "failed to create temp directory", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write code to file.
+	filename := filepath.Join(tmpDir, lang.filename)
+	if err := os.WriteFile(filename, []byte(code), 0600); err != nil {
+		return ExecutionResult{}, core.NewError("sandbox.execute", core.ErrToolFailed, "failed to write code file", err)
+	}
+
+	// Build command with timeout context.
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := append(lang.args, filename)
+	cmd := exec.CommandContext(execCtx, lang.interpreter, args...)
+	cmd.Dir = tmpDir
+
+	if len(s.opts.env) > 0 {
+		cmd.Env = s.opts.env
+	}
+
+	var stdout, stderr bytes.Buffer
+	stdout.Grow(4096)
+	stderr.Grow(4096)
+	cmd.Stdout = &limitedWriter{buf: &stdout, max: maxOutput}
+	cmd.Stderr = &limitedWriter{buf: &stderr, max: maxOutput}
+
+	start := time.Now()
+	runErr := cmd.Run()
+	duration := time.Since(start)
+
+	result := ExecutionResult{
+		Output:   stdout.String(),
+		Error:    stderr.String(),
+		Duration: duration,
+	}
+
+	if runErr != nil {
+		if execCtx.Err() == context.DeadlineExceeded {
+			result.ExitCode = -1
+			return result, core.NewError("sandbox.execute", core.ErrTimeout,
+				fmt.Sprintf("execution timed out after %s", timeout), execCtx.Err())
+		}
+		if ctx.Err() != nil {
+			result.ExitCode = -1
+			return result, core.NewError("sandbox.execute", core.ErrTimeout, "execution cancelled", ctx.Err())
+		}
+		// Extract exit code if available.
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = -1
+		}
+		// Non-zero exit is not a Go error — it means the code ran but failed.
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// Close is a no-op for ProcessSandbox since each execution creates and
+// cleans up its own temporary directory.
+func (s *ProcessSandbox) Close(_ context.Context) error {
+	return nil
+}
+
+// languageSpec maps a language name to its interpreter and file extension.
+type languageSpec struct {
+	interpreter string
+	args        []string
+	filename    string
+}
+
+// supportedLanguages is the set of languages ProcessSandbox can execute.
+var supportedLanguages = map[string]languageSpec{
+	"python":     {interpreter: "python3", filename: "code.py"},
+	"javascript": {interpreter: "node", filename: "code.js"},
+	"bash":       {interpreter: "bash", filename: "code.sh"},
+	"sh":         {interpreter: "sh", filename: "code.sh"},
+	"ruby":       {interpreter: "ruby", filename: "code.rb"},
+	"go": {
+		interpreter: "go",
+		args:        []string{"run"},
+		filename:    "main.go",
+	},
+}
+
+// resolveLanguage returns the language spec for the given name or an error.
+func resolveLanguage(name string) (languageSpec, error) {
+	if name == "" {
+		return languageSpec{}, core.NewError("sandbox.execute", core.ErrInvalidInput, "language must not be empty", nil)
+	}
+	lang, ok := supportedLanguages[name]
+	if !ok {
+		return languageSpec{}, core.NewError("sandbox.execute", core.ErrInvalidInput,
+			fmt.Sprintf("unsupported language %q", name), nil)
+	}
+	return lang, nil
+}
+
+// limitedWriter wraps a bytes.Buffer and stops writing after max bytes.
+type limitedWriter struct {
+	buf *bytes.Buffer
+	max int
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	remaining := w.max - w.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil // Discard silently — still report full write to avoid cmd error.
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	return w.buf.Write(p)
+}

--- a/tool/sandbox/sandbox.go
+++ b/tool/sandbox/sandbox.go
@@ -1,0 +1,68 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Sandbox is the interface for sandboxed code execution. Implementations
+// execute arbitrary code in an isolated environment and return the result.
+type Sandbox interface {
+	// Execute runs code in the sandbox with the given configuration and
+	// returns the execution result. The context controls cancellation and
+	// deadline; if the context is cancelled the execution is aborted.
+	Execute(ctx context.Context, code string, cfg SandboxConfig) (ExecutionResult, error)
+
+	// Close releases all resources held by the sandbox. After Close returns,
+	// Execute must not be called.
+	Close(ctx context.Context) error
+}
+
+// Factory is a constructor function that creates a new Sandbox instance.
+type Factory func() (Sandbox, error)
+
+var (
+	mu       sync.RWMutex
+	registry = make(map[string]Factory)
+)
+
+// RegisterSandbox registers a sandbox factory under the given name.
+// This is typically called from an init() function.
+func RegisterSandbox(name string, f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	registry[name] = f
+}
+
+// NewSandbox creates a new Sandbox using the registered factory for name.
+// Returns an error if no factory is registered under that name.
+func NewSandbox(name string) (Sandbox, error) {
+	mu.RLock()
+	f, ok := registry[name]
+	mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("sandbox: unknown provider %q (registered: %v)", name, ListSandboxes())
+	}
+	return f()
+}
+
+// ListSandboxes returns a sorted list of all registered sandbox provider names.
+func ListSandboxes() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func init() {
+	RegisterSandbox("process", func() (Sandbox, error) {
+		return NewProcessSandbox(), nil
+	})
+}

--- a/tool/sandbox/sandbox_test.go
+++ b/tool/sandbox/sandbox_test.go
@@ -1,0 +1,555 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Registry Tests ---
+
+func TestRegistryRoundtrip(t *testing.T) {
+	// "process" is registered in init().
+	names := ListSandboxes()
+	assert.Contains(t, names, "process")
+
+	sb, err := NewSandbox("process")
+	require.NoError(t, err)
+	require.NotNil(t, sb)
+	assert.IsType(t, &ProcessSandbox{}, sb)
+}
+
+func TestNewSandboxUnknown(t *testing.T) {
+	_, err := NewSandbox("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown provider")
+}
+
+// --- ProcessSandbox Tests ---
+
+func hasPython() bool {
+	_, err := exec.LookPath("python3")
+	return err == nil
+}
+
+func hasBash() bool {
+	_, err := exec.LookPath("bash")
+	return err == nil
+}
+
+func TestProcessSandboxExecute(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	result, err := sb.Execute(ctx, "print('hello world')", SandboxConfig{
+		Language: "python",
+		Timeout:  10 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hello world\n", result.Output)
+	assert.Empty(t, result.Error)
+	assert.Greater(t, result.Duration, time.Duration(0))
+}
+
+func TestProcessSandboxBash(t *testing.T) {
+	if !hasBash() {
+		t.Skip("bash not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	result, err := sb.Execute(ctx, "echo hello from bash", SandboxConfig{
+		Language: "bash",
+		Timeout:  10 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hello from bash\n", result.Output)
+}
+
+func TestProcessSandboxNonZeroExit(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	result, err := sb.Execute(ctx, "import sys; sys.exit(42)", SandboxConfig{
+		Language: "python",
+		Timeout:  10 * time.Second,
+	})
+	// Non-zero exit is not a Go error.
+	require.NoError(t, err)
+	assert.Equal(t, 42, result.ExitCode)
+}
+
+func TestProcessSandboxStderr(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	result, err := sb.Execute(ctx, "import sys; print('oops', file=sys.stderr); sys.exit(1)", SandboxConfig{
+		Language: "python",
+		Timeout:  10 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExitCode)
+	assert.Contains(t, result.Error, "oops")
+}
+
+func TestProcessSandboxTimeout(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	_, err := sb.Execute(ctx, "import time; time.sleep(60)", SandboxConfig{
+		Language: "python",
+		Timeout:  200 * time.Millisecond,
+	})
+	require.Error(t, err)
+	var coreErr *core.Error
+	require.True(t, errors.As(err, &coreErr))
+	assert.Equal(t, core.ErrTimeout, coreErr.Code)
+}
+
+func TestProcessSandboxContextCancellation(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel immediately.
+	cancel()
+
+	_, err := sb.Execute(ctx, "import time; time.sleep(60)", SandboxConfig{
+		Language: "python",
+		Timeout:  30 * time.Second,
+	})
+	require.Error(t, err)
+}
+
+func TestProcessSandboxEmptyCode(t *testing.T) {
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	_, err := sb.Execute(ctx, "", SandboxConfig{Language: "python"})
+	require.Error(t, err)
+	var coreErr *core.Error
+	require.True(t, errors.As(err, &coreErr))
+	assert.Equal(t, core.ErrInvalidInput, coreErr.Code)
+}
+
+func TestProcessSandboxEmptyLanguage(t *testing.T) {
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	_, err := sb.Execute(ctx, "print('hi')", SandboxConfig{Language: ""})
+	require.Error(t, err)
+	var coreErr *core.Error
+	require.True(t, errors.As(err, &coreErr))
+	assert.Equal(t, core.ErrInvalidInput, coreErr.Code)
+}
+
+func TestProcessSandboxUnsupportedLanguage(t *testing.T) {
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	_, err := sb.Execute(ctx, "code", SandboxConfig{Language: "brainfuck"})
+	require.Error(t, err)
+	var coreErr *core.Error
+	require.True(t, errors.As(err, &coreErr))
+	assert.Equal(t, core.ErrInvalidInput, coreErr.Code)
+	assert.Contains(t, coreErr.Message, "unsupported language")
+}
+
+func TestProcessSandboxWithOptions(t *testing.T) {
+	if !hasBash() {
+		t.Skip("bash not available")
+	}
+
+	sb := NewProcessSandbox(
+		WithWorkDir(t.TempDir()),
+		WithEnv([]string{"PATH=/usr/bin:/bin", "MY_VAR=hello"}),
+	)
+	ctx := context.Background()
+
+	result, err := sb.Execute(ctx, "echo $MY_VAR", SandboxConfig{
+		Language: "bash",
+		Timeout:  10 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Equal(t, "hello\n", result.Output)
+}
+
+func TestProcessSandboxClose(t *testing.T) {
+	sb := NewProcessSandbox()
+	err := sb.Close(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestProcessSandboxOutputLimit(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	ctx := context.Background()
+
+	// Generate output larger than limit.
+	result, err := sb.Execute(ctx, "print('A' * 2000)", SandboxConfig{
+		Language: "python",
+		Timeout:  10 * time.Second,
+		Resources: ResourceLimits{
+			MaxOutputBytes: 100,
+		},
+	})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(result.Output), 100)
+}
+
+// --- Pool Tests ---
+
+func TestPoolCheckoutCheckin(t *testing.T) {
+	pool, err := NewSandboxPool("process", WithPoolSize(2))
+	require.NoError(t, err)
+	defer pool.Close(context.Background())
+
+	ctx := context.Background()
+
+	sb1, err := pool.Checkout(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sb1)
+
+	sb2, err := pool.Checkout(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sb2)
+
+	pool.Checkin(sb1)
+	pool.Checkin(sb2)
+
+	// Should be able to check out again.
+	sb3, err := pool.Checkout(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, sb3)
+	pool.Checkin(sb3)
+}
+
+func TestPoolWarmup(t *testing.T) {
+	pool, err := NewSandboxPool("process", WithPoolSize(2), WithWarmup(true))
+	require.NoError(t, err)
+	defer pool.Close(context.Background())
+
+	ctx := context.Background()
+
+	// Both should be available immediately from the warmed pool.
+	sb1, err := pool.Checkout(ctx)
+	require.NoError(t, err)
+	sb2, err := pool.Checkout(ctx)
+	require.NoError(t, err)
+
+	pool.Checkin(sb1)
+	pool.Checkin(sb2)
+}
+
+func TestPoolClose(t *testing.T) {
+	pool, err := NewSandboxPool("process", WithPoolSize(2), WithWarmup(true))
+	require.NoError(t, err)
+
+	err = pool.Close(context.Background())
+	require.NoError(t, err)
+
+	// Checkout after close returns error.
+	_, err = pool.Checkout(context.Background())
+	require.Error(t, err)
+}
+
+func TestPoolCheckinAfterClose(t *testing.T) {
+	pool, err := NewSandboxPool("process", WithPoolSize(2))
+	require.NoError(t, err)
+
+	sb, err := pool.Checkout(context.Background())
+	require.NoError(t, err)
+
+	err = pool.Close(context.Background())
+	require.NoError(t, err)
+
+	// Checkin after close should not panic — sandbox is closed.
+	pool.Checkin(sb)
+}
+
+func TestPoolCheckinNil(t *testing.T) {
+	pool, err := NewSandboxPool("process", WithPoolSize(2))
+	require.NoError(t, err)
+	defer pool.Close(context.Background())
+
+	// Should not panic.
+	pool.Checkin(nil)
+}
+
+func TestPoolInvalidSize(t *testing.T) {
+	_, err := NewSandboxPool("process", WithPoolSize(0))
+	require.Error(t, err)
+
+	_, err = NewSandboxPool("process", WithPoolSize(-1))
+	require.Error(t, err)
+}
+
+// --- SandboxTool Tests ---
+
+func TestSandboxToolInterface(t *testing.T) {
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb)
+
+	assert.Equal(t, "code_sandbox", st.Name())
+	assert.NotEmpty(t, st.Description())
+
+	schema := st.InputSchema()
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, props, "code")
+	assert.Contains(t, props, "language")
+
+	required, ok := schema["required"].([]string)
+	require.True(t, ok)
+	assert.Contains(t, required, "code")
+	assert.Contains(t, required, "language")
+}
+
+func TestSandboxToolExecute(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb)
+	ctx := context.Background()
+
+	result, err := st.Execute(ctx, map[string]any{
+		"code":     "print('tool output')",
+		"language": "python",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+}
+
+func TestSandboxToolMissingCode(t *testing.T) {
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb)
+	ctx := context.Background()
+
+	_, err := st.Execute(ctx, map[string]any{
+		"language": "python",
+	})
+	require.Error(t, err)
+}
+
+func TestSandboxToolMissingLanguage(t *testing.T) {
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb)
+	ctx := context.Background()
+
+	_, err := st.Execute(ctx, map[string]any{
+		"code": "print('hi')",
+	})
+	require.Error(t, err)
+}
+
+func TestSandboxToolNonZeroExit(t *testing.T) {
+	if !hasPython() {
+		t.Skip("python3 not available")
+	}
+
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb)
+	ctx := context.Background()
+
+	result, err := st.Execute(ctx, map[string]any{
+		"code":     "import sys; sys.exit(1)",
+		"language": "python",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+}
+
+func TestSandboxToolWithTimeout(t *testing.T) {
+	sb := NewProcessSandbox()
+	st := NewSandboxTool(sb, WithToolTimeout(5*time.Second))
+	assert.Equal(t, 5*time.Second, st.timeout)
+}
+
+// --- Hooks Tests ---
+
+func TestComposeHooksBeforeExecute(t *testing.T) {
+	var calls []string
+
+	h1 := Hooks{
+		BeforeExecute: func(_ context.Context, code string, _ SandboxConfig) error {
+			calls = append(calls, "h1:"+code)
+			return nil
+		},
+	}
+	h2 := Hooks{
+		BeforeExecute: func(_ context.Context, code string, _ SandboxConfig) error {
+			calls = append(calls, "h2:"+code)
+			return nil
+		},
+	}
+
+	composed := ComposeHooks(h1, h2)
+	err := composed.BeforeExecute(context.Background(), "test", SandboxConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"h1:test", "h2:test"}, calls)
+}
+
+func TestComposeHooksBeforeExecuteShortCircuit(t *testing.T) {
+	sentinel := errors.New("stop")
+	var calls []string
+
+	h1 := Hooks{
+		BeforeExecute: func(_ context.Context, _ string, _ SandboxConfig) error {
+			calls = append(calls, "h1")
+			return sentinel
+		},
+	}
+	h2 := Hooks{
+		BeforeExecute: func(_ context.Context, _ string, _ SandboxConfig) error {
+			calls = append(calls, "h2")
+			return nil
+		},
+	}
+
+	composed := ComposeHooks(h1, h2)
+	err := composed.BeforeExecute(context.Background(), "test", SandboxConfig{})
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{"h1"}, calls)
+}
+
+func TestComposeHooksAfterExecute(t *testing.T) {
+	var calls int
+
+	h := ComposeHooks(
+		Hooks{AfterExecute: func(_ context.Context, _ ExecutionResult, _ error) { calls++ }},
+		Hooks{AfterExecute: func(_ context.Context, _ ExecutionResult, _ error) { calls++ }},
+	)
+	h.AfterExecute(context.Background(), ExecutionResult{}, nil)
+	assert.Equal(t, 2, calls)
+}
+
+func TestComposeHooksOnTimeout(t *testing.T) {
+	var calls int
+
+	h := ComposeHooks(
+		Hooks{OnTimeout: func(_ context.Context, _ string, _ SandboxConfig) { calls++ }},
+		Hooks{OnTimeout: func(_ context.Context, _ string, _ SandboxConfig) { calls++ }},
+	)
+	h.OnTimeout(context.Background(), "code", SandboxConfig{})
+	assert.Equal(t, 2, calls)
+}
+
+func TestComposeHooksOnError(t *testing.T) {
+	original := errors.New("original")
+	replaced := errors.New("replaced")
+
+	h := ComposeHooks(
+		Hooks{OnError: func(_ context.Context, _ error) error { return replaced }},
+	)
+	err := h.OnError(context.Background(), original)
+	assert.ErrorIs(t, err, replaced)
+}
+
+func TestComposeHooksNilFields(t *testing.T) {
+	// Should not panic with empty hooks.
+	h := ComposeHooks(Hooks{}, Hooks{})
+	assert.NotNil(t, h.BeforeExecute)
+	assert.NotNil(t, h.AfterExecute)
+	assert.NotNil(t, h.OnTimeout)
+	assert.NotNil(t, h.OnError)
+
+	// Calling them should be safe.
+	err := h.BeforeExecute(context.Background(), "", SandboxConfig{})
+	assert.NoError(t, err)
+	h.AfterExecute(context.Background(), ExecutionResult{}, nil)
+	h.OnTimeout(context.Background(), "", SandboxConfig{})
+	err = h.OnError(context.Background(), errors.New("test"))
+	assert.Error(t, err) // passthrough returns original.
+}
+
+// --- LimitedWriter Tests ---
+
+func TestLimitedWriter(t *testing.T) {
+	tests := []struct {
+		name    string
+		max     int
+		writes  []string
+		want    string
+		wantLen int
+	}{
+		{
+			name:    "within limit",
+			max:     100,
+			writes:  []string{"hello"},
+			want:    "hello",
+			wantLen: 5,
+		},
+		{
+			name:    "exactly at limit",
+			max:     5,
+			writes:  []string{"hello"},
+			want:    "hello",
+			wantLen: 5,
+		},
+		{
+			name:    "exceeds limit",
+			max:     3,
+			writes:  []string{"hello"},
+			want:    "hel",
+			wantLen: 3,
+		},
+		{
+			name:    "multiple writes exceed limit",
+			max:     5,
+			writes:  []string{"hel", "lo world"},
+			want:    "hello",
+			wantLen: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := &limitedWriter{buf: &buf, max: tt.max}
+			for _, s := range tt.writes {
+				_, err := w.Write([]byte(s))
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, buf.String())
+			assert.Equal(t, tt.wantLen, buf.Len())
+		})
+	}
+}

--- a/tool/sandbox/tool.go
+++ b/tool/sandbox/tool.go
@@ -1,0 +1,114 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// Compile-time interface check.
+var _ tool.Tool = (*SandboxTool)(nil)
+
+// SandboxTool wraps a Sandbox as a tool.Tool, making it callable by agents.
+// The tool accepts JSON input with "code" and "language" fields and returns
+// the execution result as structured JSON text.
+type SandboxTool struct {
+	sandbox Sandbox
+	timeout time.Duration
+}
+
+// SandboxToolOption configures a SandboxTool.
+type SandboxToolOption func(*SandboxTool)
+
+// WithToolTimeout sets the default execution timeout for the sandbox tool.
+// This can be overridden by the SandboxConfig timeout if the sandbox
+// provider supports it. Default is 30 seconds.
+func WithToolTimeout(d time.Duration) SandboxToolOption {
+	return func(t *SandboxTool) { t.timeout = d }
+}
+
+// NewSandboxTool creates a new SandboxTool wrapping the given Sandbox.
+func NewSandboxTool(sb Sandbox, opts ...SandboxToolOption) *SandboxTool {
+	t := &SandboxTool{
+		sandbox: sb,
+		timeout: defaultTimeout,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// Name returns the tool name.
+func (t *SandboxTool) Name() string { return "code_sandbox" }
+
+// Description returns a human-readable description for LLM tool selection.
+func (t *SandboxTool) Description() string {
+	return "Execute code in a sandboxed environment. Supports python, javascript, bash, sh, ruby, and go."
+}
+
+// InputSchema returns the JSON Schema for the tool's input parameters.
+func (t *SandboxTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"code": map[string]any{
+				"type":        "string",
+				"description": "The source code to execute",
+			},
+			"language": map[string]any{
+				"type":        "string",
+				"description": "Programming language (python, javascript, bash, sh, ruby, go)",
+				"enum":        []string{"python", "javascript", "bash", "sh", "ruby", "go"},
+			},
+		},
+		"required": []string{"code", "language"},
+	}
+}
+
+// Execute runs code in the sandbox. Input must contain "code" (string) and
+// "language" (string) fields. Returns a tool.Result with the execution output
+// as JSON text.
+func (t *SandboxTool) Execute(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	code, ok := input["code"].(string)
+	if !ok || code == "" {
+		return nil, core.NewError("sandbox.tool", core.ErrInvalidInput, "input must contain a non-empty 'code' string", nil)
+	}
+
+	language, ok := input["language"].(string)
+	if !ok || language == "" {
+		return nil, core.NewError("sandbox.tool", core.ErrInvalidInput, "input must contain a non-empty 'language' string", nil)
+	}
+
+	cfg := SandboxConfig{
+		Language: language,
+		Timeout:  t.timeout,
+	}
+
+	result, err := t.sandbox.Execute(ctx, code, cfg)
+	if err != nil {
+		return tool.ErrorResult(fmt.Errorf("sandbox execution failed: %w", err)), nil
+	}
+
+	// Marshal the result as JSON for structured output.
+	output := map[string]any{
+		"output":    result.Output,
+		"error":     result.Error,
+		"exit_code": result.ExitCode,
+		"duration":  result.Duration.String(),
+	}
+	data, marshalErr := json.Marshal(output)
+	if marshalErr != nil {
+		return tool.ErrorResult(fmt.Errorf("failed to marshal result: %w", marshalErr)), nil
+	}
+
+	r := tool.TextResult(string(data))
+	if result.ExitCode != 0 {
+		r.IsError = true
+	}
+	return r, nil
+}

--- a/tool/sandbox/types.go
+++ b/tool/sandbox/types.go
@@ -41,6 +41,13 @@ type SandboxConfig struct {
 
 	// NetworkPolicy controls network access for this execution.
 	// Zero value defaults to NetworkIsolated.
+	//
+	// IMPORTANT: Enforcement of NetworkPolicy depends on the sandbox
+	// provider. Container-based providers (Docker, gVisor, Firecracker,
+	// E2B) enforce this via network namespaces or egress policies.
+	// ProcessSandbox CANNOT enforce network policies and always runs
+	// with the parent process's network access — it rejects any
+	// non-unrestricted policy at Execute() time.
 	NetworkPolicy NetworkPolicy
 
 	// Resources sets compute resource limits for this execution.

--- a/tool/sandbox/types.go
+++ b/tool/sandbox/types.go
@@ -1,0 +1,73 @@
+package sandbox
+
+import "time"
+
+// NetworkPolicy controls the network access level for a sandbox.
+type NetworkPolicy string
+
+const (
+	// NetworkIsolated denies all network access from the sandbox.
+	NetworkIsolated NetworkPolicy = "isolated"
+
+	// NetworkAllowListed permits network access only to explicitly allowed hosts.
+	NetworkAllowListed NetworkPolicy = "allow_listed"
+
+	// NetworkUnrestricted permits all outbound network access.
+	NetworkUnrestricted NetworkPolicy = "unrestricted"
+)
+
+// ResourceLimits defines the compute resources available to a sandbox.
+type ResourceLimits struct {
+	// MemoryMB is the maximum memory in megabytes. Zero means no limit.
+	MemoryMB int
+
+	// CPUs is the number of CPU cores available. Zero means no limit.
+	CPUs float64
+
+	// MaxOutputBytes is the maximum combined size of stdout and stderr
+	// captured from the sandbox. Zero means use the default (1 MB).
+	MaxOutputBytes int
+}
+
+// SandboxConfig configures a single code execution request.
+type SandboxConfig struct {
+	// Language is the programming language of the code to execute
+	// (e.g., "python", "javascript", "go", "bash").
+	Language string
+
+	// Timeout is the maximum duration for the execution. Zero means
+	// use the sandbox's default timeout.
+	Timeout time.Duration
+
+	// NetworkPolicy controls network access for this execution.
+	// Zero value defaults to NetworkIsolated.
+	NetworkPolicy NetworkPolicy
+
+	// Resources sets compute resource limits for this execution.
+	Resources ResourceLimits
+
+	// AllowedHosts is the list of permitted hosts when NetworkPolicy
+	// is NetworkAllowListed. Ignored for other policies.
+	AllowedHosts []string
+}
+
+// ExecutionResult holds the output of a sandboxed code execution.
+type ExecutionResult struct {
+	// Output is the captured stdout from the execution.
+	Output string
+
+	// Error is the captured stderr from the execution.
+	Error string
+
+	// ExitCode is the process exit code. Zero indicates success.
+	ExitCode int
+
+	// Duration is the wall-clock time the execution took.
+	Duration time.Duration
+}
+
+// defaultTimeout is the fallback execution timeout when none is specified.
+const defaultTimeout = 30 * time.Second
+
+// defaultMaxOutputBytes is the fallback maximum output size (1 MB).
+const defaultMaxOutputBytes = 1024 * 1024


### PR DESCRIPTION
## Summary
- tool/sandbox package, Sandbox interface, ProcessSandbox (dev-only), SandboxPool with warmup, NetworkPolicy

## Linear
- LOO-28: https://linear.app/lookatitude/issue/LOO-28

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)