### PR TITLE
LOO-31: Tool Learning and Creation by Agents

### DIFF
--- a/tool/learning/doc.go
+++ b/tool/learning/doc.go
@@ -1,0 +1,26 @@
+// Package learning provides tool learning and creation capabilities for agents.
+//
+// It enables agents to dynamically create, validate, version, and register tools
+// at runtime. Unlike FuncTool which requires compile-time generics, DynamicTool
+// supports runtime-defined schemas and code execution.
+//
+// Key components:
+//
+//   - DynamicTool: A tool.Tool implementation with runtime-defined input schema
+//     and a pluggable CodeExecutor for execution.
+//
+//   - CodeExecutor: Interface for executing tool code. Includes ASTValidator
+//     for static analysis (go/ast allowlist checking) and NoopExecutor for testing.
+//
+//   - ToolGenerator: Uses an llm.ChatModel to generate tool code from natural
+//     language descriptions, with function signature templates and few-shot prompts.
+//
+//   - VersionedRegistry: Wraps tool.Registry with immutable version tracking,
+//     supporting Upsert, Activate, Rollback, and History operations.
+//
+//   - ToolTester: Validates generated tools by running test inputs before
+//     registration, ensuring tools produce expected outputs.
+//
+//   - Hooks: Lifecycle callbacks (OnToolCreated, OnToolTested, OnVersionActivated)
+//     for observability and integration.
+package learning

--- a/tool/learning/dynamic.go
+++ b/tool/learning/dynamic.go
@@ -1,0 +1,90 @@
+package learning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// DynamicTool implements tool.Tool with a runtime-defined schema and a pluggable
+// CodeExecutor for execution. Unlike FuncTool which requires compile-time generics,
+// DynamicTool supports schemas and execution logic defined at runtime, making it
+// suitable for agent-generated tools.
+type DynamicTool struct {
+	name        string
+	description string
+	schema      map[string]any
+	code        string
+	executor    CodeExecutor
+	version     int
+}
+
+// Compile-time check that DynamicTool implements tool.Tool.
+var _ tool.Tool = (*DynamicTool)(nil)
+
+// DynamicToolOption configures a DynamicTool.
+type DynamicToolOption func(*DynamicTool)
+
+// WithVersion sets the version number for the dynamic tool.
+func WithVersion(v int) DynamicToolOption {
+	return func(d *DynamicTool) {
+		d.version = v
+	}
+}
+
+// NewDynamicTool creates a new DynamicTool with the given name, description,
+// input schema, source code, and code executor. The schema should be a valid
+// JSON Schema object describing the tool's expected input parameters.
+func NewDynamicTool(
+	name, description string,
+	inputSchema map[string]any,
+	code string,
+	executor CodeExecutor,
+	opts ...DynamicToolOption,
+) *DynamicTool {
+	dt := &DynamicTool{
+		name:        name,
+		description: description,
+		schema:      inputSchema,
+		code:        code,
+		executor:    executor,
+		version:     1,
+	}
+	for _, opt := range opts {
+		opt(dt)
+	}
+	return dt
+}
+
+// Name returns the tool's unique identifier.
+func (d *DynamicTool) Name() string { return d.name }
+
+// Description returns the tool's human-readable description.
+func (d *DynamicTool) Description() string { return d.description }
+
+// InputSchema returns the JSON Schema describing the tool's expected input.
+func (d *DynamicTool) InputSchema() map[string]any { return d.schema }
+
+// Code returns the source code of the dynamic tool.
+func (d *DynamicTool) Code() string { return d.code }
+
+// Version returns the version number of the dynamic tool.
+func (d *DynamicTool) Version() int { return d.version }
+
+// Execute runs the tool by serializing the input map to JSON and passing it
+// along with the tool's code to the configured CodeExecutor.
+func (d *DynamicTool) Execute(ctx context.Context, input map[string]any) (*tool.Result, error) {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic tool %s: failed to marshal input: %w", d.name, err)
+	}
+
+	output, err := d.executor.Execute(ctx, d.code, string(inputJSON))
+	if err != nil {
+		return nil, fmt.Errorf("dynamic tool %s: execution failed: %w", d.name, err)
+	}
+
+	return tool.TextResult(output), nil
+}

--- a/tool/learning/dynamic_test.go
+++ b/tool/learning/dynamic_test.go
@@ -1,0 +1,119 @@
+package learning
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicTool_Interface(t *testing.T) {
+	exec := &NoopExecutor{Response: "result"}
+	dt := NewDynamicTool(
+		"test_tool",
+		"A test tool",
+		map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+		},
+		`package main; func run(input string) (string, error) { return "result", nil }`,
+		exec,
+	)
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "test_tool", dt.Name())
+	})
+
+	t.Run("Description", func(t *testing.T) {
+		assert.Equal(t, "A test tool", dt.Description())
+	})
+
+	t.Run("InputSchema", func(t *testing.T) {
+		s := dt.InputSchema()
+		assert.Equal(t, "object", s["type"])
+	})
+
+	t.Run("Code", func(t *testing.T) {
+		assert.Contains(t, dt.Code(), "func run")
+	})
+
+	t.Run("Version default", func(t *testing.T) {
+		assert.Equal(t, 1, dt.Version())
+	})
+}
+
+func TestDynamicTool_WithVersion(t *testing.T) {
+	exec := &NoopExecutor{Response: "ok"}
+	dt := NewDynamicTool("t", "d", nil, "", exec, WithVersion(5))
+	assert.Equal(t, 5, dt.Version())
+}
+
+func TestDynamicTool_Execute(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]any
+		executor CodeExecutor
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "successful execution",
+			input:    map[string]any{"query": "hello"},
+			executor: &NoopExecutor{Response: "hello result"},
+			want:     "hello result",
+		},
+		{
+			name:     "empty input",
+			input:    map[string]any{},
+			executor: &NoopExecutor{Response: "empty"},
+			want:     "empty",
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			executor: &NoopExecutor{Response: "nil"},
+			want:     "nil",
+		},
+		{
+			name:     "executor error",
+			input:    map[string]any{"x": 1},
+			executor: &NoopExecutor{Err: assert.AnError},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dt := NewDynamicTool("test", "test tool", nil, "code", tt.executor)
+			result, err := dt.Execute(context.Background(), tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result.Content, 1)
+			tp, ok := result.Content[0].(schema.TextPart)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, tp.Text)
+		})
+	}
+}
+
+func TestDynamicTool_ExecuteContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// NoopExecutor doesn't check context, but Execute marshals input first.
+	// This tests that the tool propagates context to the executor.
+	exec := &NoopExecutor{Response: "ok"}
+	dt := NewDynamicTool("t", "d", nil, "", exec)
+	// Even with cancelled context, NoopExecutor succeeds (it ignores context).
+	result, err := dt.Execute(ctx, map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/tool/learning/executor.go
+++ b/tool/learning/executor.go
@@ -1,0 +1,108 @@
+package learning
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+)
+
+// CodeExecutor defines the interface for executing dynamically generated tool code.
+// Implementations control the sandboxing and safety guarantees of code execution.
+type CodeExecutor interface {
+	// Execute runs the given code with the provided JSON input string and returns
+	// the output as a string. The code is expected to be a valid Go function body.
+	Execute(ctx context.Context, code string, input string) (string, error)
+}
+
+// ASTValidator performs static analysis on Go source code using go/ast to ensure
+// only allowed imports and constructs are used. It acts as a first safety gate
+// before code execution.
+type ASTValidator struct {
+	// allowedImports is the set of import paths that are permitted in generated code.
+	allowedImports map[string]bool
+}
+
+// NewASTValidator creates a new ASTValidator with the given set of allowed import paths.
+// If allowedImports is nil, a default safe set is used: encoding/json, fmt, math,
+// strings, strconv, sort, unicode.
+func NewASTValidator(allowedImports []string) *ASTValidator {
+	allowed := make(map[string]bool, len(allowedImports))
+	if len(allowedImports) == 0 {
+		// Default safe imports.
+		for _, imp := range []string{
+			"encoding/json", "fmt", "math", "strings",
+			"strconv", "sort", "unicode",
+		} {
+			allowed[imp] = true
+		}
+	} else {
+		for _, imp := range allowedImports {
+			allowed[imp] = true
+		}
+	}
+	return &ASTValidator{allowedImports: allowed}
+}
+
+// Validate parses the given Go source code and checks that all imports are in the
+// allowed set and that no disallowed constructs (go statements, unsafe operations)
+// are used. Returns nil if the code passes validation.
+func (v *ASTValidator) Validate(code string) error {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "tool.go", code, parser.AllErrors)
+	if err != nil {
+		return fmt.Errorf("ast validation: parse error: %w", err)
+	}
+
+	// Check imports.
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if !v.allowedImports[path] {
+			return fmt.Errorf("ast validation: disallowed import %q", path)
+		}
+	}
+
+	// Walk the AST looking for disallowed constructs.
+	var walkErr error
+	ast.Inspect(f, func(n ast.Node) bool {
+		if walkErr != nil {
+			return false
+		}
+		switch n.(type) {
+		case *ast.GoStmt:
+			walkErr = fmt.Errorf("ast validation: goroutine spawning (go statement) is not allowed")
+			return false
+		}
+		// Check for unsafe package usage in selector expressions.
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if ident, ok := sel.X.(*ast.Ident); ok {
+				if ident.Name == "unsafe" {
+					walkErr = fmt.Errorf("ast validation: unsafe package usage is not allowed")
+					return false
+				}
+			}
+		}
+		return true
+	})
+
+	return walkErr
+}
+
+// NoopExecutor is a CodeExecutor that returns a configurable fixed response.
+// It is intended for testing and development purposes.
+type NoopExecutor struct {
+	// Response is the fixed string returned by Execute.
+	Response string
+	// Err is the error returned by Execute, if non-nil.
+	Err error
+}
+
+// Execute returns the configured Response and Err without executing any code.
+func (n *NoopExecutor) Execute(_ context.Context, _ string, _ string) (string, error) {
+	return n.Response, n.Err
+}
+
+// Compile-time check.
+var _ CodeExecutor = (*NoopExecutor)(nil)

--- a/tool/learning/executor_test.go
+++ b/tool/learning/executor_test.go
@@ -1,0 +1,164 @@
+package learning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestASTValidator_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		allowed []string
+		code    string
+		wantErr string
+	}{
+		{
+			name: "valid code with allowed imports",
+			code: `package main
+
+import "fmt"
+
+func run(input string) (string, error) {
+	return fmt.Sprintf("hello %s", input), nil
+}
+`,
+		},
+		{
+			name: "valid code with no imports",
+			code: `package main
+
+func run(input string) (string, error) {
+	return "hello", nil
+}
+`,
+		},
+		{
+			name: "disallowed import",
+			code: `package main
+
+import "os/exec"
+
+func run(input string) (string, error) {
+	return "", nil
+}
+`,
+			wantErr: `disallowed import "os/exec"`,
+		},
+		{
+			name: "goroutine spawning",
+			code: `package main
+
+import "fmt"
+
+func run(input string) (string, error) {
+	go fmt.Println("bad")
+	return "", nil
+}
+`,
+			wantErr: "goroutine spawning",
+		},
+		{
+			name: "unsafe package usage",
+			code: `package main
+
+import "unsafe"
+
+func run(input string) (string, error) {
+	_ = unsafe.Sizeof(0)
+	return "", nil
+}
+`,
+			wantErr: "unsafe",
+		},
+		{
+			name: "syntax error",
+			code: `package main
+
+func run(input string (string, error) {
+`,
+			wantErr: "parse error",
+		},
+		{
+			name:    "custom allowed imports",
+			allowed: []string{"net/url"},
+			code: `package main
+
+import "net/url"
+
+func run(input string) (string, error) {
+	u, _ := url.Parse(input)
+	return u.Host, nil
+}
+`,
+		},
+		{
+			name:    "custom allowed rejects default",
+			allowed: []string{"net/url"},
+			code: `package main
+
+import "fmt"
+
+func run(input string) (string, error) {
+	return fmt.Sprintf("%s", input), nil
+}
+`,
+			wantErr: `disallowed import "fmt"`,
+		},
+		{
+			name: "multiple imports mixed",
+			code: `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func run(input string) (string, error) {
+	_ = os.Getenv("x")
+	return fmt.Sprintf("%s", input), nil
+}
+`,
+			wantErr: `disallowed import "os"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewASTValidator(tt.allowed)
+			err := v.Validate(tt.code)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoopExecutor(t *testing.T) {
+	t.Run("returns configured response", func(t *testing.T) {
+		exec := &NoopExecutor{Response: "hello world"}
+		out, err := exec.Execute(context.Background(), "code", "input")
+		require.NoError(t, err)
+		assert.Equal(t, "hello world", out)
+	})
+
+	t.Run("returns configured error", func(t *testing.T) {
+		exec := &NoopExecutor{Err: fmt.Errorf("boom")}
+		_, err := exec.Execute(context.Background(), "code", "input")
+		require.Error(t, err)
+		assert.Equal(t, "boom", err.Error())
+	})
+
+	t.Run("returns both", func(t *testing.T) {
+		exec := &NoopExecutor{Response: "partial", Err: fmt.Errorf("fail")}
+		out, err := exec.Execute(context.Background(), "", "")
+		assert.Equal(t, "partial", out)
+		assert.Error(t, err)
+	})
+}

--- a/tool/learning/generator.go
+++ b/tool/learning/generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/lookatitude/beluga-ai/llm"
@@ -161,8 +162,13 @@ func (g *ToolGenerator) buildPrompt(req GenerateRequest) string {
 
 	if len(req.InputFields) > 0 {
 		b.WriteString("Input fields:\n")
-		for name, desc := range req.InputFields {
-			b.WriteString(fmt.Sprintf("  - %s: %s\n", name, desc))
+		keys := make([]string, 0, len(req.InputFields))
+		for k := range req.InputFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			b.WriteString(fmt.Sprintf("  - %s: %s\n", name, req.InputFields[name]))
 		}
 		b.WriteString("\n")
 	}

--- a/tool/learning/generator.go
+++ b/tool/learning/generator.go
@@ -1,0 +1,238 @@
+package learning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// ToolGenerator uses an LLM to generate tool implementations from natural language
+// descriptions. It produces DynamicTool instances with generated code and schemas.
+type ToolGenerator struct {
+	model          llm.ChatModel
+	validator      *ASTValidator
+	allowedImports []string
+	maxRetries     int
+}
+
+// GeneratorOption configures a ToolGenerator.
+type GeneratorOption func(*generatorOptions)
+
+type generatorOptions struct {
+	allowedImports []string
+	maxRetries     int
+}
+
+// WithAllowedImports sets the list of Go import paths allowed in generated code.
+// If not set, the default safe set from ASTValidator is used.
+func WithAllowedImports(imports []string) GeneratorOption {
+	return func(o *generatorOptions) {
+		o.allowedImports = imports
+	}
+}
+
+// WithMaxRetries sets the maximum number of generation retries on validation failure.
+// Defaults to 3.
+func WithMaxRetries(n int) GeneratorOption {
+	return func(o *generatorOptions) {
+		if n > 0 {
+			o.maxRetries = n
+		}
+	}
+}
+
+// NewToolGenerator creates a new ToolGenerator that uses the given ChatModel for
+// code generation. Options can configure allowed imports and retry behavior.
+func NewToolGenerator(model llm.ChatModel, opts ...GeneratorOption) *ToolGenerator {
+	o := generatorOptions{
+		maxRetries: 3,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return &ToolGenerator{
+		model:          model,
+		validator:      NewASTValidator(o.allowedImports),
+		allowedImports: o.allowedImports,
+		maxRetries:     o.maxRetries,
+	}
+}
+
+// GenerateRequest describes what tool to generate.
+type GenerateRequest struct {
+	// Name is the desired tool name.
+	Name string
+	// Description describes what the tool should do.
+	Description string
+	// InputFields describes the expected input parameters as field name to description.
+	InputFields map[string]string
+	// Examples provides optional few-shot examples of input/output pairs.
+	Examples []Example
+}
+
+// Example is an input/output pair for few-shot prompting.
+type Example struct {
+	// Input is a sample input as a JSON object string.
+	Input string
+	// Output is the expected output string.
+	Output string
+}
+
+// generatedTool is the structured output expected from the LLM.
+type generatedTool struct {
+	Code        string         `json:"code"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
+// Generate creates a new DynamicTool from the given request using the LLM.
+// It retries up to MaxRetries times if the generated code fails AST validation.
+// The returned tool uses a NoopExecutor by default; callers should replace the
+// executor with a production implementation before registering.
+func (g *ToolGenerator) Generate(ctx context.Context, req GenerateRequest, executor CodeExecutor) (*DynamicTool, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("tool generator: name is required")
+	}
+	if req.Description == "" {
+		return nil, fmt.Errorf("tool generator: description is required")
+	}
+
+	prompt := g.buildPrompt(req)
+
+	var lastErr error
+	for attempt := 0; attempt <= g.maxRetries; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		msgs := []schema.Message{
+			schema.NewSystemMessage(systemPrompt(g.allowedImports)),
+			schema.NewHumanMessage(prompt),
+		}
+
+		if lastErr != nil {
+			msgs = append(msgs, schema.NewHumanMessage(
+				fmt.Sprintf("The previous attempt failed validation: %v\nPlease fix the code and try again.", lastErr),
+			))
+		}
+
+		resp, err := g.model.Generate(ctx, msgs)
+		if err != nil {
+			return nil, fmt.Errorf("tool generator: llm error: %w", err)
+		}
+
+		text := resp.Text()
+		gen, err := parseGeneratedTool(text)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to parse LLM output: %w", err)
+			continue
+		}
+
+		// Validate the generated code.
+		if err := g.validator.Validate(gen.Code); err != nil {
+			lastErr = err
+			continue
+		}
+
+		return NewDynamicTool(
+			req.Name,
+			req.Description,
+			gen.InputSchema,
+			gen.Code,
+			executor,
+		), nil
+	}
+
+	return nil, fmt.Errorf("tool generator: failed after %d retries: %w", g.maxRetries, lastErr)
+}
+
+// buildPrompt constructs the user prompt for tool generation.
+func (g *ToolGenerator) buildPrompt(req GenerateRequest) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("Create a Go tool named %q.\n", req.Name))
+	b.WriteString(fmt.Sprintf("Description: %s\n\n", req.Description))
+
+	if len(req.InputFields) > 0 {
+		b.WriteString("Input fields:\n")
+		for name, desc := range req.InputFields {
+			b.WriteString(fmt.Sprintf("  - %s: %s\n", name, desc))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(req.Examples) > 0 {
+		b.WriteString("Examples:\n")
+		for i, ex := range req.Examples {
+			b.WriteString(fmt.Sprintf("  Example %d:\n    Input: %s\n    Output: %s\n", i+1, ex.Input, ex.Output))
+		}
+	}
+
+	return b.String()
+}
+
+// systemPrompt returns the system message for tool generation.
+func systemPrompt(allowedImports []string) string {
+	imports := "encoding/json, fmt, math, strings, strconv, sort, unicode"
+	if len(allowedImports) > 0 {
+		imports = strings.Join(allowedImports, ", ")
+	}
+
+	return fmt.Sprintf(`You are a tool code generator. Generate Go source code for tools.
+
+Rules:
+1. Only use these imports: %s
+2. Do not use goroutines (no go statements)
+3. Do not use the unsafe package
+4. The code must be a complete, valid Go file with a package declaration
+5. The main function should be named "run" and accept a JSON string input parameter and return (string, error)
+
+Respond with ONLY a JSON object with these fields:
+- "code": the complete Go source code as a string
+- "input_schema": a JSON Schema object describing the input parameters
+
+Do not include any text before or after the JSON object.`, imports)
+}
+
+// parseGeneratedTool extracts the generated tool from the LLM response text.
+func parseGeneratedTool(text string) (*generatedTool, error) {
+	// Try to find JSON in the response.
+	text = strings.TrimSpace(text)
+
+	// Strip markdown code fences if present.
+	if strings.HasPrefix(text, "```") {
+		lines := strings.Split(text, "\n")
+		var jsonLines []string
+		inBlock := false
+		for _, line := range lines {
+			if strings.HasPrefix(line, "```") {
+				inBlock = !inBlock
+				continue
+			}
+			if inBlock {
+				jsonLines = append(jsonLines, line)
+			}
+		}
+		text = strings.Join(jsonLines, "\n")
+	}
+
+	var gen generatedTool
+	if err := json.Unmarshal([]byte(text), &gen); err != nil {
+		return nil, fmt.Errorf("invalid JSON in response: %w", err)
+	}
+
+	if gen.Code == "" {
+		return nil, fmt.Errorf("generated code is empty")
+	}
+	if gen.InputSchema == nil {
+		gen.InputSchema = map[string]any{"type": "object"}
+	}
+
+	return &gen, nil
+}

--- a/tool/learning/generator_test.go
+++ b/tool/learning/generator_test.go
@@ -1,0 +1,256 @@
+package learning
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChatModel implements llm.ChatModel for testing.
+type mockChatModel struct {
+	responses []string
+	callCount int
+}
+
+var _ llm.ChatModel = (*mockChatModel)(nil)
+
+func (m *mockChatModel) Generate(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) (*schema.AIMessage, error) {
+	if m.callCount >= len(m.responses) {
+		return nil, fmt.Errorf("no more responses")
+	}
+	resp := m.responses[m.callCount]
+	m.callCount++
+	return schema.NewAIMessage(resp), nil
+}
+
+func (m *mockChatModel) Stream(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
+	return func(yield func(schema.StreamChunk, error) bool) {}
+}
+
+func (m *mockChatModel) BindTools(_ []schema.ToolDefinition) llm.ChatModel {
+	return m
+}
+
+func (m *mockChatModel) ModelID() string { return "mock" }
+
+func validGenResponse() string {
+	gen := generatedTool{
+		Code: `package main
+
+import "fmt"
+
+func run(input string) (string, error) {
+	return fmt.Sprintf("processed: %s", input), nil
+}
+`,
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+		},
+	}
+	b, _ := json.Marshal(gen)
+	return string(b)
+}
+
+func invalidCodeGenResponse() string {
+	gen := generatedTool{
+		Code: `package main
+
+import "os/exec"
+
+func run(input string) (string, error) {
+	return "", nil
+}
+`,
+		InputSchema: map[string]any{"type": "object"},
+	}
+	b, _ := json.Marshal(gen)
+	return string(b)
+}
+
+func TestToolGenerator_Generate(t *testing.T) {
+	t.Run("successful generation", func(t *testing.T) {
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock)
+
+		dt, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "search",
+			Description: "Search the web",
+			InputFields: map[string]string{"query": "search query"},
+		}, &NoopExecutor{Response: "ok"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "search", dt.Name())
+		assert.Equal(t, "Search the web", dt.Description())
+		assert.NotNil(t, dt.InputSchema())
+		assert.NotEmpty(t, dt.Code())
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock)
+
+		_, err := gen.Generate(context.Background(), GenerateRequest{
+			Description: "Search the web",
+		}, &NoopExecutor{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("empty description", func(t *testing.T) {
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock)
+
+		_, err := gen.Generate(context.Background(), GenerateRequest{
+			Name: "search",
+		}, &NoopExecutor{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "description is required")
+	})
+
+	t.Run("retries on validation failure then succeeds", func(t *testing.T) {
+		mock := &mockChatModel{
+			responses: []string{
+				invalidCodeGenResponse(),
+				validGenResponse(),
+			},
+		}
+		gen := NewToolGenerator(mock, WithMaxRetries(3))
+
+		dt, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "search",
+			Description: "Search",
+		}, &NoopExecutor{Response: "ok"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "search", dt.Name())
+		assert.Equal(t, 2, mock.callCount)
+	})
+
+	t.Run("exhausts retries", func(t *testing.T) {
+		mock := &mockChatModel{
+			responses: []string{
+				invalidCodeGenResponse(),
+				invalidCodeGenResponse(),
+				invalidCodeGenResponse(),
+				invalidCodeGenResponse(),
+			},
+		}
+		gen := NewToolGenerator(mock, WithMaxRetries(2))
+
+		_, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "bad",
+			Description: "Bad tool",
+		}, &NoopExecutor{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed after")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock)
+
+		_, err := gen.Generate(ctx, GenerateRequest{
+			Name:        "search",
+			Description: "Search",
+		}, &NoopExecutor{})
+		require.Error(t, err)
+	})
+
+	t.Run("LLM error", func(t *testing.T) {
+		mock := &mockChatModel{responses: nil} // Will return error
+		gen := NewToolGenerator(mock)
+
+		_, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "search",
+			Description: "Search",
+		}, &NoopExecutor{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "llm error")
+	})
+
+	t.Run("with examples", func(t *testing.T) {
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock)
+
+		dt, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "calc",
+			Description: "Calculate",
+			Examples: []Example{
+				{Input: `{"a": 1, "b": 2}`, Output: "3"},
+			},
+		}, &NoopExecutor{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "calc", dt.Name())
+	})
+
+	t.Run("with allowed imports", func(t *testing.T) {
+		mock := &mockChatModel{responses: []string{validGenResponse()}}
+		gen := NewToolGenerator(mock, WithAllowedImports([]string{"fmt", "strings"}))
+
+		dt, err := gen.Generate(context.Background(), GenerateRequest{
+			Name:        "search",
+			Description: "Search",
+		}, &NoopExecutor{})
+		require.NoError(t, err)
+		assert.Equal(t, "search", dt.Name())
+	})
+}
+
+func TestParseGeneratedTool(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:  "valid JSON",
+			input: `{"code": "package main\nfunc run() {}", "input_schema": {"type": "object"}}`,
+		},
+		{
+			name:  "markdown fenced JSON",
+			input: "```json\n{\"code\": \"package main\\nfunc run() {}\", \"input_schema\": {\"type\": \"object\"}}\n```",
+		},
+		{
+			name:    "empty code",
+			input:   `{"code": "", "input_schema": {"type": "object"}}`,
+			wantErr: "generated code is empty",
+		},
+		{
+			name:    "invalid JSON",
+			input:   `not json at all`,
+			wantErr: "invalid JSON",
+		},
+		{
+			name:  "nil input schema defaults",
+			input: `{"code": "package main\nfunc run() {}"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gen, err := parseGeneratedTool(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, gen.Code)
+			assert.NotNil(t, gen.InputSchema)
+		})
+	}
+}

--- a/tool/learning/hooks.go
+++ b/tool/learning/hooks.go
@@ -1,0 +1,46 @@
+package learning
+
+// Hooks provides lifecycle callbacks for tool learning operations.
+// All fields are optional — nil hooks are skipped.
+type Hooks struct {
+	// OnToolCreated is called when a new tool is generated and validated.
+	// Receives the tool name and the generated code.
+	OnToolCreated func(toolName string, code string)
+
+	// OnToolTested is called after a tool has been tested.
+	// Receives the tool name and whether all tests passed.
+	OnToolTested func(toolName string, allPassed bool)
+
+	// OnVersionActivated is called when a tool version is activated.
+	// Receives the tool name and the activated version number.
+	OnVersionActivated func(toolName string, version int)
+}
+
+// ComposeHooks merges multiple Hooks into a single Hooks struct.
+// OnToolCreated hooks run in order. OnToolTested hooks run in order.
+// OnVersionActivated hooks run in order.
+func ComposeHooks(hooks ...Hooks) Hooks {
+	return Hooks{
+		OnToolCreated: func(toolName string, code string) {
+			for _, h := range hooks {
+				if h.OnToolCreated != nil {
+					h.OnToolCreated(toolName, code)
+				}
+			}
+		},
+		OnToolTested: func(toolName string, allPassed bool) {
+			for _, h := range hooks {
+				if h.OnToolTested != nil {
+					h.OnToolTested(toolName, allPassed)
+				}
+			}
+		},
+		OnVersionActivated: func(toolName string, version int) {
+			for _, h := range hooks {
+				if h.OnVersionActivated != nil {
+					h.OnVersionActivated(toolName, version)
+				}
+			}
+		},
+	}
+}

--- a/tool/learning/hooks_test.go
+++ b/tool/learning/hooks_test.go
@@ -1,0 +1,61 @@
+package learning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComposeHooks(t *testing.T) {
+	t.Run("composes OnToolCreated", func(t *testing.T) {
+		var calls []string
+		h1 := Hooks{OnToolCreated: func(name, code string) { calls = append(calls, "h1:"+name) }}
+		h2 := Hooks{OnToolCreated: func(name, code string) { calls = append(calls, "h2:"+name) }}
+
+		composed := ComposeHooks(h1, h2)
+		composed.OnToolCreated("test", "code")
+
+		assert.Equal(t, []string{"h1:test", "h2:test"}, calls)
+	})
+
+	t.Run("composes OnToolTested", func(t *testing.T) {
+		var calls []bool
+		h1 := Hooks{OnToolTested: func(name string, passed bool) { calls = append(calls, passed) }}
+		h2 := Hooks{OnToolTested: func(name string, passed bool) { calls = append(calls, !passed) }}
+
+		composed := ComposeHooks(h1, h2)
+		composed.OnToolTested("t", true)
+
+		assert.Equal(t, []bool{true, false}, calls)
+	})
+
+	t.Run("composes OnVersionActivated", func(t *testing.T) {
+		var versions []int
+		h1 := Hooks{OnVersionActivated: func(name string, v int) { versions = append(versions, v) }}
+		h2 := Hooks{OnVersionActivated: func(name string, v int) { versions = append(versions, v*10) }}
+
+		composed := ComposeHooks(h1, h2)
+		composed.OnVersionActivated("t", 3)
+
+		assert.Equal(t, []int{3, 30}, versions)
+	})
+
+	t.Run("nil hooks skipped", func(t *testing.T) {
+		var calls int
+		h1 := Hooks{} // All nil.
+		h2 := Hooks{OnToolCreated: func(name, code string) { calls++ }}
+
+		composed := ComposeHooks(h1, h2)
+		composed.OnToolCreated("test", "code")
+
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("empty compose", func(t *testing.T) {
+		composed := ComposeHooks()
+		// Should not panic.
+		composed.OnToolCreated("test", "code")
+		composed.OnToolTested("test", true)
+		composed.OnVersionActivated("test", 1)
+	})
+}

--- a/tool/learning/tester.go
+++ b/tool/learning/tester.go
@@ -1,0 +1,167 @@
+package learning
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// TestCase defines a single test case for validating a generated tool.
+type TestCase struct {
+	// Name is a descriptive name for the test case.
+	Name string
+	// Input is the input map to pass to the tool's Execute method.
+	Input map[string]any
+	// WantOutput is the expected output string. If empty, only checks that
+	// execution succeeds without error.
+	WantOutput string
+	// WantError indicates whether the test case expects an error.
+	WantError bool
+}
+
+// TestResult holds the outcome of running a single test case.
+type TestResult struct {
+	// Name is the test case name.
+	Name string
+	// Passed indicates whether the test case passed.
+	Passed bool
+	// GotOutput is the actual output from the tool.
+	GotOutput string
+	// Error is any error that occurred during execution.
+	Error error
+}
+
+// ToolTester validates generated tools by running test inputs before registration.
+// It ensures tools produce expected outputs and handle errors correctly.
+type ToolTester struct {
+	hooks Hooks
+}
+
+// TesterOption configures a ToolTester.
+type TesterOption func(*ToolTester)
+
+// WithTesterHooks sets lifecycle hooks on the tool tester.
+func WithTesterHooks(h Hooks) TesterOption {
+	return func(tt *ToolTester) {
+		tt.hooks = h
+	}
+}
+
+// NewToolTester creates a new ToolTester with the given options.
+func NewToolTester(opts ...TesterOption) *ToolTester {
+	tt := &ToolTester{}
+	for _, opt := range opts {
+		opt(tt)
+	}
+	return tt
+}
+
+// Test runs the given test cases against the tool and returns the results.
+// All test cases are run regardless of individual failures.
+func (tt *ToolTester) Test(ctx context.Context, t *DynamicTool, cases []TestCase) []TestResult {
+	results := make([]TestResult, 0, len(cases))
+
+	for _, tc := range cases {
+		select {
+		case <-ctx.Done():
+			results = append(results, TestResult{
+				Name:   tc.Name,
+				Passed: false,
+				Error:  ctx.Err(),
+			})
+			return results
+		default:
+		}
+
+		result := tt.runCase(ctx, t, tc)
+		results = append(results, result)
+	}
+
+	// Fire hook.
+	if tt.hooks.OnToolTested != nil {
+		allPassed := true
+		for _, r := range results {
+			if !r.Passed {
+				allPassed = false
+				break
+			}
+		}
+		tt.hooks.OnToolTested(t.Name(), allPassed)
+	}
+
+	return results
+}
+
+// Validate runs test cases and returns an error if any test case fails.
+// This is a convenience method for use in registration pipelines.
+func (tt *ToolTester) Validate(ctx context.Context, t *DynamicTool, cases []TestCase) error {
+	results := tt.Test(ctx, t, cases)
+
+	var failures []string
+	for _, r := range results {
+		if !r.Passed {
+			msg := fmt.Sprintf("test %q failed", r.Name)
+			if r.Error != nil {
+				msg += fmt.Sprintf(": %v", r.Error)
+			}
+			failures = append(failures, msg)
+		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("tool %q validation failed: %s", t.Name(), joinStrings(failures, "; "))
+	}
+	return nil
+}
+
+// runCase executes a single test case against the tool.
+func (tt *ToolTester) runCase(ctx context.Context, t *DynamicTool, tc TestCase) TestResult {
+	result, err := t.Execute(ctx, tc.Input)
+
+	if tc.WantError {
+		if err != nil {
+			return TestResult{Name: tc.Name, Passed: true, Error: err}
+		}
+		return TestResult{
+			Name:   tc.Name,
+			Passed: false,
+			Error:  fmt.Errorf("expected error but got none"),
+		}
+	}
+
+	if err != nil {
+		return TestResult{Name: tc.Name, Passed: false, Error: err}
+	}
+
+	// Extract text output from result.
+	gotOutput := ""
+	if result != nil && len(result.Content) > 0 {
+		if tp, ok := result.Content[0].(schema.TextPart); ok {
+			gotOutput = tp.Text
+		}
+	}
+
+	if tc.WantOutput != "" && gotOutput != tc.WantOutput {
+		return TestResult{
+			Name:      tc.Name,
+			Passed:    false,
+			GotOutput: gotOutput,
+			Error:     fmt.Errorf("output mismatch: want %q, got %q", tc.WantOutput, gotOutput),
+		}
+	}
+
+	return TestResult{Name: tc.Name, Passed: true, GotOutput: gotOutput}
+}
+
+// joinStrings joins strings with a separator.
+func joinStrings(strs []string, sep string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	result := strs[0]
+	for _, s := range strs[1:] {
+		result += sep + s
+	}
+	return result
+}

--- a/tool/learning/tester.go
+++ b/tool/learning/tester.go
@@ -3,6 +3,7 @@ package learning
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/lookatitude/beluga-ai/schema"
 )
@@ -110,7 +111,7 @@ func (tt *ToolTester) Validate(ctx context.Context, t *DynamicTool, cases []Test
 	}
 
 	if len(failures) > 0 {
-		return fmt.Errorf("tool %q validation failed: %s", t.Name(), joinStrings(failures, "; "))
+		return fmt.Errorf("tool %q validation failed: %s", t.Name(), strings.Join(failures, "; "))
 	}
 	return nil
 }
@@ -152,16 +153,4 @@ func (tt *ToolTester) runCase(ctx context.Context, t *DynamicTool, tc TestCase) 
 	}
 
 	return TestResult{Name: tc.Name, Passed: true, GotOutput: gotOutput}
-}
-
-// joinStrings joins strings with a separator.
-func joinStrings(strs []string, sep string) string {
-	if len(strs) == 0 {
-		return ""
-	}
-	result := strs[0]
-	for _, s := range strs[1:] {
-		result += sep + s
-	}
-	return result
 }

--- a/tool/learning/tester_test.go
+++ b/tool/learning/tester_test.go
@@ -1,0 +1,149 @@
+package learning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolTester_Test(t *testing.T) {
+	t.Run("all tests pass", func(t *testing.T) {
+		dt := NewDynamicTool("greet", "greet tool", nil, "code",
+			&NoopExecutor{Response: "hello"})
+
+		tester := NewToolTester()
+		results := tester.Test(context.Background(), dt, []TestCase{
+			{Name: "basic", Input: map[string]any{"name": "world"}, WantOutput: "hello"},
+			{Name: "no check", Input: map[string]any{}},
+		})
+
+		assert.Len(t, results, 2)
+		assert.True(t, results[0].Passed)
+		assert.True(t, results[1].Passed)
+	})
+
+	t.Run("output mismatch", func(t *testing.T) {
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Response: "actual"})
+
+		tester := NewToolTester()
+		results := tester.Test(context.Background(), dt, []TestCase{
+			{Name: "mismatch", Input: map[string]any{}, WantOutput: "expected"},
+		})
+
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Passed)
+		assert.Contains(t, results[0].Error.Error(), "output mismatch")
+	})
+
+	t.Run("expected error", func(t *testing.T) {
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Err: fmt.Errorf("boom")})
+
+		tester := NewToolTester()
+		results := tester.Test(context.Background(), dt, []TestCase{
+			{Name: "error expected", Input: map[string]any{}, WantError: true},
+		})
+
+		require.Len(t, results, 1)
+		assert.True(t, results[0].Passed)
+	})
+
+	t.Run("expected error but none", func(t *testing.T) {
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Response: "ok"})
+
+		tester := NewToolTester()
+		results := tester.Test(context.Background(), dt, []TestCase{
+			{Name: "no error", Input: map[string]any{}, WantError: true},
+		})
+
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Passed)
+		assert.Contains(t, results[0].Error.Error(), "expected error")
+	})
+
+	t.Run("unexpected error", func(t *testing.T) {
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Err: fmt.Errorf("surprise")})
+
+		tester := NewToolTester()
+		results := tester.Test(context.Background(), dt, []TestCase{
+			{Name: "surprise", Input: map[string]any{}},
+		})
+
+		require.Len(t, results, 1)
+		assert.False(t, results[0].Passed)
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Response: "ok"})
+
+		tester := NewToolTester()
+		results := tester.Test(ctx, dt, []TestCase{
+			{Name: "first", Input: map[string]any{}},
+			{Name: "second", Input: map[string]any{}},
+		})
+
+		// Should stop after detecting cancellation.
+		require.GreaterOrEqual(t, len(results), 1)
+		lastResult := results[len(results)-1]
+		assert.False(t, lastResult.Passed)
+	})
+}
+
+func TestToolTester_Validate(t *testing.T) {
+	t.Run("all pass", func(t *testing.T) {
+		dt := NewDynamicTool("t", "d", nil, "code",
+			&NoopExecutor{Response: "ok"})
+
+		tester := NewToolTester()
+		err := tester.Validate(context.Background(), dt, []TestCase{
+			{Name: "pass", Input: map[string]any{}, WantOutput: "ok"},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("failure returns error", func(t *testing.T) {
+		dt := NewDynamicTool("bad_tool", "d", nil, "code",
+			&NoopExecutor{Response: "wrong"})
+
+		tester := NewToolTester()
+		err := tester.Validate(context.Background(), dt, []TestCase{
+			{Name: "fail", Input: map[string]any{}, WantOutput: "right"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad_tool")
+		assert.Contains(t, err.Error(), "validation failed")
+	})
+}
+
+func TestToolTester_Hooks(t *testing.T) {
+	var testedTools []string
+	var testedResults []bool
+
+	hooks := Hooks{
+		OnToolTested: func(name string, passed bool) {
+			testedTools = append(testedTools, name)
+			testedResults = append(testedResults, passed)
+		},
+	}
+
+	dt := NewDynamicTool("hooked_tool", "d", nil, "code",
+		&NoopExecutor{Response: "ok"})
+
+	tester := NewToolTester(WithTesterHooks(hooks))
+	tester.Test(context.Background(), dt, []TestCase{
+		{Name: "test1", Input: map[string]any{}, WantOutput: "ok"},
+	})
+
+	assert.Equal(t, []string{"hooked_tool"}, testedTools)
+	assert.Equal(t, []bool{true}, testedResults)
+}

--- a/tool/learning/versioned_registry.go
+++ b/tool/learning/versioned_registry.go
@@ -1,0 +1,214 @@
+package learning
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// VersionRecord is an immutable record of a tool version in the registry.
+type VersionRecord struct {
+	// Version is the sequential version number.
+	Version int
+	// Tool is the tool at this version.
+	Tool tool.Tool
+	// CreatedAt is the timestamp when this version was created.
+	CreatedAt time.Time
+	// Active indicates whether this version is the currently active one.
+	Active bool
+}
+
+// toolEntry holds all versions and the current pointer for a single tool name.
+type toolEntry struct {
+	versions []VersionRecord
+	current  int // index into versions for the active version
+}
+
+// VersionedRegistry wraps a tool.Registry with version tracking. Each tool can
+// have multiple immutable versions, with a "current" pointer that determines
+// which version is served. Supports Upsert, Activate, Rollback, and History.
+type VersionedRegistry struct {
+	mu      sync.RWMutex
+	inner   *tool.Registry
+	entries map[string]*toolEntry
+	hooks   Hooks
+}
+
+// VersionedRegistryOption configures a VersionedRegistry.
+type VersionedRegistryOption func(*VersionedRegistry)
+
+// WithRegistryHooks sets lifecycle hooks on the versioned registry.
+func WithRegistryHooks(h Hooks) VersionedRegistryOption {
+	return func(vr *VersionedRegistry) {
+		vr.hooks = h
+	}
+}
+
+// NewVersionedRegistry creates a new VersionedRegistry backed by the given
+// tool.Registry. If registry is nil, a new one is created.
+func NewVersionedRegistry(registry *tool.Registry, opts ...VersionedRegistryOption) *VersionedRegistry {
+	if registry == nil {
+		registry = tool.NewRegistry()
+	}
+	vr := &VersionedRegistry{
+		inner:   registry,
+		entries: make(map[string]*toolEntry),
+	}
+	for _, opt := range opts {
+		opt(vr)
+	}
+	return vr
+}
+
+// Upsert adds a new version of a tool. If the tool already exists, a new version
+// is appended and activated. If it is new, the first version is created and activated.
+// Returns the new version number.
+func (vr *VersionedRegistry) Upsert(t tool.Tool) (int, error) {
+	vr.mu.Lock()
+	defer vr.mu.Unlock()
+
+	name := t.Name()
+
+	entry, exists := vr.entries[name]
+	if !exists {
+		entry = &toolEntry{
+			versions: nil,
+			current:  0,
+		}
+		vr.entries[name] = entry
+	}
+
+	// Deactivate current version.
+	if len(entry.versions) > 0 {
+		entry.versions[entry.current].Active = false
+	}
+
+	version := len(entry.versions) + 1
+	record := VersionRecord{
+		Version:   version,
+		Tool:      t,
+		CreatedAt: time.Now(),
+		Active:    true,
+	}
+	entry.versions = append(entry.versions, record)
+	entry.current = len(entry.versions) - 1
+
+	// Update inner registry. Remove first if exists, then add.
+	if exists {
+		_ = vr.inner.Remove(name)
+	}
+	if err := vr.inner.Add(t); err != nil {
+		return 0, fmt.Errorf("versioned registry: failed to add tool %q: %w", name, err)
+	}
+
+	// Fire hook.
+	if vr.hooks.OnVersionActivated != nil {
+		vr.hooks.OnVersionActivated(name, version)
+	}
+
+	return version, nil
+}
+
+// Activate sets the given version as the current active version for the named tool.
+// Returns an error if the tool or version does not exist.
+func (vr *VersionedRegistry) Activate(name string, version int) error {
+	vr.mu.Lock()
+	defer vr.mu.Unlock()
+
+	entry, exists := vr.entries[name]
+	if !exists {
+		return fmt.Errorf("versioned registry: tool %q not found", name)
+	}
+
+	idx := version - 1
+	if idx < 0 || idx >= len(entry.versions) {
+		return fmt.Errorf("versioned registry: version %d not found for tool %q", version, name)
+	}
+
+	// Deactivate current, activate target.
+	entry.versions[entry.current].Active = false
+	entry.versions[idx].Active = true
+	entry.current = idx
+
+	// Update inner registry.
+	_ = vr.inner.Remove(name)
+	if err := vr.inner.Add(entry.versions[idx].Tool); err != nil {
+		return fmt.Errorf("versioned registry: failed to activate tool %q v%d: %w", name, version, err)
+	}
+
+	if vr.hooks.OnVersionActivated != nil {
+		vr.hooks.OnVersionActivated(name, version)
+	}
+
+	return nil
+}
+
+// Rollback activates the previous version of the named tool. Returns an error
+// if there is no previous version or the tool does not exist.
+func (vr *VersionedRegistry) Rollback(name string) (int, error) {
+	vr.mu.Lock()
+
+	entry, exists := vr.entries[name]
+	if !exists {
+		vr.mu.Unlock()
+		return 0, fmt.Errorf("versioned registry: tool %q not found", name)
+	}
+
+	if entry.current == 0 {
+		vr.mu.Unlock()
+		return 0, fmt.Errorf("versioned registry: no previous version for tool %q", name)
+	}
+
+	prevVersion := entry.versions[entry.current-1].Version
+	vr.mu.Unlock()
+
+	// Use Activate which acquires the lock.
+	if err := vr.Activate(name, prevVersion); err != nil {
+		return 0, err
+	}
+
+	return prevVersion, nil
+}
+
+// History returns all version records for the named tool, ordered by version.
+// Returns an error if the tool does not exist.
+func (vr *VersionedRegistry) History(name string) ([]VersionRecord, error) {
+	vr.mu.RLock()
+	defer vr.mu.RUnlock()
+
+	entry, exists := vr.entries[name]
+	if !exists {
+		return nil, fmt.Errorf("versioned registry: tool %q not found", name)
+	}
+
+	// Return a copy to prevent mutation.
+	records := make([]VersionRecord, len(entry.versions))
+	copy(records, entry.versions)
+	return records, nil
+}
+
+// Get returns the currently active version of the named tool.
+func (vr *VersionedRegistry) Get(name string) (tool.Tool, error) {
+	return vr.inner.Get(name)
+}
+
+// List returns a sorted list of all tool names in the registry.
+func (vr *VersionedRegistry) List() []string {
+	vr.mu.RLock()
+	defer vr.mu.RUnlock()
+
+	names := make([]string, 0, len(vr.entries))
+	for name := range vr.entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// All returns all currently active tools from the inner registry.
+func (vr *VersionedRegistry) All() []tool.Tool {
+	return vr.inner.All()
+}

--- a/tool/learning/versioned_registry.go
+++ b/tool/learning/versioned_registry.go
@@ -78,14 +78,25 @@ func (vr *VersionedRegistry) Upsert(t tool.Tool) (int, error) {
 			versions: nil,
 			current:  0,
 		}
-		vr.entries[name] = entry
 	}
 
-	// Deactivate current version.
+	// Update inner registry FIRST, before mutating in-memory entry state.
+	// This ensures we can cleanly return an error without leaving the
+	// in-memory view ahead of the inner registry.
+	if exists {
+		_ = vr.inner.Remove(name)
+	}
+	if err := vr.inner.Add(t); err != nil {
+		return 0, fmt.Errorf("versioned registry: failed to add tool %q: %w", name, err)
+	}
+
+	// Inner registry succeeded — now mutate in-memory state.
+	if !exists {
+		vr.entries[name] = entry
+	}
 	if len(entry.versions) > 0 {
 		entry.versions[entry.current].Active = false
 	}
-
 	version := len(entry.versions) + 1
 	record := VersionRecord{
 		Version:   version,
@@ -95,14 +106,6 @@ func (vr *VersionedRegistry) Upsert(t tool.Tool) (int, error) {
 	}
 	entry.versions = append(entry.versions, record)
 	entry.current = len(entry.versions) - 1
-
-	// Update inner registry. Remove first if exists, then add.
-	if exists {
-		_ = vr.inner.Remove(name)
-	}
-	if err := vr.inner.Add(t); err != nil {
-		return 0, fmt.Errorf("versioned registry: failed to add tool %q: %w", name, err)
-	}
 
 	// Fire hook.
 	if vr.hooks.OnVersionActivated != nil {
@@ -128,16 +131,17 @@ func (vr *VersionedRegistry) Activate(name string, version int) error {
 		return fmt.Errorf("versioned registry: version %d not found for tool %q", version, name)
 	}
 
-	// Deactivate current, activate target.
-	entry.versions[entry.current].Active = false
-	entry.versions[idx].Active = true
-	entry.current = idx
-
-	// Update inner registry.
+	// Update inner registry FIRST, before mutating in-memory state, so a
+	// failure leaves the registry consistent.
 	_ = vr.inner.Remove(name)
 	if err := vr.inner.Add(entry.versions[idx].Tool); err != nil {
 		return fmt.Errorf("versioned registry: failed to activate tool %q v%d: %w", name, version, err)
 	}
+
+	// Deactivate current, activate target.
+	entry.versions[entry.current].Active = false
+	entry.versions[idx].Active = true
+	entry.current = idx
 
 	if vr.hooks.OnVersionActivated != nil {
 		vr.hooks.OnVersionActivated(name, version)
@@ -150,26 +154,33 @@ func (vr *VersionedRegistry) Activate(name string, version int) error {
 // if there is no previous version or the tool does not exist.
 func (vr *VersionedRegistry) Rollback(name string) (int, error) {
 	vr.mu.Lock()
+	defer vr.mu.Unlock()
 
 	entry, exists := vr.entries[name]
 	if !exists {
-		vr.mu.Unlock()
 		return 0, fmt.Errorf("versioned registry: tool %q not found", name)
 	}
-
 	if entry.current == 0 {
-		vr.mu.Unlock()
 		return 0, fmt.Errorf("versioned registry: no previous version for tool %q", name)
 	}
 
-	prevVersion := entry.versions[entry.current-1].Version
-	vr.mu.Unlock()
+	idx := entry.current - 1
+	prevVersion := entry.versions[idx].Version
 
-	// Use Activate which acquires the lock.
-	if err := vr.Activate(name, prevVersion); err != nil {
-		return 0, err
+	// Update inner registry FIRST, before mutating in-memory state, so a
+	// failure leaves the registry consistent.
+	_ = vr.inner.Remove(name)
+	if err := vr.inner.Add(entry.versions[idx].Tool); err != nil {
+		return 0, fmt.Errorf("versioned registry: failed to rollback tool %q: %w", name, err)
 	}
 
+	entry.versions[entry.current].Active = false
+	entry.versions[idx].Active = true
+	entry.current = idx
+
+	if vr.hooks.OnVersionActivated != nil {
+		vr.hooks.OnVersionActivated(name, prevVersion)
+	}
 	return prevVersion, nil
 }
 

--- a/tool/learning/versioned_registry_test.go
+++ b/tool/learning/versioned_registry_test.go
@@ -1,0 +1,191 @@
+package learning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeDynTool(name string, version int) *DynamicTool {
+	return NewDynamicTool(
+		name,
+		"description for "+name,
+		map[string]any{"type": "object"},
+		"code v"+string(rune('0'+version)),
+		&NoopExecutor{Response: "v" + string(rune('0'+version))},
+		WithVersion(version),
+	)
+}
+
+func TestVersionedRegistry_Upsert(t *testing.T) {
+	vr := NewVersionedRegistry(nil)
+
+	t.Run("first upsert creates version 1", func(t *testing.T) {
+		tool := makeDynTool("calc", 1)
+		v, err := vr.Upsert(tool)
+		require.NoError(t, err)
+		assert.Equal(t, 1, v)
+	})
+
+	t.Run("second upsert creates version 2", func(t *testing.T) {
+		tool := makeDynTool("calc", 2)
+		v, err := vr.Upsert(tool)
+		require.NoError(t, err)
+		assert.Equal(t, 2, v)
+	})
+
+	t.Run("get returns latest version", func(t *testing.T) {
+		got, err := vr.Get("calc")
+		require.NoError(t, err)
+		assert.Equal(t, "calc", got.Name())
+	})
+
+	t.Run("list returns tool names", func(t *testing.T) {
+		names := vr.List()
+		assert.Equal(t, []string{"calc"}, names)
+	})
+}
+
+func TestVersionedRegistry_Activate(t *testing.T) {
+	vr := NewVersionedRegistry(nil)
+
+	// Create 3 versions.
+	for i := 1; i <= 3; i++ {
+		_, err := vr.Upsert(makeDynTool("search", i))
+		require.NoError(t, err)
+	}
+
+	t.Run("activate version 1", func(t *testing.T) {
+		err := vr.Activate("search", 1)
+		require.NoError(t, err)
+
+		history, err := vr.History("search")
+		require.NoError(t, err)
+		assert.True(t, history[0].Active)
+		assert.False(t, history[1].Active)
+		assert.False(t, history[2].Active)
+	})
+
+	t.Run("activate nonexistent tool", func(t *testing.T) {
+		err := vr.Activate("nonexistent", 1)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("activate nonexistent version", func(t *testing.T) {
+		err := vr.Activate("search", 99)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "version 99 not found")
+	})
+}
+
+func TestVersionedRegistry_Rollback(t *testing.T) {
+	vr := NewVersionedRegistry(nil)
+
+	t.Run("rollback with no previous version", func(t *testing.T) {
+		_, err := vr.Upsert(makeDynTool("single", 1))
+		require.NoError(t, err)
+
+		_, err = vr.Rollback("single")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no previous version")
+	})
+
+	t.Run("rollback to previous version", func(t *testing.T) {
+		_, err := vr.Upsert(makeDynTool("multi", 1))
+		require.NoError(t, err)
+		_, err = vr.Upsert(makeDynTool("multi", 2))
+		require.NoError(t, err)
+
+		v, err := vr.Rollback("multi")
+		require.NoError(t, err)
+		assert.Equal(t, 1, v)
+
+		history, err := vr.History("multi")
+		require.NoError(t, err)
+		assert.True(t, history[0].Active)
+		assert.False(t, history[1].Active)
+	})
+
+	t.Run("rollback nonexistent tool", func(t *testing.T) {
+		_, err := vr.Rollback("ghost")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestVersionedRegistry_History(t *testing.T) {
+	vr := NewVersionedRegistry(nil)
+
+	t.Run("history of nonexistent tool", func(t *testing.T) {
+		_, err := vr.History("nope")
+		assert.Error(t, err)
+	})
+
+	t.Run("history returns all versions", func(t *testing.T) {
+		for i := 1; i <= 3; i++ {
+			_, err := vr.Upsert(makeDynTool("hist", i))
+			require.NoError(t, err)
+		}
+
+		records, err := vr.History("hist")
+		require.NoError(t, err)
+		require.Len(t, records, 3)
+
+		assert.Equal(t, 1, records[0].Version)
+		assert.Equal(t, 2, records[1].Version)
+		assert.Equal(t, 3, records[2].Version)
+
+		// Only last should be active.
+		assert.False(t, records[0].Active)
+		assert.False(t, records[1].Active)
+		assert.True(t, records[2].Active)
+	})
+
+	t.Run("history is a copy", func(t *testing.T) {
+		records, err := vr.History("hist")
+		require.NoError(t, err)
+		records[0].Active = true // Mutate the copy.
+
+		original, err := vr.History("hist")
+		require.NoError(t, err)
+		assert.False(t, original[0].Active) // Original unchanged.
+	})
+}
+
+func TestVersionedRegistry_All(t *testing.T) {
+	vr := NewVersionedRegistry(nil)
+
+	_, err := vr.Upsert(makeDynTool("a", 1))
+	require.NoError(t, err)
+	_, err = vr.Upsert(makeDynTool("b", 1))
+	require.NoError(t, err)
+
+	all := vr.All()
+	assert.Len(t, all, 2)
+}
+
+func TestVersionedRegistry_Hooks(t *testing.T) {
+	var activated []string
+
+	hooks := Hooks{
+		OnVersionActivated: func(name string, version int) {
+			activated = append(activated, name)
+		},
+	}
+
+	vr := NewVersionedRegistry(nil, WithRegistryHooks(hooks))
+	_, err := vr.Upsert(makeDynTool("hooked", 1))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"hooked"}, activated)
+
+	// Activate fires hook too.
+	_, err = vr.Upsert(makeDynTool("hooked", 2))
+	require.NoError(t, err)
+	err = vr.Activate("hooked", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"hooked", "hooked", "hooked"}, activated)
+}


### PR DESCRIPTION
## Summary
- tool/learning package, DynamicTool, ASTValidator (go/ast allowlist), ToolGenerator, VersionedRegistry with rollback

## Linear
- LOO-31: https://linear.app/lookatitude/issue/LOO-31

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)