### PR TITLE
LOO-29: Computer Use / Browser Automation Tools

### DIFF
--- a/tool/computeruse/action.go
+++ b/tool/computeruse/action.go
@@ -14,8 +14,8 @@ const (
 	// ActionClick performs a mouse click at coordinates.
 	ActionClick ActionType = "click"
 
-	// ActionType_ performs keyboard text input.
-	ActionType_ ActionType = "type"
+	// ActionTypeText performs keyboard text input.
+	ActionTypeText ActionType = "type"
 
 	// ActionScroll performs a scroll action.
 	ActionScroll ActionType = "scroll"

--- a/tool/computeruse/action.go
+++ b/tool/computeruse/action.go
@@ -1,0 +1,67 @@
+package computeruse
+
+import (
+	"context"
+)
+
+// ActionType identifies the kind of computer action.
+type ActionType string
+
+const (
+	// ActionScreenshot captures the current screen state.
+	ActionScreenshot ActionType = "screenshot"
+
+	// ActionClick performs a mouse click at coordinates.
+	ActionClick ActionType = "click"
+
+	// ActionType_ performs keyboard text input.
+	ActionType_ ActionType = "type"
+
+	// ActionScroll performs a scroll action.
+	ActionScroll ActionType = "scroll"
+
+	// ActionKeyPress sends a key press event.
+	ActionKeyPress ActionType = "key_press"
+)
+
+// ActionRequest describes a computer action to perform.
+type ActionRequest struct {
+	// Type is the kind of action to perform.
+	Type ActionType
+
+	// X is the horizontal coordinate for click/scroll actions.
+	X int
+
+	// Y is the vertical coordinate for click/scroll actions.
+	Y int
+
+	// Text is the text to type for type actions, or the key name for key_press.
+	Text string
+
+	// ScrollDelta is the scroll amount (positive = down, negative = up).
+	ScrollDelta int
+}
+
+// ActionResult holds the outcome of a computer action.
+type ActionResult struct {
+	// Screenshot is the screen capture after the action, as PNG bytes.
+	// May be nil for non-screenshot actions if the backend does not
+	// automatically capture.
+	Screenshot []byte
+
+	// Description is a human-readable description of the action result.
+	Description string
+
+	// Success indicates whether the action completed without error.
+	Success bool
+}
+
+// ComputerAction is the interface for performing screen interactions.
+// Implementations drive actual computer or browser automation.
+type ComputerAction interface {
+	// Execute performs the requested action and returns the result.
+	Execute(ctx context.Context, req ActionRequest) (*ActionResult, error)
+
+	// Screenshot captures the current screen state as PNG bytes.
+	Screenshot(ctx context.Context) ([]byte, error)
+}

--- a/tool/computeruse/analyzer.go
+++ b/tool/computeruse/analyzer.go
@@ -1,0 +1,75 @@
+package computeruse
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+const analyzePrompt = "Describe what you see in this screenshot. Focus on interactive elements (buttons, links, text fields, menus) and their positions. Be concise."
+
+// analyzerOptions holds configuration for ScreenAnalyzer.
+type analyzerOptions struct {
+	model  llm.ChatModel
+	prompt string
+}
+
+// AnalyzerOption configures a ScreenAnalyzer.
+type AnalyzerOption func(*analyzerOptions)
+
+// WithAnalyzerModel sets the multimodal LLM used for screenshot analysis.
+func WithAnalyzerModel(m llm.ChatModel) AnalyzerOption {
+	return func(o *analyzerOptions) {
+		o.model = m
+	}
+}
+
+// WithAnalyzerPrompt sets a custom analysis prompt.
+func WithAnalyzerPrompt(prompt string) AnalyzerOption {
+	return func(o *analyzerOptions) {
+		o.prompt = prompt
+	}
+}
+
+// ScreenAnalyzer uses a multimodal LLM to describe screenshots, enabling
+// vision-based interaction for agents that need to understand screen content.
+type ScreenAnalyzer struct {
+	opts analyzerOptions
+}
+
+// NewScreenAnalyzer creates a new ScreenAnalyzer with the given options.
+func NewScreenAnalyzer(opts ...AnalyzerOption) (*ScreenAnalyzer, error) {
+	o := analyzerOptions{prompt: analyzePrompt}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.model == nil {
+		return nil, core.NewError("computeruse.analyzer.new", core.ErrInvalidInput, "model is required", nil)
+	}
+	return &ScreenAnalyzer{opts: o}, nil
+}
+
+// Analyze sends a screenshot to the multimodal LLM and returns a textual
+// description of the screen content.
+func (a *ScreenAnalyzer) Analyze(ctx context.Context, screenshot []byte) (string, error) {
+	if len(screenshot) == 0 {
+		return "", core.NewError("computeruse.analyzer.analyze", core.ErrInvalidInput, "screenshot must not be empty", nil)
+	}
+
+	msg := &schema.HumanMessage{
+		Parts: []schema.ContentPart{
+			schema.TextPart{Text: a.opts.prompt},
+			schema.ImagePart{Data: screenshot, MimeType: "image/png"},
+		},
+	}
+
+	resp, err := a.opts.model.Generate(ctx, []schema.Message{msg})
+	if err != nil {
+		return "", fmt.Errorf("screen analyzer: llm generate: %w", err)
+	}
+
+	return resp.Text(), nil
+}

--- a/tool/computeruse/browser.go
+++ b/tool/computeruse/browser.go
@@ -1,0 +1,33 @@
+package computeruse
+
+import (
+	"context"
+)
+
+// BrowserBackend is the interface for browser automation. Implementations
+// wrap headless browsers or browser automation frameworks.
+type BrowserBackend interface {
+	// Navigate loads the given URL in the browser.
+	Navigate(ctx context.Context, url string) error
+
+	// Screenshot captures the current page as PNG bytes.
+	Screenshot(ctx context.Context) ([]byte, error)
+
+	// Click performs a mouse click at the given coordinates.
+	Click(ctx context.Context, x, y int) error
+
+	// Type enters text into the currently focused element.
+	Type(ctx context.Context, text string) error
+}
+
+// ExtendedBrowser is an optional interface for browsers that support
+// JavaScript execution and scrolling. Check via type assertion.
+type ExtendedBrowser interface {
+	BrowserBackend
+
+	// Scroll scrolls the page by the given delta (positive = down).
+	Scroll(ctx context.Context, x, y, delta int) error
+
+	// ExecuteJS runs JavaScript in the browser and returns the result.
+	ExecuteJS(ctx context.Context, script string) (string, error)
+}

--- a/tool/computeruse/computeruse_test.go
+++ b/tool/computeruse/computeruse_test.go
@@ -1,0 +1,387 @@
+package computeruse
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/internal/testutil/mockllm"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock implementations ---
+
+type mockAction struct {
+	lastReq    ActionRequest
+	screenshot []byte
+	result     *ActionResult
+	err        error
+}
+
+func (m *mockAction) Execute(_ context.Context, req ActionRequest) (*ActionResult, error) {
+	m.lastReq = req
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.result != nil {
+		return m.result, nil
+	}
+	return &ActionResult{Success: true, Description: "action executed"}, nil
+}
+
+func (m *mockAction) Screenshot(_ context.Context) ([]byte, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.screenshot, nil
+}
+
+type mockBrowser struct {
+	lastURL    string
+	lastText   string
+	lastX      int
+	lastY      int
+	screenshot []byte
+	err        error
+}
+
+func (m *mockBrowser) Navigate(_ context.Context, url string) error {
+	m.lastURL = url
+	return m.err
+}
+
+func (m *mockBrowser) Screenshot(_ context.Context) ([]byte, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.screenshot, nil
+}
+
+func (m *mockBrowser) Click(_ context.Context, x, y int) error {
+	m.lastX, m.lastY = x, y
+	return m.err
+}
+
+func (m *mockBrowser) Type(_ context.Context, text string) error {
+	m.lastText = text
+	return m.err
+}
+
+// mockChatModel adapts mockllm to llm.ChatModel.
+type mockChatModel struct {
+	*mockllm.MockChatModel
+}
+
+func (m *mockChatModel) Generate(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+	return m.MockChatModel.Generate(ctx, msgs)
+}
+
+func (m *mockChatModel) Stream(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
+	return m.MockChatModel.Stream(ctx, msgs)
+}
+
+func (m *mockChatModel) BindTools(tools []schema.ToolDefinition) llm.ChatModel {
+	return &mockChatModel{m.MockChatModel.BindTools(tools)}
+}
+
+// --- SafetyGuard tests ---
+
+func TestSafetyGuard_CheckURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		hosts    []string
+		block    []string
+		url      string
+		wantErr  bool
+		wantCode core.ErrorCode
+	}{
+		{
+			name:  "allowed host",
+			hosts: []string{"example.com"},
+			url:   "https://example.com/page",
+		},
+		{
+			name:     "blocked host",
+			hosts:    []string{"example.com"},
+			url:      "https://evil.com/page",
+			wantErr:  true,
+			wantCode: core.ErrGuardBlocked,
+		},
+		{
+			name: "no allowlist permits all",
+			url:  "https://anything.com",
+		},
+		{
+			name:     "block pattern match",
+			block:    []string{"/admin"},
+			url:      "https://example.com/admin/settings",
+			wantErr:  true,
+			wantCode: core.ErrGuardBlocked,
+		},
+		{
+			name:     "invalid URL",
+			url:      "://bad",
+			wantErr:  true,
+			wantCode: core.ErrInvalidInput,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []GuardOption{}
+			if len(tt.hosts) > 0 {
+				opts = append(opts, WithAllowedHosts(tt.hosts...))
+			}
+			if len(tt.block) > 0 {
+				opts = append(opts, WithBlockPatterns(tt.block...))
+			}
+			guard := NewSafetyGuard(opts...)
+
+			err := guard.CheckURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				var coreErr *core.Error
+				require.ErrorAs(t, err, &coreErr)
+				assert.Equal(t, tt.wantCode, coreErr.Code)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSafetyGuard_CheckAction_RateLimit(t *testing.T) {
+	guard := NewSafetyGuard(WithMaxActionsPerMinute(3))
+
+	require.NoError(t, guard.CheckAction())
+	require.NoError(t, guard.CheckAction())
+	require.NoError(t, guard.CheckAction())
+
+	err := guard.CheckAction()
+	require.Error(t, err)
+	var coreErr *core.Error
+	require.ErrorAs(t, err, &coreErr)
+	assert.Equal(t, core.ErrRateLimit, coreErr.Code)
+}
+
+func TestSafetyGuard_ActionsInWindow(t *testing.T) {
+	guard := NewSafetyGuard(WithMaxActionsPerMinute(10))
+	_ = guard.CheckAction()
+	_ = guard.CheckAction()
+	assert.Equal(t, 2, guard.ActionsInWindow())
+}
+
+// --- ScreenAnalyzer tests ---
+
+func TestScreenAnalyzer_Analyze(t *testing.T) {
+	model := &mockChatModel{mockllm.New(mockllm.WithResponse(schema.NewAIMessage("A login page with username and password fields")))}
+	analyzer, err := NewScreenAnalyzer(WithAnalyzerModel(model))
+	require.NoError(t, err)
+
+	desc, err := analyzer.Analyze(context.Background(), []byte("fake-png"))
+	require.NoError(t, err)
+	assert.Contains(t, desc, "login page")
+}
+
+func TestScreenAnalyzer_EmptyScreenshot(t *testing.T) {
+	model := &mockChatModel{mockllm.New()}
+	analyzer, err := NewScreenAnalyzer(WithAnalyzerModel(model))
+	require.NoError(t, err)
+
+	_, err = analyzer.Analyze(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestScreenAnalyzer_NoModel(t *testing.T) {
+	_, err := NewScreenAnalyzer()
+	require.Error(t, err)
+}
+
+// --- ComputerUseTool tests ---
+
+func TestComputerUseTool_Name(t *testing.T) {
+	action := &mockAction{screenshot: []byte("png")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+	assert.Equal(t, "computer_use", ct.Name())
+}
+
+func TestComputerUseTool_Description(t *testing.T) {
+	action := &mockAction{screenshot: []byte("png")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+	assert.NotEmpty(t, ct.Description())
+}
+
+func TestComputerUseTool_InputSchema(t *testing.T) {
+	action := &mockAction{screenshot: []byte("png")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+	schema := ct.InputSchema()
+	assert.Equal(t, "object", schema["type"])
+}
+
+func TestComputerUseTool_NoBackend(t *testing.T) {
+	_, err := NewComputerUseTool()
+	require.Error(t, err)
+}
+
+func TestComputerUseTool_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]any
+		wantErr bool
+		check   func(t *testing.T, action *mockAction, browser *mockBrowser)
+	}{
+		{
+			name:  "screenshot via action",
+			input: map[string]any{"action": "screenshot"},
+		},
+		{
+			name:  "click via browser",
+			input: map[string]any{"action": "click", "x": float64(100), "y": float64(200)},
+			check: func(t *testing.T, _ *mockAction, browser *mockBrowser) {
+				assert.Equal(t, 100, browser.lastX)
+				assert.Equal(t, 200, browser.lastY)
+			},
+		},
+		{
+			name:  "type via browser",
+			input: map[string]any{"action": "type", "text": "hello"},
+			check: func(t *testing.T, _ *mockAction, browser *mockBrowser) {
+				assert.Equal(t, "hello", browser.lastText)
+			},
+		},
+		{
+			name:  "navigate",
+			input: map[string]any{"action": "navigate", "url": "https://example.com"},
+			check: func(t *testing.T, _ *mockAction, browser *mockBrowser) {
+				assert.Equal(t, "https://example.com", browser.lastURL)
+			},
+		},
+		{
+			name:  "key_press via action",
+			input: map[string]any{"action": "key_press", "text": "Enter"},
+			check: func(t *testing.T, action *mockAction, _ *mockBrowser) {
+				assert.Equal(t, ActionKeyPress, action.lastReq.Type)
+				assert.Equal(t, "Enter", action.lastReq.Text)
+			},
+		},
+		{
+			name:  "missing action",
+			input: map[string]any{},
+		},
+		{
+			name:  "unknown action",
+			input: map[string]any{"action": "fly"},
+		},
+		{
+			name:  "type missing text",
+			input: map[string]any{"action": "type"},
+		},
+		{
+			name:  "navigate missing url",
+			input: map[string]any{"action": "navigate"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action := &mockAction{
+				screenshot: []byte("fake-png"),
+				result:     &ActionResult{Success: true, Description: "done"},
+			}
+			browser := &mockBrowser{screenshot: []byte("fake-png")}
+			guard := NewSafetyGuard(WithAllowedHosts("example.com"))
+
+			ct, err := NewComputerUseTool(
+				WithAction(action),
+				WithBrowser(browser),
+				WithSafetyGuard(guard),
+			)
+			require.NoError(t, err)
+
+			result, err := ct.Execute(context.Background(), tt.input)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+
+			if tt.check != nil {
+				tt.check(t, action, browser)
+			}
+		})
+	}
+}
+
+func TestComputerUseTool_NavigateBlocked(t *testing.T) {
+	browser := &mockBrowser{}
+	guard := NewSafetyGuard(WithAllowedHosts("safe.com"))
+
+	ct, err := NewComputerUseTool(WithBrowser(browser), WithSafetyGuard(guard))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "navigate",
+		"url":    "https://evil.com",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_RateLimited(t *testing.T) {
+	action := &mockAction{screenshot: []byte("png")}
+	guard := NewSafetyGuard(WithMaxActionsPerMinute(1))
+
+	ct, err := NewComputerUseTool(WithAction(action), WithSafetyGuard(guard))
+	require.NoError(t, err)
+
+	// First action succeeds.
+	result, err := ct.Execute(context.Background(), map[string]any{"action": "screenshot"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// Second action rate limited.
+	result, err = ct.Execute(context.Background(), map[string]any{"action": "screenshot"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_BrowserError(t *testing.T) {
+	browser := &mockBrowser{err: errors.New("browser crashed")}
+	ct, err := NewComputerUseTool(WithBrowser(browser))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "navigate",
+		"url":    "https://example.com",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_ScreenshotWithAnalyzer(t *testing.T) {
+	model := &mockChatModel{mockllm.New(mockllm.WithResponse(schema.NewAIMessage("A web page")))}
+	analyzer, err := NewScreenAnalyzer(WithAnalyzerModel(model))
+	require.NoError(t, err)
+
+	browser := &mockBrowser{screenshot: []byte("fake-png")}
+	ct, err := NewComputerUseTool(WithBrowser(browser), WithScreenAnalyzer(analyzer))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{"action": "screenshot"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	// Should have image part + text description.
+	assert.Len(t, result.Content, 2)
+}
+
+func TestToInt(t *testing.T) {
+	assert.Equal(t, 42, toInt(float64(42)))
+	assert.Equal(t, 42, toInt(42))
+	assert.Equal(t, 0, toInt("not a number"))
+	assert.Equal(t, 0, toInt(nil))
+}

--- a/tool/computeruse/computeruse_test.go
+++ b/tool/computeruse/computeruse_test.go
@@ -2,6 +2,7 @@ package computeruse
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"iter"
 	"testing"
@@ -384,4 +385,281 @@ func TestToInt(t *testing.T) {
 	assert.Equal(t, 42, toInt(42))
 	assert.Equal(t, 0, toInt("not a number"))
 	assert.Equal(t, 0, toInt(nil))
+	assert.Equal(t, 99, toInt(json.Number("99")))
+}
+
+// mockExtendedBrowser is a BrowserBackend that also implements ExtendedBrowser.
+type mockExtendedBrowser struct {
+	mockBrowser
+	lastScrollX     int
+	lastScrollY     int
+	lastScrollDelta int
+	scrollErr       error
+}
+
+func (m *mockExtendedBrowser) Scroll(_ context.Context, x, y, delta int) error {
+	m.lastScrollX = x
+	m.lastScrollY = y
+	m.lastScrollDelta = delta
+	return m.scrollErr
+}
+
+func (m *mockExtendedBrowser) ExecuteJS(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func TestComputerUseTool_Scroll(t *testing.T) {
+	tests := []struct {
+		name       string
+		useAction  bool
+		useBrowser bool
+		extBrowser bool
+		scrollErr  bool
+		input      map[string]any
+		wantError  bool
+	}{
+		{
+			name:       "scroll via extended browser",
+			useBrowser: true,
+			extBrowser: true,
+			input:      map[string]any{"action": "scroll", "x": float64(10), "y": float64(20), "scroll_delta": float64(3)},
+		},
+		{
+			name:       "scroll via extended browser error",
+			useBrowser: true,
+			extBrowser: true,
+			scrollErr:  true,
+			input:      map[string]any{"action": "scroll", "x": float64(10), "y": float64(20), "scroll_delta": float64(3)},
+			wantError:  true,
+		},
+		{
+			name:      "scroll via action backend",
+			useAction: true,
+			input:     map[string]any{"action": "scroll", "x": float64(5), "y": float64(5), "scroll_delta": float64(-1)},
+		},
+		{
+			name:       "scroll no action backend (plain browser)",
+			useBrowser: true,
+			input:      map[string]any{"action": "scroll", "x": float64(0), "y": float64(0), "scroll_delta": float64(1)},
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []ToolOption
+			var extBr *mockExtendedBrowser
+			var act *mockAction
+
+			if tt.extBrowser {
+				scrollErr := error(nil)
+				if tt.scrollErr {
+					scrollErr = errors.New("scroll failed")
+				}
+				extBr = &mockExtendedBrowser{scrollErr: scrollErr}
+				opts = append(opts, WithBrowser(extBr))
+			} else if tt.useBrowser {
+				opts = append(opts, WithBrowser(&mockBrowser{}))
+			}
+
+			if tt.useAction {
+				act = &mockAction{}
+				opts = append(opts, WithAction(act))
+			}
+
+			ct, err := NewComputerUseTool(opts...)
+			require.NoError(t, err)
+
+			result, err := ct.Execute(context.Background(), tt.input)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.wantError, result.IsError)
+
+			if extBr != nil && !tt.scrollErr {
+				assert.Equal(t, 10, extBr.lastScrollX)
+				assert.Equal(t, 20, extBr.lastScrollY)
+				assert.Equal(t, 3, extBr.lastScrollDelta)
+			}
+		})
+	}
+}
+
+func TestComputerUseTool_ClickViaAction(t *testing.T) {
+	action := &mockAction{result: &ActionResult{Success: true, Description: "clicked"}}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "click", "x": float64(50), "y": float64(60),
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, ActionClick, action.lastReq.Type)
+}
+
+func TestComputerUseTool_ClickViaActionError(t *testing.T) {
+	action := &mockAction{err: errors.New("action failed")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "click", "x": float64(50), "y": float64(60),
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_ClickViaActionNoBrowser(t *testing.T) {
+	action := &mockAction{}
+	browser := &mockBrowser{err: errors.New("click failed")}
+	ct, err := NewComputerUseTool(WithAction(action), WithBrowser(browser))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "click", "x": float64(50), "y": float64(60),
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_TypeViaAction(t *testing.T) {
+	action := &mockAction{result: &ActionResult{Success: true, Description: "typed"}}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "type", "text": "hello world",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, ActionTypeText, action.lastReq.Type)
+	assert.Equal(t, "hello world", action.lastReq.Text)
+}
+
+func TestComputerUseTool_TypeViaActionError(t *testing.T) {
+	action := &mockAction{err: errors.New("type failed")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "type", "text": "hello",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_TypeViaActionNoBrowserText(t *testing.T) {
+	action := &mockAction{}
+	browser := &mockBrowser{err: errors.New("type failed")}
+	ct, err := NewComputerUseTool(WithAction(action), WithBrowser(browser))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "type", "text": "hello",
+	})
+	require.NoError(t, err)
+	// browser Type error returns an error result, but browser path is tried first
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_KeyPressMissingText(t *testing.T) {
+	action := &mockAction{}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{"action": "key_press"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_KeyPressActionError(t *testing.T) {
+	action := &mockAction{err: errors.New("key press failed")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action": "key_press", "text": "Escape",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_ScreenshotActionError(t *testing.T) {
+	action := &mockAction{err: errors.New("screenshot failed")}
+	ct, err := NewComputerUseTool(WithAction(action))
+	require.NoError(t, err)
+
+	result, err := ct.Execute(context.Background(), map[string]any{"action": "screenshot"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestComputerUseTool_InputSchema_BrowserOnly(t *testing.T) {
+	browser := &mockBrowser{}
+	ct, err := NewComputerUseTool(WithBrowser(browser))
+	require.NoError(t, err)
+
+	schema := ct.InputSchema()
+	props := schema["properties"].(map[string]any)
+	actionSchema := props["action"].(map[string]any)
+	actions := actionSchema["enum"].([]string)
+
+	// key_press should not be in actions list when no ComputerAction backend
+	for _, a := range actions {
+		assert.NotEqual(t, "key_press", a)
+	}
+	// navigate should be present for browser backend
+	found := false
+	for _, a := range actions {
+		if a == "navigate" {
+			found = true
+		}
+	}
+	assert.True(t, found, "navigate should be advertised when browser backend is set")
+}
+
+func TestSafetyGuard_CheckURL_SchemeBlocked(t *testing.T) {
+	guard := NewSafetyGuard()
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"file scheme", "file:///etc/passwd"},
+		{"javascript scheme", "javascript:alert(1)"},
+		{"data scheme", "data:text/html,<h1>test</h1>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := guard.CheckURL(tt.url)
+			require.Error(t, err)
+			var coreErr *core.Error
+			require.ErrorAs(t, err, &coreErr)
+			assert.Equal(t, core.ErrInvalidInput, coreErr.Code)
+		})
+	}
+}
+
+func TestSafetyGuard_WithAllowedHosts_IPv6(t *testing.T) {
+	// IPv6 addresses: url.Hostname() strips brackets, returning "::1".
+	// WithAllowedHosts must normalize "[::1]" to "::1" so that the comparison
+	// is consistent (the colon-check detects the colons inside the brackets
+	// and leaves the entry unchanged because strings.Contains(normalized[:i], ":")
+	// is true for an IPv6 address).
+	guard := NewSafetyGuard(WithAllowedHosts("::1"))
+	err := guard.CheckURL("https://[::1]/page")
+	require.NoError(t, err)
+}
+
+func TestWithAnalyzerPrompt(t *testing.T) {
+	model := &mockChatModel{mockllm.New(mockllm.WithResponse(schema.NewAIMessage("described")))}
+	analyzer, err := NewScreenAnalyzer(
+		WithAnalyzerModel(model),
+		WithAnalyzerPrompt("custom prompt"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "custom prompt", analyzer.opts.prompt)
+
+	desc, err := analyzer.Analyze(context.Background(), []byte("fake-png"))
+	require.NoError(t, err)
+	assert.Equal(t, "described", desc)
 }

--- a/tool/computeruse/doc.go
+++ b/tool/computeruse/doc.go
@@ -1,0 +1,15 @@
+// Package computeruse provides computer use and browser automation
+// capabilities for AI agents.
+//
+// It defines interfaces for computer actions (screenshot, click, type, scroll)
+// and browser backends, with safety guards for URL allowlisting and action
+// rate limiting. A ScreenAnalyzer uses multimodal LLMs to describe
+// screenshots, enabling vision-based agent interaction.
+//
+// Key types:
+//   - ComputerAction: Interface for screen interactions
+//   - BrowserBackend: Interface for browser automation
+//   - ScreenAnalyzer: Multimodal LLM-based screenshot analysis
+//   - ComputerUseTool: Implements tool.Tool for agent integration
+//   - SafetyGuard: URL allowlisting and action rate limiting
+package computeruse

--- a/tool/computeruse/guard.go
+++ b/tool/computeruse/guard.go
@@ -10,6 +10,9 @@ import (
 	"github.com/lookatitude/beluga-ai/core"
 )
 
+// checkURLOp identifies the guard.CheckURL operation in error codes.
+const checkURLOp = "computeruse.guard.check_url"
+
 // guardOptions holds configuration for SafetyGuard.
 type guardOptions struct {
 	allowedHosts        map[string]bool
@@ -85,7 +88,7 @@ func NewSafetyGuard(opts ...GuardOption) *SafetyGuard {
 func (g *SafetyGuard) CheckURL(rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return core.NewError("computeruse.guard.check_url", core.ErrInvalidInput,
+		return core.NewError(checkURLOp, core.ErrInvalidInput,
 			fmt.Sprintf("invalid URL: %s", rawURL), err)
 	}
 
@@ -97,14 +100,14 @@ func (g *SafetyGuard) CheckURL(rawURL string) error {
 	case "http", "https":
 		// allowed
 	default:
-		return core.NewError("computeruse.guard.check_url", core.ErrInvalidInput,
+		return core.NewError(checkURLOp, core.ErrInvalidInput,
 			fmt.Sprintf("URL scheme %q is not allowed", scheme), nil)
 	}
 
 	// Check block patterns.
 	for _, pattern := range g.opts.blockPatterns {
 		if strings.Contains(rawURL, pattern) {
-			return core.NewError("computeruse.guard.check_url", core.ErrGuardBlocked,
+			return core.NewError(checkURLOp, core.ErrGuardBlocked,
 				fmt.Sprintf("URL matches block pattern %q", pattern), nil)
 		}
 	}
@@ -113,7 +116,7 @@ func (g *SafetyGuard) CheckURL(rawURL string) error {
 	if len(g.opts.allowedHosts) > 0 {
 		host := strings.ToLower(parsed.Hostname())
 		if !g.opts.allowedHosts[host] {
-			return core.NewError("computeruse.guard.check_url", core.ErrGuardBlocked,
+			return core.NewError(checkURLOp, core.ErrGuardBlocked,
 				fmt.Sprintf("host %q is not in the allowed list", host), nil)
 		}
 	}

--- a/tool/computeruse/guard.go
+++ b/tool/computeruse/guard.go
@@ -22,10 +22,20 @@ type GuardOption func(*guardOptions)
 
 // WithAllowedHosts sets the URL hosts that the browser is allowed to navigate to.
 // An empty set means all hosts are allowed (not recommended for production).
+// Any port suffix on a host entry (for example "example.com:8080") is
+// stripped at registration so that the comparison against url.Hostname()
+// — which also strips the port — is consistent.
 func WithAllowedHosts(hosts ...string) GuardOption {
 	return func(o *guardOptions) {
 		for _, h := range hosts {
-			o.allowedHosts[h] = true
+			normalized := strings.ToLower(h)
+			if i := strings.LastIndex(normalized, ":"); i >= 0 {
+				// Strip ":port" suffix but not IPv6 brackets.
+				if !strings.Contains(normalized[:i], ":") {
+					normalized = normalized[:i]
+				}
+			}
+			o.allowedHosts[normalized] = true
 		}
 	}
 }
@@ -79,6 +89,18 @@ func (g *SafetyGuard) CheckURL(rawURL string) error {
 			fmt.Sprintf("invalid URL: %s", rawURL), err)
 	}
 
+	// Only allow http and https schemes. Schemes such as file://,
+	// javascript:, data: and others have either no hostname or an
+	// irrelevant one and must never bypass the allowlist.
+	scheme := strings.ToLower(parsed.Scheme)
+	switch scheme {
+	case "http", "https":
+		// allowed
+	default:
+		return core.NewError("computeruse.guard.check_url", core.ErrInvalidInput,
+			fmt.Sprintf("URL scheme %q is not allowed", scheme), nil)
+	}
+
 	// Check block patterns.
 	for _, pattern := range g.opts.blockPatterns {
 		if strings.Contains(rawURL, pattern) {
@@ -89,7 +111,7 @@ func (g *SafetyGuard) CheckURL(rawURL string) error {
 
 	// Check allowed hosts (empty set = all allowed).
 	if len(g.opts.allowedHosts) > 0 {
-		host := parsed.Hostname()
+		host := strings.ToLower(parsed.Hostname())
 		if !g.opts.allowedHosts[host] {
 			return core.NewError("computeruse.guard.check_url", core.ErrGuardBlocked,
 				fmt.Sprintf("host %q is not in the allowed list", host), nil)

--- a/tool/computeruse/guard.go
+++ b/tool/computeruse/guard.go
@@ -1,0 +1,142 @@
+package computeruse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// guardOptions holds configuration for SafetyGuard.
+type guardOptions struct {
+	allowedHosts        map[string]bool
+	maxActionsPerMinute int
+	blockPatterns       []string
+}
+
+// GuardOption configures a SafetyGuard.
+type GuardOption func(*guardOptions)
+
+// WithAllowedHosts sets the URL hosts that the browser is allowed to navigate to.
+// An empty set means all hosts are allowed (not recommended for production).
+func WithAllowedHosts(hosts ...string) GuardOption {
+	return func(o *guardOptions) {
+		for _, h := range hosts {
+			o.allowedHosts[h] = true
+		}
+	}
+}
+
+// WithMaxActionsPerMinute sets the maximum number of actions per minute.
+// Defaults to 60.
+func WithMaxActionsPerMinute(n int) GuardOption {
+	return func(o *guardOptions) {
+		if n > 0 {
+			o.maxActionsPerMinute = n
+		}
+	}
+}
+
+// WithBlockPatterns sets URL patterns that are always blocked,
+// even if the host is allowed.
+func WithBlockPatterns(patterns ...string) GuardOption {
+	return func(o *guardOptions) {
+		o.blockPatterns = append(o.blockPatterns, patterns...)
+	}
+}
+
+// SafetyGuard enforces URL allowlisting and action rate limiting for
+// computer use operations. It prevents unauthorized navigation and
+// excessive action rates.
+type SafetyGuard struct {
+	opts guardOptions
+
+	mu          sync.Mutex
+	actionTimes []time.Time
+}
+
+// NewSafetyGuard creates a new SafetyGuard with the given options.
+func NewSafetyGuard(opts ...GuardOption) *SafetyGuard {
+	o := guardOptions{
+		allowedHosts:        make(map[string]bool),
+		maxActionsPerMinute: 60,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &SafetyGuard{opts: o}
+}
+
+// CheckURL validates that a URL is allowed by the guard's policy.
+// Returns an error if the URL is blocked.
+func (g *SafetyGuard) CheckURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return core.NewError("computeruse.guard.check_url", core.ErrInvalidInput,
+			fmt.Sprintf("invalid URL: %s", rawURL), err)
+	}
+
+	// Check block patterns.
+	for _, pattern := range g.opts.blockPatterns {
+		if strings.Contains(rawURL, pattern) {
+			return core.NewError("computeruse.guard.check_url", core.ErrGuardBlocked,
+				fmt.Sprintf("URL matches block pattern %q", pattern), nil)
+		}
+	}
+
+	// Check allowed hosts (empty set = all allowed).
+	if len(g.opts.allowedHosts) > 0 {
+		host := parsed.Hostname()
+		if !g.opts.allowedHosts[host] {
+			return core.NewError("computeruse.guard.check_url", core.ErrGuardBlocked,
+				fmt.Sprintf("host %q is not in the allowed list", host), nil)
+		}
+	}
+
+	return nil
+}
+
+// CheckAction validates that the action rate limit has not been exceeded.
+// Returns an error if the rate limit is exceeded.
+func (g *SafetyGuard) CheckAction() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-time.Minute)
+
+	// Remove expired entries.
+	valid := g.actionTimes[:0]
+	for _, t := range g.actionTimes {
+		if t.After(cutoff) {
+			valid = append(valid, t)
+		}
+	}
+	g.actionTimes = valid
+
+	if len(g.actionTimes) >= g.opts.maxActionsPerMinute {
+		return core.NewError("computeruse.guard.check_action", core.ErrRateLimit,
+			fmt.Sprintf("rate limit exceeded: %d actions/minute", g.opts.maxActionsPerMinute), nil)
+	}
+
+	g.actionTimes = append(g.actionTimes, now)
+	return nil
+}
+
+// ActionsInWindow returns the number of actions recorded in the last minute.
+func (g *SafetyGuard) ActionsInWindow() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	cutoff := time.Now().Add(-time.Minute)
+	count := 0
+	for _, t := range g.actionTimes {
+		if t.After(cutoff) {
+			count++
+		}
+	}
+	return count
+}

--- a/tool/computeruse/tool.go
+++ b/tool/computeruse/tool.go
@@ -80,14 +80,25 @@ func (t *ComputerUseTool) Description() string {
 	return "Interact with a computer screen: take screenshots, click, type, scroll, navigate web pages, and execute browser actions."
 }
 
-// InputSchema returns the JSON Schema for the tool's input.
+// InputSchema returns the JSON Schema for the tool's input. The set of
+// advertised actions is narrowed to those the configured backends can
+// actually execute — for example, key_press is excluded when only a
+// browser backend is wired up, because key_press dispatches exclusively
+// through a ComputerAction backend.
 func (t *ComputerUseTool) InputSchema() map[string]any {
+	actions := []string{"screenshot", "click", "type", "scroll"}
+	if t.opts.action != nil {
+		actions = append(actions, "key_press")
+	}
+	if t.opts.browser != nil {
+		actions = append(actions, "navigate")
+	}
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
 			"action": map[string]any{
 				"type":        "string",
-				"enum":        []string{"screenshot", "click", "type", "scroll", "key_press", "navigate"},
+				"enum":        actions,
 				"description": "The action to perform",
 			},
 			"x":            map[string]any{"type": "integer", "description": "X coordinate for click/scroll"},
@@ -217,11 +228,13 @@ func (t *ComputerUseTool) handleType(ctx context.Context, input map[string]any) 
 		if err := t.opts.browser.Type(ctx, text); err != nil {
 			return tool.ErrorResult(fmt.Errorf("type failed: %w", err)), nil
 		}
-		return tool.TextResult(fmt.Sprintf("Typed: %s", text)), nil
+		// Do not echo typed text back to the LLM — it may contain
+		// passwords, tokens, or other credentials.
+		return tool.TextResult(fmt.Sprintf("Typed %d character(s)", len(text))), nil
 	}
 
 	if t.opts.action != nil {
-		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionType_, Text: text})
+		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionTypeText, Text: text})
 		if err != nil {
 			return tool.ErrorResult(fmt.Errorf("type failed: %w", err)), nil
 		}

--- a/tool/computeruse/tool.go
+++ b/tool/computeruse/tool.go
@@ -1,0 +1,286 @@
+package computeruse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// Compile-time interface check.
+var _ tool.Tool = (*ComputerUseTool)(nil)
+
+// toolOptions holds configuration for ComputerUseTool.
+type toolOptions struct {
+	action   ComputerAction
+	browser  BrowserBackend
+	analyzer *ScreenAnalyzer
+	guard    *SafetyGuard
+}
+
+// ToolOption configures a ComputerUseTool.
+type ToolOption func(*toolOptions)
+
+// WithAction sets the computer action backend.
+func WithAction(a ComputerAction) ToolOption {
+	return func(o *toolOptions) {
+		o.action = a
+	}
+}
+
+// WithBrowser sets the browser backend.
+func WithBrowser(b BrowserBackend) ToolOption {
+	return func(o *toolOptions) {
+		o.browser = b
+	}
+}
+
+// WithScreenAnalyzer sets the screen analyzer for describing screenshots.
+func WithScreenAnalyzer(a *ScreenAnalyzer) ToolOption {
+	return func(o *toolOptions) {
+		o.analyzer = a
+	}
+}
+
+// WithSafetyGuard sets the safety guard for URL and rate limiting checks.
+func WithSafetyGuard(g *SafetyGuard) ToolOption {
+	return func(o *toolOptions) {
+		o.guard = g
+	}
+}
+
+// ComputerUseTool implements tool.Tool for computer use and browser
+// automation. It dispatches actions to the configured backend and applies
+// safety guards.
+type ComputerUseTool struct {
+	opts toolOptions
+}
+
+// NewComputerUseTool creates a new ComputerUseTool with the given options.
+func NewComputerUseTool(opts ...ToolOption) (*ComputerUseTool, error) {
+	o := toolOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.action == nil && o.browser == nil {
+		return nil, core.NewError("computeruse.tool.new", core.ErrInvalidInput,
+			"at least one of action or browser backend is required", nil)
+	}
+	return &ComputerUseTool{opts: o}, nil
+}
+
+// Name returns "computer_use".
+func (t *ComputerUseTool) Name() string { return "computer_use" }
+
+// Description returns a description of the computer use tool.
+func (t *ComputerUseTool) Description() string {
+	return "Interact with a computer screen: take screenshots, click, type, scroll, navigate web pages, and execute browser actions."
+}
+
+// InputSchema returns the JSON Schema for the tool's input.
+func (t *ComputerUseTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type":        "string",
+				"enum":        []string{"screenshot", "click", "type", "scroll", "key_press", "navigate"},
+				"description": "The action to perform",
+			},
+			"x":            map[string]any{"type": "integer", "description": "X coordinate for click/scroll"},
+			"y":            map[string]any{"type": "integer", "description": "Y coordinate for click/scroll"},
+			"text":         map[string]any{"type": "string", "description": "Text to type or key to press"},
+			"url":          map[string]any{"type": "string", "description": "URL to navigate to"},
+			"scroll_delta": map[string]any{"type": "integer", "description": "Scroll amount (positive=down)"},
+		},
+		"required": []string{"action"},
+	}
+}
+
+// Execute runs the requested computer action.
+func (t *ComputerUseTool) Execute(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	actionStr, _ := input["action"].(string)
+	if actionStr == "" {
+		return tool.ErrorResult(fmt.Errorf("action is required")), nil
+	}
+
+	// Check rate limit via safety guard.
+	if t.opts.guard != nil {
+		if err := t.opts.guard.CheckAction(); err != nil {
+			return tool.ErrorResult(err), nil
+		}
+	}
+
+	switch actionStr {
+	case "navigate":
+		return t.handleNavigate(ctx, input)
+	case "screenshot":
+		return t.handleScreenshot(ctx)
+	case "click":
+		return t.handleClick(ctx, input)
+	case "type":
+		return t.handleType(ctx, input)
+	case "scroll":
+		return t.handleScroll(ctx, input)
+	case "key_press":
+		return t.handleKeyPress(ctx, input)
+	default:
+		return tool.ErrorResult(fmt.Errorf("unknown action: %s", actionStr)), nil
+	}
+}
+
+func (t *ComputerUseTool) handleNavigate(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	rawURL, _ := input["url"].(string)
+	if rawURL == "" {
+		return tool.ErrorResult(fmt.Errorf("url is required for navigate action")), nil
+	}
+
+	if t.opts.guard != nil {
+		if err := t.opts.guard.CheckURL(rawURL); err != nil {
+			return tool.ErrorResult(err), nil
+		}
+	}
+
+	if t.opts.browser == nil {
+		return tool.ErrorResult(fmt.Errorf("browser backend not configured")), nil
+	}
+
+	if err := t.opts.browser.Navigate(ctx, rawURL); err != nil {
+		return tool.ErrorResult(fmt.Errorf("navigate failed: %w", err)), nil
+	}
+
+	return tool.TextResult(fmt.Sprintf("Navigated to %s", rawURL)), nil
+}
+
+func (t *ComputerUseTool) handleScreenshot(ctx context.Context) (*tool.Result, error) {
+	var screenshot []byte
+	var err error
+
+	if t.opts.browser != nil {
+		screenshot, err = t.opts.browser.Screenshot(ctx)
+	} else if t.opts.action != nil {
+		screenshot, err = t.opts.action.Screenshot(ctx)
+	} else {
+		return tool.ErrorResult(fmt.Errorf("no backend configured for screenshots")), nil
+	}
+
+	if err != nil {
+		return tool.ErrorResult(fmt.Errorf("screenshot failed: %w", err)), nil
+	}
+
+	parts := []schema.ContentPart{
+		schema.ImagePart{Data: screenshot, MimeType: "image/png"},
+	}
+
+	// If analyzer is available, add description.
+	if t.opts.analyzer != nil {
+		desc, analyzeErr := t.opts.analyzer.Analyze(ctx, screenshot)
+		if analyzeErr == nil {
+			parts = append(parts, schema.TextPart{Text: desc})
+		}
+	}
+
+	return &tool.Result{Content: parts}, nil
+}
+
+func (t *ComputerUseTool) handleClick(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	x, y := toInt(input["x"]), toInt(input["y"])
+
+	if t.opts.browser != nil {
+		if err := t.opts.browser.Click(ctx, x, y); err != nil {
+			return tool.ErrorResult(fmt.Errorf("click failed: %w", err)), nil
+		}
+		return tool.TextResult(fmt.Sprintf("Clicked at (%d, %d)", x, y)), nil
+	}
+
+	if t.opts.action != nil {
+		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionClick, X: x, Y: y})
+		if err != nil {
+			return tool.ErrorResult(fmt.Errorf("click failed: %w", err)), nil
+		}
+		return tool.TextResult(result.Description), nil
+	}
+
+	return tool.ErrorResult(fmt.Errorf("no backend configured for click")), nil
+}
+
+func (t *ComputerUseTool) handleType(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	text, _ := input["text"].(string)
+	if text == "" {
+		return tool.ErrorResult(fmt.Errorf("text is required for type action")), nil
+	}
+
+	if t.opts.browser != nil {
+		if err := t.opts.browser.Type(ctx, text); err != nil {
+			return tool.ErrorResult(fmt.Errorf("type failed: %w", err)), nil
+		}
+		return tool.TextResult(fmt.Sprintf("Typed: %s", text)), nil
+	}
+
+	if t.opts.action != nil {
+		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionType_, Text: text})
+		if err != nil {
+			return tool.ErrorResult(fmt.Errorf("type failed: %w", err)), nil
+		}
+		return tool.TextResult(result.Description), nil
+	}
+
+	return tool.ErrorResult(fmt.Errorf("no backend configured for type")), nil
+}
+
+func (t *ComputerUseTool) handleScroll(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	x, y := toInt(input["x"]), toInt(input["y"])
+	delta := toInt(input["scroll_delta"])
+
+	if eb, ok := t.opts.browser.(ExtendedBrowser); ok {
+		if err := eb.Scroll(ctx, x, y, delta); err != nil {
+			return tool.ErrorResult(fmt.Errorf("scroll failed: %w", err)), nil
+		}
+		return tool.TextResult(fmt.Sprintf("Scrolled by %d at (%d, %d)", delta, x, y)), nil
+	}
+
+	if t.opts.action != nil {
+		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionScroll, X: x, Y: y, ScrollDelta: delta})
+		if err != nil {
+			return tool.ErrorResult(fmt.Errorf("scroll failed: %w", err)), nil
+		}
+		return tool.TextResult(result.Description), nil
+	}
+
+	return tool.ErrorResult(fmt.Errorf("no backend configured for scroll")), nil
+}
+
+func (t *ComputerUseTool) handleKeyPress(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	key, _ := input["text"].(string)
+	if key == "" {
+		return tool.ErrorResult(fmt.Errorf("text (key name) is required for key_press action")), nil
+	}
+
+	if t.opts.action != nil {
+		result, err := t.opts.action.Execute(ctx, ActionRequest{Type: ActionKeyPress, Text: key})
+		if err != nil {
+			return tool.ErrorResult(fmt.Errorf("key_press failed: %w", err)), nil
+		}
+		return tool.TextResult(result.Description), nil
+	}
+
+	return tool.ErrorResult(fmt.Errorf("no backend configured for key_press")), nil
+}
+
+// toInt converts a JSON number to int, handling both float64 and json.Number.
+func toInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Summary
- tool/computeruse package, ComputerAction + BrowserBackend interfaces, ScreenAnalyzer (multimodal LLM), SafetyGuard with allowlists

## Linear
- LOO-29: https://linear.app/lookatitude/issue/LOO-29

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)