### PR TITLE
LOO-34: Temporal Least Privilege and Agentic Identity

### DIFF
--- a/auth/credential/context.go
+++ b/auth/credential/context.go
@@ -1,0 +1,21 @@
+package credential
+
+import "context"
+
+// contextKey is an unexported type used for context keys in this package to
+// prevent collisions with keys defined in other packages.
+type contextKey int
+
+const credentialKey contextKey = iota
+
+// WithCredential returns a copy of ctx carrying the given credential.
+func WithCredential(ctx context.Context, cred *AgentCredential) context.Context {
+	return context.WithValue(ctx, credentialKey, cred)
+}
+
+// CredentialFromContext extracts the AgentCredential from ctx. It returns nil
+// if no credential is present.
+func CredentialFromContext(ctx context.Context) *AgentCredential {
+	cred, _ := ctx.Value(credentialKey).(*AgentCredential)
+	return cred
+}

--- a/auth/credential/credential.go
+++ b/auth/credential/credential.go
@@ -1,0 +1,48 @@
+package credential
+
+import "time"
+
+// AgentCredential represents a time-bounded, scoped credential issued to an
+// agent. It carries explicit permissions and expiry information.
+type AgentCredential struct {
+	// ID uniquely identifies this credential.
+	ID string
+
+	// AgentID identifies the agent this credential was issued to.
+	AgentID string
+
+	// Permissions lists the actions this credential grants.
+	Permissions []string
+
+	// IssuedAt records when the credential was created.
+	IssuedAt time.Time
+
+	// ExpiresAt records when the credential becomes invalid.
+	ExpiresAt time.Time
+
+	// Revoked indicates whether the credential has been explicitly revoked.
+	Revoked bool
+
+	// Metadata carries optional key-value pairs for auditing and tracing.
+	Metadata map[string]string
+}
+
+// IsExpired reports whether the credential has passed its expiry time.
+func (c *AgentCredential) IsExpired() bool {
+	return time.Now().After(c.ExpiresAt)
+}
+
+// IsValid reports whether the credential is neither expired nor revoked.
+func (c *AgentCredential) IsValid() bool {
+	return !c.Revoked && !c.IsExpired()
+}
+
+// HasPermission reports whether the credential includes the given permission.
+func (c *AgentCredential) HasPermission(perm string) bool {
+	for _, p := range c.Permissions {
+		if p == perm {
+			return true
+		}
+	}
+	return false
+}

--- a/auth/credential/credential_test.go
+++ b/auth/credential/credential_test.go
@@ -1,0 +1,676 @@
+package credential
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/auth"
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// --- AgentCredential tests ---
+
+func TestAgentCredential_IsExpired(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{
+			name:      "not expired",
+			expiresAt: time.Now().Add(time.Hour),
+			want:      false,
+		},
+		{
+			name:      "expired",
+			expiresAt: time.Now().Add(-time.Hour),
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred := &AgentCredential{ExpiresAt: tt.expiresAt}
+			if got := cred.IsExpired(); got != tt.want {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentCredential_IsValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		revoked   bool
+		want      bool
+	}{
+		{
+			name:      "valid",
+			expiresAt: time.Now().Add(time.Hour),
+			revoked:   false,
+			want:      true,
+		},
+		{
+			name:      "expired",
+			expiresAt: time.Now().Add(-time.Hour),
+			revoked:   false,
+			want:      false,
+		},
+		{
+			name:      "revoked",
+			expiresAt: time.Now().Add(time.Hour),
+			revoked:   true,
+			want:      false,
+		},
+		{
+			name:      "expired and revoked",
+			expiresAt: time.Now().Add(-time.Hour),
+			revoked:   true,
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred := &AgentCredential{ExpiresAt: tt.expiresAt, Revoked: tt.revoked}
+			if got := cred.IsValid(); got != tt.want {
+				t.Errorf("IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentCredential_HasPermission(t *testing.T) {
+	cred := &AgentCredential{Permissions: []string{"tool:execute", "memory:read"}}
+
+	if !cred.HasPermission("tool:execute") {
+		t.Error("HasPermission(tool:execute) = false, want true")
+	}
+	if !cred.HasPermission("memory:read") {
+		t.Error("HasPermission(memory:read) = false, want true")
+	}
+	if cred.HasPermission("memory:write") {
+		t.Error("HasPermission(memory:write) = true, want false")
+	}
+}
+
+// --- Context tests ---
+
+func TestContext_RoundTrip(t *testing.T) {
+	cred := &AgentCredential{ID: "test-123", AgentID: "agent-1"}
+	ctx := WithCredential(context.Background(), cred)
+
+	got := CredentialFromContext(ctx)
+	if got == nil {
+		t.Fatal("CredentialFromContext returned nil")
+	}
+	if got.ID != "test-123" {
+		t.Errorf("ID = %q, want %q", got.ID, "test-123")
+	}
+}
+
+func TestContext_Missing(t *testing.T) {
+	got := CredentialFromContext(context.Background())
+	if got != nil {
+		t.Errorf("CredentialFromContext returned %v, want nil", got)
+	}
+}
+
+// --- InMemoryIssuer tests ---
+
+func TestInMemoryIssuer_Issue(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer(WithDefaultTTL(10 * time.Minute))
+
+	cred, err := iss.Issue(ctx, "agent-1", []string{"tool:execute"}, 0)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if cred.AgentID != "agent-1" {
+		t.Errorf("AgentID = %q, want %q", cred.AgentID, "agent-1")
+	}
+	if len(cred.Permissions) != 1 || cred.Permissions[0] != "tool:execute" {
+		t.Errorf("Permissions = %v, want [tool:execute]", cred.Permissions)
+	}
+	if cred.IsExpired() {
+		t.Error("newly issued credential should not be expired")
+	}
+	if cred.Revoked {
+		t.Error("newly issued credential should not be revoked")
+	}
+	if cred.ID == "" {
+		t.Error("credential ID should not be empty")
+	}
+
+	// Verify it's retrievable.
+	got, err := iss.Get(ctx, cred.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.ID != cred.ID {
+		t.Errorf("Get returned ID = %q, want %q", got.ID, cred.ID)
+	}
+}
+
+func TestInMemoryIssuer_Issue_CustomTTL(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	cred, err := iss.Issue(ctx, "agent-1", []string{"tool:execute"}, 30*time.Second)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	// ExpiresAt should be roughly 30s from now.
+	if time.Until(cred.ExpiresAt) > 31*time.Second || time.Until(cred.ExpiresAt) < 29*time.Second {
+		t.Errorf("ExpiresAt too far from expected: %v", cred.ExpiresAt)
+	}
+}
+
+func TestInMemoryIssuer_Issue_EmptyAgentID(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	_, err := iss.Issue(ctx, "", []string{"tool:execute"}, 0)
+	if err == nil {
+		t.Fatal("Issue() with empty agent ID should return error")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrInvalidInput {
+		t.Errorf("error code = %v, want %v", err, core.ErrInvalidInput)
+	}
+}
+
+func TestInMemoryIssuer_Issue_EmptyPermissions(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	_, err := iss.Issue(ctx, "agent-1", nil, 0)
+	if err == nil {
+		t.Fatal("Issue() with nil permissions should return error")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrInvalidInput {
+		t.Errorf("error code = %v, want %v", err, core.ErrInvalidInput)
+	}
+}
+
+func TestInMemoryIssuer_Issue_MaxCredentials(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer(WithMaxCredentials(2))
+
+	_, err := iss.Issue(ctx, "a1", []string{"p"}, time.Hour)
+	if err != nil {
+		t.Fatalf("first Issue() error = %v", err)
+	}
+	_, err = iss.Issue(ctx, "a2", []string{"p"}, time.Hour)
+	if err != nil {
+		t.Fatalf("second Issue() error = %v", err)
+	}
+	_, err = iss.Issue(ctx, "a3", []string{"p"}, time.Hour)
+	if err == nil {
+		t.Fatal("third Issue() should fail when max reached")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrBudgetExhausted {
+		t.Errorf("error code = %v, want %v", err, core.ErrBudgetExhausted)
+	}
+}
+
+func TestInMemoryIssuer_Revoke(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	cred, err := iss.Issue(ctx, "agent-1", []string{"p"}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if err := iss.Revoke(ctx, cred.ID); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+
+	got, err := iss.Get(ctx, cred.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !got.Revoked {
+		t.Error("credential should be revoked")
+	}
+}
+
+func TestInMemoryIssuer_Revoke_NotFound(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	err := iss.Revoke(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("Revoke() of nonexistent should return error")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrNotFound {
+		t.Errorf("error code = %v, want %v", err, core.ErrNotFound)
+	}
+}
+
+func TestInMemoryIssuer_Get_NotFound(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	_, err := iss.Get(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("Get() of nonexistent should return error")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrNotFound {
+		t.Errorf("error code = %v, want %v", err, core.ErrNotFound)
+	}
+}
+
+func TestInMemoryIssuer_PermissionsCopy(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	perms := []string{"a", "b"}
+	cred, err := iss.Issue(ctx, "agent-1", perms, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	// Mutate original slice; credential should be unaffected.
+	perms[0] = "mutated"
+	if cred.Permissions[0] != "a" {
+		t.Error("credential permissions were mutated via original slice")
+	}
+}
+
+func TestInMemoryIssuer_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer(WithMaxCredentials(1000))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = iss.Issue(ctx, "agent", []string{"p"}, time.Hour)
+		}()
+	}
+	wg.Wait()
+
+	if iss.Count() != 100 {
+		t.Errorf("Count() = %d, want 100", iss.Count())
+	}
+}
+
+func TestInMemoryIssuer_Expired(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	// Issue one expired credential (negative TTL trick: issue then manually set)
+	cred, err := iss.Issue(ctx, "agent-1", []string{"p"}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	// Force expiry.
+	iss.mu.Lock()
+	iss.store[cred.ID].ExpiresAt = time.Now().Add(-time.Second)
+	iss.mu.Unlock()
+
+	// Issue one valid credential.
+	_, err = iss.Issue(ctx, "agent-2", []string{"p"}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	expired := iss.Expired()
+	if len(expired) != 1 {
+		t.Errorf("Expired() returned %d credentials, want 1", len(expired))
+	}
+	if len(expired) > 0 && expired[0].ID != cred.ID {
+		t.Errorf("expired credential ID = %q, want %q", expired[0].ID, cred.ID)
+	}
+}
+
+// --- AutoRevoker tests ---
+
+func TestAutoRevoker_Lifecycle(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+	revoker := NewAutoRevoker(iss, WithScanInterval(10*time.Millisecond))
+
+	// Health before start.
+	h := revoker.Health()
+	if h.Status != core.HealthUnhealthy {
+		t.Errorf("Health before start = %v, want unhealthy", h.Status)
+	}
+
+	if err := revoker.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Health after start.
+	h = revoker.Health()
+	if h.Status != core.HealthHealthy {
+		t.Errorf("Health after start = %v, want healthy", h.Status)
+	}
+
+	// Double start should fail.
+	if err := revoker.Start(ctx); err == nil {
+		t.Error("double Start() should return error")
+	}
+
+	if err := revoker.Stop(ctx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	// Double stop should be safe.
+	if err := revoker.Stop(ctx); err != nil {
+		t.Fatalf("double Stop() error = %v", err)
+	}
+}
+
+func TestAutoRevoker_RevokesExpired(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	// Issue a credential and force it to be expired.
+	cred, err := iss.Issue(ctx, "agent-1", []string{"p"}, time.Hour)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	iss.mu.Lock()
+	iss.store[cred.ID].ExpiresAt = time.Now().Add(-time.Second)
+	iss.mu.Unlock()
+
+	var revoked int
+	hooks := RevokerHooks{
+		OnScanComplete: func(_ context.Context, n int) {
+			revoked += n
+		},
+	}
+
+	revoker := NewAutoRevoker(iss,
+		WithScanInterval(10*time.Millisecond),
+		WithRevokerHooks(hooks),
+	)
+
+	if err := revoker.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Wait for at least one scan.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := revoker.Stop(ctx); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	got, err := iss.Get(ctx, cred.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !got.Revoked {
+		t.Error("expired credential should have been revoked by AutoRevoker")
+	}
+	if revoked < 1 {
+		t.Errorf("OnScanComplete reported %d revocations, want >= 1", revoked)
+	}
+}
+
+// --- JITProvider tests ---
+
+func TestJITProvider_Issue(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+	jit := NewJITProvider(iss, WithJITTTL(1*time.Minute))
+
+	cred, err := jit.Issue(ctx, "agent-1", []string{"tool:execute"})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if cred.AgentID != "agent-1" {
+		t.Errorf("AgentID = %q, want %q", cred.AgentID, "agent-1")
+	}
+	if !cred.HasPermission("tool:execute") {
+		t.Error("credential should have tool:execute permission")
+	}
+	if cred.Metadata["issued_by"] != "jit" {
+		t.Errorf("issued_by metadata = %q, want %q", cred.Metadata["issued_by"], "jit")
+	}
+	// TTL should be ~1 minute.
+	if time.Until(cred.ExpiresAt) > 61*time.Second {
+		t.Errorf("ExpiresAt too far in the future: %v", cred.ExpiresAt)
+	}
+}
+
+func TestJITProvider_Issue_EmptyAgent(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+	jit := NewJITProvider(iss)
+
+	_, err := jit.Issue(ctx, "", []string{"p"})
+	if err == nil {
+		t.Fatal("Issue() with empty agent should error")
+	}
+}
+
+func TestJITProvider_Issue_EmptyPermissions(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+	jit := NewJITProvider(iss)
+
+	_, err := jit.Issue(ctx, "agent-1", nil)
+	if err == nil {
+		t.Fatal("Issue() with nil permissions should error")
+	}
+}
+
+func TestJITProvider_PermissionNarrowing(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	narrower := func(_ string, requested []string) ([]string, error) {
+		// Only allow tool:execute.
+		var allowed []string
+		for _, p := range requested {
+			if p == "tool:execute" {
+				allowed = append(allowed, p)
+			}
+		}
+		return allowed, nil
+	}
+
+	jit := NewJITProvider(iss, WithPermissionNarrowing(narrower))
+
+	cred, err := jit.Issue(ctx, "agent-1", []string{"tool:execute", "memory:write"})
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if len(cred.Permissions) != 1 || cred.Permissions[0] != "tool:execute" {
+		t.Errorf("Permissions = %v, want [tool:execute]", cred.Permissions)
+	}
+}
+
+func TestJITProvider_PermissionNarrowing_AllDenied(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	narrower := func(_ string, _ []string) ([]string, error) {
+		return nil, nil // deny all
+	}
+
+	jit := NewJITProvider(iss, WithPermissionNarrowing(narrower))
+
+	_, err := jit.Issue(ctx, "agent-1", []string{"tool:execute"})
+	if err == nil {
+		t.Fatal("Issue() should fail when all permissions denied")
+	}
+}
+
+func TestJITProvider_PermissionNarrowing_Error(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer()
+
+	narrower := func(_ string, _ []string) ([]string, error) {
+		return nil, errors.New("policy unavailable")
+	}
+
+	jit := NewJITProvider(iss, WithPermissionNarrowing(narrower))
+
+	_, err := jit.Issue(ctx, "agent-1", []string{"tool:execute"})
+	if err == nil {
+		t.Fatal("Issue() should propagate narrower error")
+	}
+}
+
+// --- CredentialMiddleware tests ---
+
+func TestCredentialMiddleware_NoCredential(t *testing.T) {
+	ctx := context.Background()
+	policy := newAllowAllPolicy()
+	wrapped := CredentialMiddleware()(policy)
+
+	allowed, err := wrapped.Authorize(ctx, "alice", auth.PermToolExec, "calc")
+	if err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if !allowed {
+		t.Error("should delegate to underlying policy when no credential")
+	}
+}
+
+func TestCredentialMiddleware_ValidCredential(t *testing.T) {
+	cred := &AgentCredential{
+		ID:          "cred-1",
+		AgentID:     "agent-1",
+		Permissions: []string{string(auth.PermToolExec)},
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	ctx := WithCredential(context.Background(), cred)
+	policy := newAllowAllPolicy()
+	wrapped := CredentialMiddleware()(policy)
+
+	allowed, err := wrapped.Authorize(ctx, "alice", auth.PermToolExec, "calc")
+	if err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if !allowed {
+		t.Error("should allow with valid credential and matching permission")
+	}
+}
+
+func TestCredentialMiddleware_ExpiredCredential(t *testing.T) {
+	cred := &AgentCredential{
+		ID:          "cred-1",
+		AgentID:     "agent-1",
+		Permissions: []string{string(auth.PermToolExec)},
+		ExpiresAt:   time.Now().Add(-time.Hour),
+	}
+	ctx := WithCredential(context.Background(), cred)
+	policy := newAllowAllPolicy()
+	wrapped := CredentialMiddleware()(policy)
+
+	_, err := wrapped.Authorize(ctx, "alice", auth.PermToolExec, "calc")
+	if err == nil {
+		t.Fatal("should return error for expired credential")
+	}
+	var coreErr *core.Error
+	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrAuth {
+		t.Errorf("error = %v, want auth error", err)
+	}
+}
+
+func TestCredentialMiddleware_RevokedCredential(t *testing.T) {
+	cred := &AgentCredential{
+		ID:          "cred-1",
+		AgentID:     "agent-1",
+		Permissions: []string{string(auth.PermToolExec)},
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Revoked:     true,
+	}
+	ctx := WithCredential(context.Background(), cred)
+	policy := newAllowAllPolicy()
+	wrapped := CredentialMiddleware()(policy)
+
+	_, err := wrapped.Authorize(ctx, "alice", auth.PermToolExec, "calc")
+	if err == nil {
+		t.Fatal("should return error for revoked credential")
+	}
+}
+
+func TestCredentialMiddleware_MissingPermission(t *testing.T) {
+	cred := &AgentCredential{
+		ID:          "cred-1",
+		AgentID:     "agent-1",
+		Permissions: []string{"memory:read"},
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	ctx := WithCredential(context.Background(), cred)
+	policy := newAllowAllPolicy()
+	wrapped := CredentialMiddleware()(policy)
+
+	allowed, err := wrapped.Authorize(ctx, "alice", auth.PermToolExec, "calc")
+	if err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if allowed {
+		t.Error("should deny when credential lacks required permission")
+	}
+}
+
+// --- Full lifecycle integration test ---
+
+func TestFullLifecycle(t *testing.T) {
+	ctx := context.Background()
+	iss := NewInMemoryIssuer(WithDefaultTTL(5*time.Minute), WithMaxCredentials(100))
+	jit := NewJITProvider(iss, WithJITTTL(1*time.Minute))
+
+	// Issue via JIT.
+	cred, err := jit.Issue(ctx, "agent-alpha", []string{string(auth.PermToolExec)})
+	if err != nil {
+		t.Fatalf("JIT Issue() error = %v", err)
+	}
+	if !cred.IsValid() {
+		t.Fatal("fresh JIT credential should be valid")
+	}
+
+	// Use in middleware.
+	credCtx := WithCredential(ctx, cred)
+	policy := auth.ApplyMiddleware(newAllowAllPolicy(), CredentialMiddleware())
+
+	allowed, err := policy.Authorize(credCtx, "agent-alpha", auth.PermToolExec, "calculator")
+	if err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if !allowed {
+		t.Error("should allow valid JIT credential")
+	}
+
+	// Revoke.
+	if err := iss.Revoke(ctx, cred.ID); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+
+	// Should now fail.
+	_, err = policy.Authorize(credCtx, "agent-alpha", auth.PermToolExec, "calculator")
+	if err == nil {
+		t.Fatal("should return error after revocation")
+	}
+}
+
+// --- test helpers ---
+
+// allowAllPolicy is a test helper that always allows authorization.
+type allowAllPolicy struct{}
+
+func newAllowAllPolicy() auth.Policy { return &allowAllPolicy{} }
+
+func (p *allowAllPolicy) Name() string { return "allow-all" }
+
+func (p *allowAllPolicy) Authorize(_ context.Context, _ string, _ auth.Permission, _ string) (bool, error) {
+	return true, nil
+}
+
+var _ auth.Policy = (*allowAllPolicy)(nil)

--- a/auth/credential/credential_test.go
+++ b/auth/credential/credential_test.go
@@ -385,9 +385,18 @@ func TestAutoRevoker_RevokesExpired(t *testing.T) {
 	iss.mu.Unlock()
 
 	var revoked int
+	var revokedIDs []string
+	var hookMu sync.Mutex
 	hooks := RevokerHooks{
 		OnScanComplete: func(_ context.Context, n int) {
+			hookMu.Lock()
 			revoked += n
+			hookMu.Unlock()
+		},
+		OnRevoke: func(_ context.Context, c *AgentCredential) {
+			hookMu.Lock()
+			revokedIDs = append(revokedIDs, c.ID)
+			hookMu.Unlock()
 		},
 	}
 
@@ -407,15 +416,15 @@ func TestAutoRevoker_RevokesExpired(t *testing.T) {
 		t.Fatalf("Stop() error = %v", err)
 	}
 
-	got, err := iss.Get(ctx, cred.ID)
-	if err != nil {
-		t.Fatalf("Get() error = %v", err)
+	hookMu.Lock()
+	sawID := len(revokedIDs) > 0 && revokedIDs[0] == cred.ID
+	gotRevoked := revoked
+	hookMu.Unlock()
+	if !sawID {
+		t.Errorf("expired credential should have been revoked by AutoRevoker, got IDs = %v", revokedIDs)
 	}
-	if !got.Revoked {
-		t.Error("expired credential should have been revoked by AutoRevoker")
-	}
-	if revoked < 1 {
-		t.Errorf("OnScanComplete reported %d revocations, want >= 1", revoked)
+	if gotRevoked < 1 {
+		t.Errorf("OnScanComplete reported %d revocations, want >= 1", gotRevoked)
 	}
 }
 
@@ -652,6 +661,15 @@ func TestFullLifecycle(t *testing.T) {
 	if err := iss.Revoke(ctx, cred.ID); err != nil {
 		t.Fatalf("Revoke() error = %v", err)
 	}
+
+	// Re-fetch the credential snapshot: issuer now returns deep copies so the
+	// previously-held pointer represents a point-in-time view, not a live
+	// reference. Callers that need the current state must query the issuer.
+	refreshed, err := iss.Get(ctx, cred.ID)
+	if err != nil {
+		t.Fatalf("Get() after revoke error = %v", err)
+	}
+	credCtx = WithCredential(ctx, refreshed)
 
 	// Should now fail.
 	_, err = policy.Authorize(credCtx, "agent-alpha", auth.PermToolExec, "calculator")

--- a/auth/credential/doc.go
+++ b/auth/credential/doc.go
@@ -1,0 +1,61 @@
+// Package credential provides temporal least-privilege credential management
+// for the Beluga AI framework. Credentials are time-bounded, scoped to
+// specific permissions, and automatically revoked when expired.
+//
+// # AgentCredential
+//
+// An AgentCredential ties a set of permissions to an agent identity with
+// explicit issuance and expiry timestamps. Credentials can be revoked
+// manually or automatically by the AutoRevoker.
+//
+//	cred := credential.AgentCredential{
+//	    ID:          "cred-123",
+//	    AgentID:     "agent-alpha",
+//	    Permissions: []string{"tool:execute", "memory:read"},
+//	    IssuedAt:    time.Now(),
+//	    ExpiresAt:   time.Now().Add(5 * time.Minute),
+//	}
+//
+// # CredentialIssuer
+//
+// The CredentialIssuer interface provides Issue, Revoke, and Get operations.
+// InMemoryIssuer is the built-in thread-safe implementation with bounded
+// storage and configurable default TTL.
+//
+//	issuer := credential.NewInMemoryIssuer(
+//	    credential.WithDefaultTTL(10 * time.Minute),
+//	    credential.WithMaxCredentials(1000),
+//	)
+//
+// # AutoRevoker
+//
+// AutoRevoker implements core.Lifecycle and runs a background scan that
+// revokes expired credentials on a configurable interval.
+//
+//	revoker := credential.NewAutoRevoker(issuer,
+//	    credential.WithScanInterval(30 * time.Second),
+//	)
+//	revoker.Start(ctx)
+//	defer revoker.Stop(ctx)
+//
+// # JITProvider
+//
+// JITProvider issues just-in-time credentials with minimal TTL scoped to
+// only the permissions required for an immediate operation.
+//
+//	jit := credential.NewJITProvider(issuer,
+//	    credential.WithJITTTL(2 * time.Minute),
+//	)
+//	cred, err := jit.Issue(ctx, "agent-alpha", []string{"tool:execute"})
+//
+// # Context Helpers
+//
+// WithCredential and CredentialFromContext store and retrieve credentials
+// from context.Context, enabling middleware-based enforcement.
+//
+// # Middleware
+//
+// CredentialMiddleware wraps an auth.Policy to enforce credential-based
+// authorization: it extracts the credential from context, validates
+// expiry, and checks that the required permission is present.
+package credential

--- a/auth/credential/issuer.go
+++ b/auth/credential/issuer.go
@@ -1,0 +1,189 @@
+package credential
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// CredentialIssuer manages the lifecycle of agent credentials. Implementations
+// must be safe for concurrent use.
+type CredentialIssuer interface {
+	// Issue creates a new credential for the given agent with the specified
+	// permissions and TTL.
+	Issue(ctx context.Context, agentID string, permissions []string, ttl time.Duration) (*AgentCredential, error)
+
+	// Revoke marks a credential as revoked by its ID.
+	Revoke(ctx context.Context, credentialID string) error
+
+	// Get retrieves a credential by its ID. Returns a core.ErrNotFound error
+	// if the credential does not exist.
+	Get(ctx context.Context, credentialID string) (*AgentCredential, error)
+}
+
+// issuerOptions holds configuration for InMemoryIssuer.
+type issuerOptions struct {
+	defaultTTL     time.Duration
+	maxCredentials int
+}
+
+// IssuerOption configures an InMemoryIssuer.
+type IssuerOption func(*issuerOptions)
+
+// WithDefaultTTL sets the default time-to-live for issued credentials.
+// Defaults to 5 minutes.
+func WithDefaultTTL(d time.Duration) IssuerOption {
+	return func(o *issuerOptions) { o.defaultTTL = d }
+}
+
+// WithMaxCredentials sets the maximum number of credentials the issuer will
+// store. When the limit is reached, Issue returns an error. Defaults to 10000.
+func WithMaxCredentials(max int) IssuerOption {
+	return func(o *issuerOptions) { o.maxCredentials = max }
+}
+
+func defaultIssuerOptions() issuerOptions {
+	return issuerOptions{
+		defaultTTL:     5 * time.Minute,
+		maxCredentials: 10000,
+	}
+}
+
+// InMemoryIssuer is a thread-safe, bounded in-memory implementation of
+// CredentialIssuer.
+type InMemoryIssuer struct {
+	mu    sync.RWMutex
+	store map[string]*AgentCredential
+	opts  issuerOptions
+}
+
+// Compile-time check that InMemoryIssuer implements CredentialIssuer.
+var _ CredentialIssuer = (*InMemoryIssuer)(nil)
+
+// NewInMemoryIssuer creates a new InMemoryIssuer with the given options.
+func NewInMemoryIssuer(opts ...IssuerOption) *InMemoryIssuer {
+	o := defaultIssuerOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &InMemoryIssuer{
+		store: make(map[string]*AgentCredential),
+		opts:  o,
+	}
+}
+
+// Issue creates a new credential for the given agent. If ttl is zero, the
+// issuer's default TTL is used.
+func (iss *InMemoryIssuer) Issue(_ context.Context, agentID string, permissions []string, ttl time.Duration) (*AgentCredential, error) {
+	if agentID == "" {
+		return nil, core.NewError("credential.issue", core.ErrInvalidInput, "agent ID must not be empty", nil)
+	}
+	if len(permissions) == 0 {
+		return nil, core.NewError("credential.issue", core.ErrInvalidInput, "permissions must not be empty", nil)
+	}
+
+	if ttl <= 0 {
+		ttl = iss.opts.defaultTTL
+	}
+
+	id, err := generateID()
+	if err != nil {
+		return nil, core.NewError("credential.issue", core.ErrAuth, "failed to generate credential ID", err)
+	}
+
+	now := time.Now()
+	cred := &AgentCredential{
+		ID:          id,
+		AgentID:     agentID,
+		Permissions: append([]string{}, permissions...), // defensive copy
+		IssuedAt:    now,
+		ExpiresAt:   now.Add(ttl),
+		Metadata:    make(map[string]string),
+	}
+
+	iss.mu.Lock()
+	defer iss.mu.Unlock()
+
+	if len(iss.store) >= iss.opts.maxCredentials {
+		return nil, core.NewError("credential.issue", core.ErrBudgetExhausted, "credential store is full", nil)
+	}
+
+	iss.store[id] = cred
+	return cred, nil
+}
+
+// Revoke marks a credential as revoked. Returns an error if the credential
+// does not exist.
+func (iss *InMemoryIssuer) Revoke(_ context.Context, credentialID string) error {
+	iss.mu.Lock()
+	defer iss.mu.Unlock()
+
+	cred, ok := iss.store[credentialID]
+	if !ok {
+		return core.NewError("credential.revoke", core.ErrNotFound, "credential not found", nil)
+	}
+	cred.Revoked = true
+	return nil
+}
+
+// Get retrieves a credential by its ID. Returns a core.ErrNotFound error if
+// the credential does not exist.
+func (iss *InMemoryIssuer) Get(_ context.Context, credentialID string) (*AgentCredential, error) {
+	iss.mu.RLock()
+	defer iss.mu.RUnlock()
+
+	cred, ok := iss.store[credentialID]
+	if !ok {
+		return nil, core.NewError("credential.get", core.ErrNotFound, "credential not found", nil)
+	}
+	return cred, nil
+}
+
+// Expired returns all expired or revoked credentials. This is used by
+// AutoRevoker to find credentials that need cleanup.
+func (iss *InMemoryIssuer) Expired() []*AgentCredential {
+	iss.mu.RLock()
+	defer iss.mu.RUnlock()
+
+	var result []*AgentCredential
+	for _, cred := range iss.store {
+		if cred.IsExpired() && !cred.Revoked {
+			result = append(result, cred)
+		}
+	}
+	return result
+}
+
+// generateID produces a cryptographically random credential ID.
+func generateID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return "cred-" + hex.EncodeToString(b), nil
+}
+
+// Count returns the number of stored credentials. This is primarily useful
+// for testing.
+func (iss *InMemoryIssuer) Count() int {
+	iss.mu.RLock()
+	defer iss.mu.RUnlock()
+	return len(iss.store)
+}
+
+// DefaultTTL returns the issuer's default time-to-live for credentials.
+func (iss *InMemoryIssuer) DefaultTTL() time.Duration {
+	return iss.opts.defaultTTL
+}
+
+// String returns a human-readable summary of the issuer.
+func (iss *InMemoryIssuer) String() string {
+	iss.mu.RLock()
+	defer iss.mu.RUnlock()
+	return fmt.Sprintf("InMemoryIssuer(count=%d, max=%d, ttl=%s)", len(iss.store), iss.opts.maxCredentials, iss.opts.defaultTTL)
+}

--- a/auth/credential/issuer.go
+++ b/auth/credential/issuer.go
@@ -114,7 +114,27 @@ func (iss *InMemoryIssuer) Issue(_ context.Context, agentID string, permissions 
 	}
 
 	iss.store[id] = cred
-	return cred, nil
+	return cloneCredential(cred), nil
+}
+
+// cloneCredential returns a deep copy of a credential so that callers cannot
+// mutate the issuer's internal state (and so concurrent reads on the returned
+// value do not race with the issuer's own writes under its mutex).
+func cloneCredential(c *AgentCredential) *AgentCredential {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	if len(c.Permissions) > 0 {
+		cp.Permissions = append([]string{}, c.Permissions...)
+	}
+	if len(c.Metadata) > 0 {
+		cp.Metadata = make(map[string]string, len(c.Metadata))
+		for k, v := range c.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return &cp
 }
 
 // Revoke marks a credential as revoked. Returns an error if the credential
@@ -141,11 +161,12 @@ func (iss *InMemoryIssuer) Get(_ context.Context, credentialID string) (*AgentCr
 	if !ok {
 		return nil, core.NewError("credential.get", core.ErrNotFound, "credential not found", nil)
 	}
-	return cred, nil
+	return cloneCredential(cred), nil
 }
 
-// Expired returns all expired or revoked credentials. This is used by
-// AutoRevoker to find credentials that need cleanup.
+// Expired returns credentials that have passed their expiry time but have not
+// yet been revoked. This is used by AutoRevoker to find credentials that need
+// automatic revocation. Returned credentials are deep copies.
 func (iss *InMemoryIssuer) Expired() []*AgentCredential {
 	iss.mu.RLock()
 	defer iss.mu.RUnlock()
@@ -153,10 +174,28 @@ func (iss *InMemoryIssuer) Expired() []*AgentCredential {
 	var result []*AgentCredential
 	for _, cred := range iss.store {
 		if cred.IsExpired() && !cred.Revoked {
-			result = append(result, cred)
+			result = append(result, cloneCredential(cred))
 		}
 	}
 	return result
+}
+
+// Cleanup removes credentials that are both expired and revoked from the
+// store. This prevents unbounded growth that would otherwise cause the
+// capacity check in Issue() to fail permanently. Returns the number of
+// credentials removed.
+func (iss *InMemoryIssuer) Cleanup(_ context.Context) int {
+	iss.mu.Lock()
+	defer iss.mu.Unlock()
+
+	removed := 0
+	for id, cred := range iss.store {
+		if cred.Revoked && cred.IsExpired() {
+			delete(iss.store, id)
+			removed++
+		}
+	}
+	return removed
 }
 
 // generateID produces a cryptographically random credential ID.

--- a/auth/credential/jit.go
+++ b/auth/credential/jit.go
@@ -1,0 +1,97 @@
+package credential
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// PermissionNarrower is a function that narrows a set of requested permissions
+// to the minimum required set. It returns the narrowed permissions and an error
+// if the requested permissions are not allowed.
+type PermissionNarrower func(agentID string, requested []string) ([]string, error)
+
+// jitOptions holds configuration for JITProvider.
+type jitOptions struct {
+	ttl      time.Duration
+	narrower PermissionNarrower
+}
+
+// JITOption configures a JITProvider.
+type JITOption func(*jitOptions)
+
+// WithJITTTL sets the time-to-live for JIT-issued credentials.
+// Defaults to 2 minutes.
+func WithJITTTL(d time.Duration) JITOption {
+	return func(o *jitOptions) { o.ttl = d }
+}
+
+// WithPermissionNarrowing sets a function that narrows requested permissions
+// to the minimum required set. If not set, all requested permissions are
+// granted as-is.
+func WithPermissionNarrowing(fn PermissionNarrower) JITOption {
+	return func(o *jitOptions) { o.narrower = fn }
+}
+
+func defaultJITOptions() jitOptions {
+	return jitOptions{
+		ttl: 2 * time.Minute,
+	}
+}
+
+// JITProvider issues just-in-time credentials with minimal TTL scoped to
+// only the permissions required for an immediate operation.
+type JITProvider struct {
+	issuer CredentialIssuer
+	opts   jitOptions
+}
+
+// NewJITProvider creates a new JITProvider backed by the given issuer.
+func NewJITProvider(issuer CredentialIssuer, opts ...JITOption) *JITProvider {
+	o := defaultJITOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &JITProvider{
+		issuer: issuer,
+		opts:   o,
+	}
+}
+
+// Issue creates a JIT credential for the agent with the requested permissions.
+// If a PermissionNarrower is configured, the requested permissions are narrowed
+// before issuance.
+func (p *JITProvider) Issue(ctx context.Context, agentID string, requested []string) (*AgentCredential, error) {
+	if agentID == "" {
+		return nil, core.NewError("credential.jit.issue", core.ErrInvalidInput, "agent ID must not be empty", nil)
+	}
+	if len(requested) == 0 {
+		return nil, core.NewError("credential.jit.issue", core.ErrInvalidInput, "requested permissions must not be empty", nil)
+	}
+
+	permissions := requested
+	if p.opts.narrower != nil {
+		narrowed, err := p.opts.narrower(agentID, requested)
+		if err != nil {
+			return nil, core.NewError("credential.jit.issue", core.ErrAuth, "permission narrowing failed", err)
+		}
+		if len(narrowed) == 0 {
+			return nil, core.NewError("credential.jit.issue", core.ErrAuth, "all requested permissions were denied", nil)
+		}
+		permissions = narrowed
+	}
+
+	cred, err := p.issuer.Issue(ctx, agentID, permissions, p.opts.ttl)
+	if err != nil {
+		return nil, fmt.Errorf("credential.jit.issue: %w", err)
+	}
+
+	if cred.Metadata == nil {
+		cred.Metadata = make(map[string]string)
+	}
+	cred.Metadata["issued_by"] = "jit"
+
+	return cred, nil
+}

--- a/auth/credential/middleware.go
+++ b/auth/credential/middleware.go
@@ -1,0 +1,58 @@
+package credential
+
+import (
+	"context"
+
+	"github.com/lookatitude/beluga-ai/auth"
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// CredentialMiddleware returns an auth.Middleware that enforces credential-based
+// authorization. It extracts the credential from the context, validates that it
+// is not expired or revoked, and checks that it contains the requested
+// permission. If any check fails, authorization is denied.
+func CredentialMiddleware() auth.Middleware {
+	return func(next auth.Policy) auth.Policy {
+		return &credentialPolicy{next: next}
+	}
+}
+
+// credentialPolicy wraps an auth.Policy with credential enforcement.
+type credentialPolicy struct {
+	next auth.Policy
+}
+
+// Compile-time check that credentialPolicy implements auth.Policy.
+var _ auth.Policy = (*credentialPolicy)(nil)
+
+// Name returns the name of the wrapped policy.
+func (p *credentialPolicy) Name() string { return p.next.Name() }
+
+// Authorize checks the credential from context before delegating to the
+// wrapped policy. If no credential is present, it delegates directly to the
+// wrapped policy (allowing non-credential-based authorization to pass through).
+// If a credential is present but invalid or missing the required permission,
+// authorization is denied.
+func (p *credentialPolicy) Authorize(ctx context.Context, subject string, permission auth.Permission, resource string) (bool, error) {
+	cred := CredentialFromContext(ctx)
+	if cred == nil {
+		// No credential in context; delegate to underlying policy.
+		return p.next.Authorize(ctx, subject, permission, resource)
+	}
+
+	// Validate the credential.
+	if cred.Revoked {
+		return false, core.NewError("credential.middleware", core.ErrAuth, "credential has been revoked", nil)
+	}
+	if cred.IsExpired() {
+		return false, core.NewError("credential.middleware", core.ErrAuth, "credential has expired", nil)
+	}
+
+	// Check that the credential has the required permission.
+	if !cred.HasPermission(string(permission)) {
+		return false, nil // clean deny: credential lacks permission
+	}
+
+	// Credential is valid and has permission; delegate to underlying policy.
+	return p.next.Authorize(ctx, subject, permission, resource)
+}

--- a/auth/credential/revoker.go
+++ b/auth/credential/revoker.go
@@ -1,0 +1,182 @@
+package credential
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// RevokerHooks provides optional callbacks for auto-revocation events.
+// All fields are optional; nil hooks are skipped.
+type RevokerHooks struct {
+	// OnRevoke is called after a credential is automatically revoked.
+	OnRevoke func(ctx context.Context, cred *AgentCredential)
+
+	// OnScanComplete is called after each scan cycle with the number of
+	// credentials revoked.
+	OnScanComplete func(ctx context.Context, revoked int)
+
+	// OnError is called when a revocation fails.
+	OnError func(ctx context.Context, credID string, err error)
+}
+
+// revokerOptions holds configuration for AutoRevoker.
+type revokerOptions struct {
+	scanInterval time.Duration
+	hooks        RevokerHooks
+	logger       *slog.Logger
+}
+
+// RevokerOption configures an AutoRevoker.
+type RevokerOption func(*revokerOptions)
+
+// WithScanInterval sets how often the revoker scans for expired credentials.
+// Defaults to 30 seconds.
+func WithScanInterval(d time.Duration) RevokerOption {
+	return func(o *revokerOptions) { o.scanInterval = d }
+}
+
+// WithRevokerHooks sets the hooks for the auto-revoker.
+func WithRevokerHooks(h RevokerHooks) RevokerOption {
+	return func(o *revokerOptions) { o.hooks = h }
+}
+
+// WithRevokerLogger sets the logger for the auto-revoker.
+func WithRevokerLogger(l *slog.Logger) RevokerOption {
+	return func(o *revokerOptions) { o.logger = l }
+}
+
+func defaultRevokerOptions() revokerOptions {
+	return revokerOptions{
+		scanInterval: 30 * time.Second,
+		logger:       slog.Default(),
+	}
+}
+
+// AutoRevoker implements core.Lifecycle and runs a background goroutine that
+// periodically scans for expired credentials and revokes them.
+type AutoRevoker struct {
+	issuer *InMemoryIssuer
+	opts   revokerOptions
+
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	running bool
+}
+
+// Compile-time check that AutoRevoker implements core.Lifecycle.
+var _ core.Lifecycle = (*AutoRevoker)(nil)
+
+// NewAutoRevoker creates a new AutoRevoker that scans the given issuer.
+func NewAutoRevoker(issuer *InMemoryIssuer, opts ...RevokerOption) *AutoRevoker {
+	o := defaultRevokerOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &AutoRevoker{
+		issuer: issuer,
+		opts:   o,
+	}
+}
+
+// Start begins the background scan loop. It blocks until the revoker is ready.
+func (r *AutoRevoker) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.running {
+		return core.NewError("credential.revoker.start", core.ErrInvalidInput, "already running", nil)
+	}
+
+	scanCtx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	r.done = make(chan struct{})
+	r.running = true
+
+	go r.loop(scanCtx)
+
+	return nil
+}
+
+// Stop gracefully shuts down the background scan loop.
+func (r *AutoRevoker) Stop(_ context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.running {
+		return nil
+	}
+
+	r.cancel()
+	<-r.done
+	r.running = false
+	return nil
+}
+
+// Health returns the current health status of the revoker.
+func (r *AutoRevoker) Health() core.HealthStatus {
+	r.mu.Lock()
+	running := r.running
+	r.mu.Unlock()
+
+	if running {
+		return core.HealthStatus{
+			Status:    core.HealthHealthy,
+			Message:   "auto-revoker is running",
+			Timestamp: time.Now(),
+		}
+	}
+	return core.HealthStatus{
+		Status:    core.HealthUnhealthy,
+		Message:   "auto-revoker is not running",
+		Timestamp: time.Now(),
+	}
+}
+
+// loop runs the periodic scan until ctx is cancelled.
+func (r *AutoRevoker) loop(ctx context.Context) {
+	defer close(r.done)
+
+	ticker := time.NewTicker(r.opts.scanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.scan(ctx)
+		}
+	}
+}
+
+// scan finds expired credentials and revokes them.
+func (r *AutoRevoker) scan(ctx context.Context) {
+	expired := r.issuer.Expired()
+	revoked := 0
+
+	for _, cred := range expired {
+		if err := r.issuer.Revoke(ctx, cred.ID); err != nil {
+			if r.opts.hooks.OnError != nil {
+				r.opts.hooks.OnError(ctx, cred.ID, err)
+			}
+			r.opts.logger.ErrorContext(ctx, "credential.revoker.scan.error",
+				"credential_id", cred.ID,
+				"error", err,
+			)
+			continue
+		}
+		revoked++
+		if r.opts.hooks.OnRevoke != nil {
+			r.opts.hooks.OnRevoke(ctx, cred)
+		}
+	}
+
+	if r.opts.hooks.OnScanComplete != nil {
+		r.opts.hooks.OnScanComplete(ctx, revoked)
+	}
+}

--- a/auth/credential/revoker.go
+++ b/auth/credential/revoker.go
@@ -83,7 +83,10 @@ func NewAutoRevoker(issuer *InMemoryIssuer, opts ...RevokerOption) *AutoRevoker 
 	}
 }
 
-// Start begins the background scan loop. It blocks until the revoker is ready.
+// Start begins the background scan loop. It returns once the loop has been
+// launched. The caller's context is propagated to the background loop so
+// tracing, tenant IDs, and deadlines survive; a locally-derived cancellation
+// is still used so Stop() can terminate the loop independently.
 func (r *AutoRevoker) Start(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -91,8 +94,11 @@ func (r *AutoRevoker) Start(ctx context.Context) error {
 	if r.running {
 		return core.NewError("credential.revoker.start", core.ErrInvalidInput, "already running", nil)
 	}
+	if err := ctx.Err(); err != nil {
+		return core.NewError("credential.revoker.start", core.ErrInvalidInput, "caller context already cancelled", err)
+	}
 
-	scanCtx, cancel := context.WithCancel(context.Background())
+	scanCtx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
 	r.done = make(chan struct{})
 	r.running = true
@@ -102,18 +108,22 @@ func (r *AutoRevoker) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop gracefully shuts down the background scan loop.
+// Stop gracefully shuts down the background scan loop. The mutex is released
+// before blocking on the loop's done channel to avoid deadlocking with hooks
+// that call back into the revoker (e.g. Health()).
 func (r *AutoRevoker) Stop(_ context.Context) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	if !r.running {
+		r.mu.Unlock()
 		return nil
 	}
-
-	r.cancel()
-	<-r.done
+	cancel := r.cancel
+	done := r.done
 	r.running = false
+	r.mu.Unlock()
+
+	cancel()
+	<-done
 	return nil
 }
 
@@ -175,6 +185,10 @@ func (r *AutoRevoker) scan(ctx context.Context) {
 			r.opts.hooks.OnRevoke(ctx, cred)
 		}
 	}
+
+	// Purge fully-handled (revoked + expired) credentials so the issuer
+	// does not exhaust its bounded capacity.
+	r.issuer.Cleanup(ctx)
 
 	if r.opts.hooks.OnScanComplete != nil {
 		r.opts.hooks.OnScanComplete(ctx, revoked)


### PR DESCRIPTION
## Summary
- auth/credential package, AgentCredential with TTL, AutoRevoker (core.Lifecycle), JITProvider, CredentialMiddleware

## Linear
- LOO-34: https://linear.app/lookatitude/issue/LOO-34

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)