### PR TITLE
LOO-36: Graceful Degradation Under Security Events

### DIFF
--- a/guard/degradation/degradation_test.go
+++ b/guard/degradation/degradation_test.go
@@ -1,0 +1,589 @@
+package degradation
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/tool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Level tests
+// ---------------------------------------------------------------------------
+
+func TestAutonomyLevel_String(t *testing.T) {
+	tests := []struct {
+		level AutonomyLevel
+		want  string
+	}{
+		{Full, "full"},
+		{Restricted, "restricted"},
+		{ReadOnly, "read_only"},
+		{Sequestered, "sequestered"},
+		{AutonomyLevel(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.level.String())
+		})
+	}
+}
+
+func TestLevelCapabilities(t *testing.T) {
+	tests := []struct {
+		level AutonomyLevel
+		want  Capabilities
+	}{
+		{
+			level: Full,
+			want: Capabilities{
+				CanExecuteTools:  true,
+				ToolsAllowlisted: false,
+				CanWrite:         true,
+				CanRespond:       true,
+			},
+		},
+		{
+			level: Restricted,
+			want: Capabilities{
+				CanExecuteTools:  true,
+				ToolsAllowlisted: true,
+				CanWrite:         true,
+				CanRespond:       true,
+			},
+		},
+		{
+			level: ReadOnly,
+			want: Capabilities{
+				CanExecuteTools:  false,
+				ToolsAllowlisted: false,
+				CanWrite:         false,
+				CanRespond:       true,
+			},
+		},
+		{
+			level: Sequestered,
+			want: Capabilities{
+				CanExecuteTools:  false,
+				ToolsAllowlisted: false,
+				CanWrite:         false,
+				CanRespond:       false,
+			},
+		},
+		{
+			level: AutonomyLevel(99),
+			want: Capabilities{
+				CanExecuteTools:  false,
+				ToolsAllowlisted: false,
+				CanWrite:         false,
+				CanRespond:       false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.level.String(), func(t *testing.T) {
+			assert.Equal(t, tt.want, LevelCapabilities(tt.level))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Monitor tests
+// ---------------------------------------------------------------------------
+
+func TestSecurityMonitor_RecordEvent_ClampsSeverity(t *testing.T) {
+	now := time.Now()
+	m := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+
+	ctx := context.Background()
+	m.RecordEvent(ctx, SecurityEvent{Type: EventGuardBlocked, Severity: -0.5, Timestamp: now})
+	m.RecordEvent(ctx, SecurityEvent{Type: EventGuardBlocked, Severity: 2.0, Timestamp: now})
+
+	// Both events should be clamped; max possible is 1.0.
+	sev := m.CurrentSeverity()
+	assert.LessOrEqual(t, sev, 1.0)
+	assert.GreaterOrEqual(t, sev, 0.0)
+}
+
+func TestSecurityMonitor_CurrentSeverity_Empty(t *testing.T) {
+	m := NewSecurityMonitor()
+	assert.Equal(t, 0.0, m.CurrentSeverity())
+}
+
+func TestSecurityMonitor_CurrentSeverity_Decay(t *testing.T) {
+	window := 10 * time.Second
+	now := time.Now()
+	m := NewSecurityMonitor(
+		WithWindowSize(window),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	// Event at the start of the window (full decay).
+	m.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventGuardBlocked,
+		Severity:  0.5,
+		Timestamp: now.Add(-9 * time.Second), // 9s ago, weight ~0.1
+	})
+
+	sev := m.CurrentSeverity()
+	// With linear decay, 9s into a 10s window gives weight 0.1.
+	assert.InDelta(t, 0.05, sev, 0.01)
+}
+
+func TestSecurityMonitor_CurrentSeverity_RecentEvent(t *testing.T) {
+	now := time.Now()
+	m := NewSecurityMonitor(
+		WithWindowSize(10*time.Second),
+		withNowFunc(func() time.Time { return now }),
+	)
+
+	// Very recent event should have weight close to 1.0.
+	m.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventInjectionDetected,
+		Severity:  0.8,
+		Timestamp: now,
+	})
+
+	sev := m.CurrentSeverity()
+	assert.InDelta(t, 0.8, sev, 0.01)
+}
+
+func TestSecurityMonitor_EventsExpire(t *testing.T) {
+	window := 1 * time.Second
+	currentTime := time.Now()
+	m := NewSecurityMonitor(
+		WithWindowSize(window),
+		withNowFunc(func() time.Time { return currentTime }),
+	)
+
+	m.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventGuardBlocked,
+		Severity:  0.9,
+		Timestamp: currentTime,
+	})
+	assert.Equal(t, 1, m.EventCount())
+
+	// Advance time past the window.
+	currentTime = currentTime.Add(2 * time.Second)
+	assert.Equal(t, 0, m.EventCount())
+	assert.Equal(t, 0.0, m.CurrentSeverity())
+}
+
+func TestSecurityMonitor_Reset(t *testing.T) {
+	m := NewSecurityMonitor()
+	m.RecordEvent(context.Background(), SecurityEvent{
+		Type: EventToolAbuse, Severity: 0.5, Timestamp: time.Now(),
+	})
+	assert.Equal(t, 1, m.EventCount())
+
+	m.Reset()
+	assert.Equal(t, 0, m.EventCount())
+	assert.Equal(t, 0.0, m.CurrentSeverity())
+}
+
+func TestSecurityMonitor_DefaultTimestamp(t *testing.T) {
+	now := time.Now()
+	m := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	m.RecordEvent(context.Background(), SecurityEvent{
+		Type:     EventCustom,
+		Severity: 0.3,
+		// Timestamp left zero; should be set to now.
+	})
+	assert.Equal(t, 1, m.EventCount())
+	sev := m.CurrentSeverity()
+	assert.InDelta(t, 0.3, sev, 0.01)
+}
+
+func TestSecurityMonitor_ConcurrentAccess(t *testing.T) {
+	m := NewSecurityMonitor(WithWindowSize(5 * time.Second))
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.RecordEvent(ctx, SecurityEvent{
+				Type:     EventGuardBlocked,
+				Severity: 0.1,
+			})
+			_ = m.CurrentSeverity()
+			_ = m.EventCount()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 100, m.EventCount())
+}
+
+// ---------------------------------------------------------------------------
+// Policy tests
+// ---------------------------------------------------------------------------
+
+func TestThresholdPolicy_Evaluate(t *testing.T) {
+	p := NewThresholdPolicy()
+
+	tests := []struct {
+		severity float64
+		want     AutonomyLevel
+	}{
+		{0.0, Full},
+		{0.1, Full},
+		{0.29, Full},
+		{0.3, Restricted},
+		{0.5, Restricted},
+		{0.59, Restricted},
+		{0.6, ReadOnly},
+		{0.7, ReadOnly},
+		{0.84, ReadOnly},
+		{0.85, Sequestered},
+		{1.0, Sequestered},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("severity_%.2f", tt.severity), func(t *testing.T) {
+			assert.Equal(t, tt.want, p.Evaluate(tt.severity))
+		})
+	}
+}
+
+func TestThresholdPolicy_CustomThresholds(t *testing.T) {
+	p := NewThresholdPolicy(WithLevelThresholds(LevelThresholds{
+		Restricted:  0.1,
+		ReadOnly:    0.5,
+		Sequestered: 0.9,
+	}))
+
+	assert.Equal(t, Full, p.Evaluate(0.05))
+	assert.Equal(t, Restricted, p.Evaluate(0.1))
+	assert.Equal(t, ReadOnly, p.Evaluate(0.5))
+	assert.Equal(t, Sequestered, p.Evaluate(0.9))
+}
+
+// ---------------------------------------------------------------------------
+// Hooks tests
+// ---------------------------------------------------------------------------
+
+func TestComposeHooks_NilFields(t *testing.T) {
+	composed := ComposeHooks(Hooks{}, Hooks{})
+	assert.Nil(t, composed.OnLevelChanged)
+	assert.Nil(t, composed.OnAnomalyDetected)
+	assert.Nil(t, composed.OnRecovery)
+}
+
+func TestComposeHooks_CallsAll(t *testing.T) {
+	var calls []string
+
+	h1 := Hooks{
+		OnLevelChanged: func(_ context.Context, _, _ AutonomyLevel) {
+			calls = append(calls, "h1-level")
+		},
+		OnAnomalyDetected: func(_ context.Context, _ SecurityEvent) {
+			calls = append(calls, "h1-anomaly")
+		},
+	}
+	h2 := Hooks{
+		OnLevelChanged: func(_ context.Context, _, _ AutonomyLevel) {
+			calls = append(calls, "h2-level")
+		},
+		OnRecovery: func(_ context.Context, _, _ AutonomyLevel) {
+			calls = append(calls, "h2-recovery")
+		},
+	}
+
+	composed := ComposeHooks(h1, h2)
+
+	composed.OnLevelChanged(context.Background(), Full, Restricted)
+	assert.Equal(t, []string{"h1-level", "h2-level"}, calls)
+
+	calls = nil
+	composed.OnAnomalyDetected(context.Background(), SecurityEvent{})
+	assert.Equal(t, []string{"h1-anomaly"}, calls)
+
+	calls = nil
+	composed.OnRecovery(context.Background(), Restricted, Full)
+	assert.Equal(t, []string{"h2-recovery"}, calls)
+}
+
+// ---------------------------------------------------------------------------
+// Degrader tests
+// ---------------------------------------------------------------------------
+
+// mockAgent is a minimal agent.Agent implementation for testing.
+type mockAgent struct {
+	id        string
+	tools     []tool.Tool
+	invokeRes string
+	invokeErr error
+	streamFn  func(ctx context.Context, input string) iter.Seq2[agent.Event, error]
+}
+
+func (m *mockAgent) ID() string              { return m.id }
+func (m *mockAgent) Persona() agent.Persona  { return agent.Persona{} }
+func (m *mockAgent) Tools() []tool.Tool      { return m.tools }
+func (m *mockAgent) Children() []agent.Agent { return nil }
+func (m *mockAgent) Invoke(ctx context.Context, input string, _ ...agent.Option) (string, error) {
+	return m.invokeRes, m.invokeErr
+}
+func (m *mockAgent) Stream(ctx context.Context, input string, _ ...agent.Option) iter.Seq2[agent.Event, error] {
+	if m.streamFn != nil {
+		return m.streamFn(ctx, input)
+	}
+	return func(yield func(agent.Event, error) bool) {
+		yield(agent.Event{Type: agent.EventText, Text: "hello"}, nil)
+	}
+}
+
+var _ agent.Agent = (*mockAgent)(nil)
+
+// mockTool is a minimal tool.Tool for testing.
+type mockTool struct {
+	name string
+}
+
+func (t *mockTool) Name() string                { return t.name }
+func (t *mockTool) Description() string         { return "" }
+func (t *mockTool) InputSchema() map[string]any { return nil }
+func (t *mockTool) Execute(_ context.Context, _ map[string]any) (*tool.Result, error) {
+	return tool.TextResult("ok"), nil
+}
+
+var _ tool.Tool = (*mockTool)(nil)
+
+func TestDegrader_FullLevel_AllToolsAvailable(t *testing.T) {
+	monitor := NewSecurityMonitor()
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy,
+		WithToolAllowlist("search"),
+	)
+
+	inner := &mockAgent{
+		id:        "test-agent",
+		tools:     []tool.Tool{&mockTool{name: "search"}, &mockTool{name: "write"}},
+		invokeRes: "response",
+	}
+
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+	tools := wrapped.Tools()
+	assert.Len(t, tools, 2)
+
+	result, err := wrapped.Invoke(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "response", result)
+}
+
+func TestDegrader_RestrictedLevel_FilteredTools(t *testing.T) {
+	now := time.Now()
+	monitor := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy,
+		WithToolAllowlist("search"),
+	)
+
+	// Push severity into Restricted range (0.3-0.6).
+	monitor.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventGuardBlocked,
+		Severity:  0.4,
+		Timestamp: now,
+	})
+
+	inner := &mockAgent{
+		id:    "test-agent",
+		tools: []tool.Tool{&mockTool{name: "search"}, &mockTool{name: "write"}},
+	}
+
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+	tools := wrapped.Tools()
+	require.Len(t, tools, 1)
+	assert.Equal(t, "search", tools[0].Name())
+}
+
+func TestDegrader_ReadOnlyLevel_NoTools(t *testing.T) {
+	now := time.Now()
+	monitor := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy)
+
+	// Push severity into ReadOnly range (0.6-0.85).
+	monitor.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventInjectionDetected,
+		Severity:  0.7,
+		Timestamp: now,
+	})
+
+	inner := &mockAgent{
+		id:        "test-agent",
+		tools:     []tool.Tool{&mockTool{name: "search"}},
+		invokeRes: "still responds",
+	}
+
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+	assert.Empty(t, wrapped.Tools())
+
+	// Can still invoke (respond).
+	result, err := wrapped.Invoke(context.Background(), "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "still responds", result)
+}
+
+func TestDegrader_SequesteredLevel_BlocksInvoke(t *testing.T) {
+	now := time.Now()
+	monitor := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy)
+
+	// Push severity into Sequestered range (>= 0.85).
+	monitor.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventInjectionDetected,
+		Severity:  0.95,
+		Timestamp: now,
+	})
+
+	inner := &mockAgent{id: "test-agent", invokeRes: "should not see this"}
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+
+	_, err := wrapped.Invoke(context.Background(), "hello")
+	require.Error(t, err)
+
+	var coreErr *core.Error
+	require.ErrorAs(t, err, &coreErr)
+	assert.Equal(t, core.ErrGuardBlocked, coreErr.Code)
+}
+
+func TestDegrader_SequesteredLevel_BlocksStream(t *testing.T) {
+	now := time.Now()
+	monitor := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy)
+
+	monitor.RecordEvent(context.Background(), SecurityEvent{
+		Type:      EventToolAbuse,
+		Severity:  0.95,
+		Timestamp: now,
+	})
+
+	inner := &mockAgent{id: "test-agent"}
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+
+	var gotErr error
+	for _, err := range wrapped.Stream(context.Background(), "hello") {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+	require.Error(t, gotErr)
+
+	var coreErr *core.Error
+	require.ErrorAs(t, gotErr, &coreErr)
+	assert.Equal(t, core.ErrGuardBlocked, coreErr.Code)
+}
+
+func TestDegrader_Recovery(t *testing.T) {
+	currentTime := time.Now()
+	monitor := NewSecurityMonitor(
+		WithWindowSize(1*time.Second),
+		withNowFunc(func() time.Time { return currentTime }),
+	)
+	policy := NewThresholdPolicy()
+
+	var transitions []string
+	degrader := NewRuntimeDegrader(monitor, policy,
+		WithHooks(Hooks{
+			OnLevelChanged: func(_ context.Context, prev, next AutonomyLevel) {
+				transitions = append(transitions, fmt.Sprintf("%s->%s", prev, next))
+			},
+			OnRecovery: func(_ context.Context, prev, next AutonomyLevel) {
+				transitions = append(transitions, fmt.Sprintf("recovery:%s->%s", prev, next))
+			},
+		}),
+	)
+
+	ctx := context.Background()
+
+	// Push to Sequestered.
+	monitor.RecordEvent(ctx, SecurityEvent{
+		Type:      EventInjectionDetected,
+		Severity:  0.95,
+		Timestamp: currentTime,
+	})
+	level := degrader.Evaluate(ctx)
+	assert.Equal(t, Sequestered, level)
+
+	// Advance time past the window so events expire.
+	currentTime = currentTime.Add(2 * time.Second)
+	level = degrader.Evaluate(ctx)
+	assert.Equal(t, Full, level)
+
+	// Verify hooks fired.
+	require.Len(t, transitions, 3)
+	assert.Equal(t, "full->sequestered", transitions[0])
+	assert.Equal(t, "sequestered->full", transitions[1])
+	assert.Equal(t, "recovery:sequestered->full", transitions[2])
+}
+
+func TestDegrader_LevelTransition_HooksFireCorrectly(t *testing.T) {
+	now := time.Now()
+	monitor := NewSecurityMonitor(withNowFunc(func() time.Time { return now }))
+	policy := NewThresholdPolicy()
+
+	var levelChanges []AutonomyLevel
+	degrader := NewRuntimeDegrader(monitor, policy,
+		WithHooks(Hooks{
+			OnLevelChanged: func(_ context.Context, _, next AutonomyLevel) {
+				levelChanges = append(levelChanges, next)
+			},
+		}),
+	)
+
+	ctx := context.Background()
+
+	// Start at Full, push to Restricted.
+	monitor.RecordEvent(ctx, SecurityEvent{
+		Type: EventGuardBlocked, Severity: 0.35, Timestamp: now,
+	})
+	degrader.Evaluate(ctx)
+	require.Len(t, levelChanges, 1)
+	assert.Equal(t, Restricted, levelChanges[0])
+
+	// Evaluate again at same severity - no additional hook call.
+	degrader.Evaluate(ctx)
+	assert.Len(t, levelChanges, 1)
+}
+
+func TestDegrader_ConcurrentEvaluate(t *testing.T) {
+	monitor := NewSecurityMonitor()
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = degrader.Evaluate(context.Background())
+			_ = degrader.CurrentLevel()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestDegrader_IDAndPersonaDelegation(t *testing.T) {
+	monitor := NewSecurityMonitor()
+	policy := NewThresholdPolicy()
+	degrader := NewRuntimeDegrader(monitor, policy)
+
+	inner := &mockAgent{id: "my-agent"}
+	wrapped := agent.ApplyMiddleware(inner, degrader.Middleware())
+
+	assert.Equal(t, "my-agent", wrapped.ID())
+	assert.Equal(t, agent.Persona{}, wrapped.Persona())
+	assert.Nil(t, wrapped.Children())
+}

--- a/guard/degradation/degrader.go
+++ b/guard/degradation/degrader.go
@@ -1,0 +1,218 @@
+package degradation
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// RuntimeDegrader enforces autonomy level restrictions on agent execution.
+// It queries a SecurityMonitor for severity, evaluates a DegradationPolicy,
+// and applies the resulting autonomy level as constraints on the wrapped
+// agent. RuntimeDegrader is safe for concurrent use.
+type RuntimeDegrader struct {
+	monitor   *SecurityMonitor
+	policy    DegradationPolicy
+	hooks     Hooks
+	allowlist map[string]bool
+	logger    *slog.Logger
+
+	mu    sync.RWMutex
+	level AutonomyLevel
+}
+
+// degraderOptions holds configuration for RuntimeDegrader.
+type degraderOptions struct {
+	hooks     Hooks
+	allowlist []string
+	logger    *slog.Logger
+}
+
+// DegraderOption configures a RuntimeDegrader.
+type DegraderOption func(*degraderOptions)
+
+// WithToolAllowlist sets the tools permitted in Restricted mode.
+func WithToolAllowlist(tools ...string) DegraderOption {
+	return func(o *degraderOptions) {
+		o.allowlist = tools
+	}
+}
+
+// WithHooks sets lifecycle hooks on the RuntimeDegrader.
+func WithHooks(h Hooks) DegraderOption {
+	return func(o *degraderOptions) {
+		o.hooks = h
+	}
+}
+
+// WithLogger sets a structured logger for the RuntimeDegrader.
+func WithLogger(l *slog.Logger) DegraderOption {
+	return func(o *degraderOptions) {
+		o.logger = l
+	}
+}
+
+// NewRuntimeDegrader creates a RuntimeDegrader that uses the given monitor
+// and policy to determine and enforce autonomy levels.
+func NewRuntimeDegrader(monitor *SecurityMonitor, policy DegradationPolicy, opts ...DegraderOption) *RuntimeDegrader {
+	o := degraderOptions{
+		logger: slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	allowlist := make(map[string]bool, len(o.allowlist))
+	for _, name := range o.allowlist {
+		allowlist[name] = true
+	}
+
+	return &RuntimeDegrader{
+		monitor:   monitor,
+		policy:    policy,
+		hooks:     o.hooks,
+		allowlist: allowlist,
+		logger:    o.logger,
+		level:     Full,
+	}
+}
+
+// CurrentLevel returns the last evaluated autonomy level.
+func (d *RuntimeDegrader) CurrentLevel() AutonomyLevel {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.level
+}
+
+// Evaluate queries the monitor and policy, updates the current level, and
+// fires hooks if the level changed. It returns the new level.
+func (d *RuntimeDegrader) Evaluate(ctx context.Context) AutonomyLevel {
+	severity := d.monitor.CurrentSeverity()
+	newLevel := d.policy.Evaluate(severity)
+
+	d.mu.Lock()
+	prev := d.level
+	d.level = newLevel
+	d.mu.Unlock()
+
+	if prev != newLevel {
+		d.logger.InfoContext(ctx, "autonomy level changed",
+			"prev", prev.String(),
+			"next", newLevel.String(),
+			"severity", severity,
+		)
+		if d.hooks.OnLevelChanged != nil {
+			d.hooks.OnLevelChanged(ctx, prev, newLevel)
+		}
+		// Recovery: transitioning to a less restrictive level.
+		if newLevel < prev && d.hooks.OnRecovery != nil {
+			d.hooks.OnRecovery(ctx, prev, newLevel)
+		}
+	}
+
+	return newLevel
+}
+
+// Middleware returns an agent.Middleware that enforces the current autonomy
+// level on every Invoke and Stream call.
+func (d *RuntimeDegrader) Middleware() agent.Middleware {
+	return func(a agent.Agent) agent.Agent {
+		return &degradedAgent{
+			inner:    a,
+			degrader: d,
+		}
+	}
+}
+
+// degradedAgent wraps an Agent and applies autonomy level restrictions.
+type degradedAgent struct {
+	inner    agent.Agent
+	degrader *RuntimeDegrader
+}
+
+// Compile-time check that degradedAgent implements agent.Agent.
+var _ agent.Agent = (*degradedAgent)(nil)
+
+// ID delegates to the inner agent.
+func (a *degradedAgent) ID() string { return a.inner.ID() }
+
+// Persona delegates to the inner agent.
+func (a *degradedAgent) Persona() agent.Persona { return a.inner.Persona() }
+
+// Tools returns the tools available under the current autonomy level.
+func (a *degradedAgent) Tools() []tool.Tool {
+	level := a.degrader.Evaluate(context.Background())
+	caps := LevelCapabilities(level)
+
+	if !caps.CanExecuteTools {
+		return nil
+	}
+
+	innerTools := a.inner.Tools()
+	if !caps.ToolsAllowlisted {
+		return innerTools
+	}
+
+	// Filter to allowlisted tools only.
+	var filtered []tool.Tool
+	for _, t := range innerTools {
+		if a.degrader.allowlist[t.Name()] {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+// Children delegates to the inner agent.
+func (a *degradedAgent) Children() []agent.Agent { return a.inner.Children() }
+
+// Invoke executes the agent under the current autonomy level constraints.
+func (a *degradedAgent) Invoke(ctx context.Context, input string, opts ...agent.Option) (string, error) {
+	level := a.degrader.Evaluate(ctx)
+	caps := LevelCapabilities(level)
+
+	if !caps.CanRespond {
+		a.degrader.logger.WarnContext(ctx, "agent invoke blocked by sequestered level",
+			"agent", a.inner.ID(),
+			"level", level.String(),
+		)
+		return "", core.NewError(
+			"degradation.invoke",
+			core.ErrGuardBlocked,
+			fmt.Sprintf("agent %q is sequestered; invoke is not permitted", a.inner.ID()),
+			nil,
+		)
+	}
+
+	return a.inner.Invoke(ctx, input, opts...)
+}
+
+// Stream executes the agent in streaming mode under autonomy level
+// constraints.
+func (a *degradedAgent) Stream(ctx context.Context, input string, opts ...agent.Option) iter.Seq2[agent.Event, error] {
+	level := a.degrader.Evaluate(ctx)
+	caps := LevelCapabilities(level)
+
+	if !caps.CanRespond {
+		return func(yield func(agent.Event, error) bool) {
+			a.degrader.logger.WarnContext(ctx, "agent stream blocked by sequestered level",
+				"agent", a.inner.ID(),
+				"level", level.String(),
+			)
+			yield(agent.Event{}, core.NewError(
+				"degradation.stream",
+				core.ErrGuardBlocked,
+				fmt.Sprintf("agent %q is sequestered; streaming is not permitted", a.inner.ID()),
+				nil,
+			))
+		}
+	}
+
+	return a.inner.Stream(ctx, input, opts...)
+}

--- a/guard/degradation/degrader.go
+++ b/guard/degradation/degrader.go
@@ -90,6 +90,17 @@ func (d *RuntimeDegrader) CurrentLevel() AutonomyLevel {
 	return d.level
 }
 
+// RecordEvent forwards a security event to the underlying monitor and fires
+// the OnAnomalyDetected hook so SIEM and alerting integrations can observe
+// the event in real time. Callers that previously talked directly to the
+// monitor should prefer this wrapper so hooks are consistently delivered.
+func (d *RuntimeDegrader) RecordEvent(ctx context.Context, event SecurityEvent) {
+	d.monitor.RecordEvent(ctx, event)
+	if d.hooks.OnAnomalyDetected != nil {
+		d.hooks.OnAnomalyDetected(ctx, event)
+	}
+}
+
 // Evaluate queries the monitor and policy, updates the current level, and
 // fires hooks if the level changed. It returns the new level.
 func (d *RuntimeDegrader) Evaluate(ctx context.Context) AutonomyLevel {
@@ -146,6 +157,13 @@ func (a *degradedAgent) ID() string { return a.inner.ID() }
 func (a *degradedAgent) Persona() agent.Persona { return a.inner.Persona() }
 
 // Tools returns the tools available under the current autonomy level.
+//
+// agent.Agent.Tools() has no context parameter, so Evaluate is called with
+// context.Background() here. This means any OnLevelChanged / OnRecovery hooks
+// that fire inside Tools() receive an empty context: no tracing span, no
+// tenant ID, and no cancellation. Callers that need hooks with a populated
+// context should invoke RuntimeDegrader.Evaluate(ctx) directly with their
+// request context before calling Tools().
 func (a *degradedAgent) Tools() []tool.Tool {
 	level := a.degrader.Evaluate(context.Background())
 	caps := LevelCapabilities(level)

--- a/guard/degradation/doc.go
+++ b/guard/degradation/doc.go
@@ -1,0 +1,46 @@
+// Package degradation provides graceful degradation of agent autonomy in
+// response to security events. It monitors anomaly signals from the guard
+// pipeline, computes a severity score, and applies runtime restrictions to
+// agent capabilities based on configurable policies.
+//
+// # Autonomy Levels
+//
+// The package defines four autonomy levels that progressively restrict agent
+// capabilities:
+//
+//   - Full: All tools and capabilities are available. Normal operation.
+//   - Restricted: Only explicitly allowlisted tools may be executed.
+//   - ReadOnly: No tool calls or write operations are permitted.
+//   - Sequestered: The agent is fully isolated; all actions are logged but
+//     not executed.
+//
+// # Security Monitor
+//
+// SecurityMonitor tracks anomaly signals from guard events within a sliding
+// time window. Each recorded SecurityEvent contributes to an aggregate
+// severity score that decays as events age out of the window.
+//
+// # Degradation Policy
+//
+// DegradationPolicy maps severity scores to autonomy levels. The built-in
+// ThresholdPolicy uses configurable severity thresholds for each level
+// transition.
+//
+// # Runtime Degrader
+//
+// RuntimeDegrader is an agent.Middleware that intercepts agent invocations
+// and enforces the current autonomy level. It queries the SecurityMonitor
+// for the current severity, evaluates the DegradationPolicy, and applies
+// the appropriate restrictions before delegating to the wrapped agent.
+//
+// # Usage
+//
+//	monitor := degradation.NewSecurityMonitor(
+//	    degradation.WithWindowSize(5 * time.Minute),
+//	)
+//	policy := degradation.NewThresholdPolicy()
+//	degrader := degradation.NewRuntimeDegrader(monitor, policy,
+//	    degradation.WithToolAllowlist("search", "read_file"),
+//	)
+//	wrapped := agent.ApplyMiddleware(myAgent, degrader.Middleware())
+package degradation

--- a/guard/degradation/hooks.go
+++ b/guard/degradation/hooks.go
@@ -1,0 +1,80 @@
+package degradation
+
+import "context"
+
+// Hooks provides optional callbacks for degradation lifecycle events. All
+// fields are optional; nil fields are skipped during invocation.
+type Hooks struct {
+	// OnLevelChanged is called when the autonomy level transitions to a
+	// different value. It receives the previous and new levels.
+	OnLevelChanged func(ctx context.Context, prev, next AutonomyLevel)
+
+	// OnAnomalyDetected is called when a new security event is recorded by
+	// the monitor.
+	OnAnomalyDetected func(ctx context.Context, event SecurityEvent)
+
+	// OnRecovery is called when the autonomy level transitions from a more
+	// restrictive level back toward Full.
+	OnRecovery func(ctx context.Context, prev, next AutonomyLevel)
+}
+
+// ComposeHooks merges multiple Hooks into a single Hooks where each
+// callback invokes all non-nil callbacks from the input hooks in order.
+func ComposeHooks(hooks ...Hooks) Hooks {
+	return Hooks{
+		OnLevelChanged:    composeOnLevelChanged(hooks),
+		OnAnomalyDetected: composeOnAnomalyDetected(hooks),
+		OnRecovery:        composeOnRecovery(hooks),
+	}
+}
+
+func composeOnLevelChanged(hooks []Hooks) func(context.Context, AutonomyLevel, AutonomyLevel) {
+	var fns []func(context.Context, AutonomyLevel, AutonomyLevel)
+	for _, h := range hooks {
+		if h.OnLevelChanged != nil {
+			fns = append(fns, h.OnLevelChanged)
+		}
+	}
+	if len(fns) == 0 {
+		return nil
+	}
+	return func(ctx context.Context, prev, next AutonomyLevel) {
+		for _, fn := range fns {
+			fn(ctx, prev, next)
+		}
+	}
+}
+
+func composeOnAnomalyDetected(hooks []Hooks) func(context.Context, SecurityEvent) {
+	var fns []func(context.Context, SecurityEvent)
+	for _, h := range hooks {
+		if h.OnAnomalyDetected != nil {
+			fns = append(fns, h.OnAnomalyDetected)
+		}
+	}
+	if len(fns) == 0 {
+		return nil
+	}
+	return func(ctx context.Context, event SecurityEvent) {
+		for _, fn := range fns {
+			fn(ctx, event)
+		}
+	}
+}
+
+func composeOnRecovery(hooks []Hooks) func(context.Context, AutonomyLevel, AutonomyLevel) {
+	var fns []func(context.Context, AutonomyLevel, AutonomyLevel)
+	for _, h := range hooks {
+		if h.OnRecovery != nil {
+			fns = append(fns, h.OnRecovery)
+		}
+	}
+	if len(fns) == 0 {
+		return nil
+	}
+	return func(ctx context.Context, prev, next AutonomyLevel) {
+		for _, fn := range fns {
+			fn(ctx, prev, next)
+		}
+	}
+}

--- a/guard/degradation/level.go
+++ b/guard/degradation/level.go
@@ -1,0 +1,95 @@
+package degradation
+
+// AutonomyLevel represents the degree of freedom an agent has during
+// execution. Levels are ordered from most permissive to most restrictive.
+type AutonomyLevel int
+
+const (
+	// Full allows unrestricted access to all tools and capabilities.
+	Full AutonomyLevel = iota
+
+	// Restricted limits tool execution to an explicit allowlist.
+	Restricted
+
+	// ReadOnly prohibits all tool calls and write operations.
+	ReadOnly
+
+	// Sequestered fully isolates the agent; actions are logged but never
+	// executed.
+	Sequestered
+)
+
+// String returns a human-readable representation of the autonomy level.
+func (l AutonomyLevel) String() string {
+	switch l {
+	case Full:
+		return "full"
+	case Restricted:
+		return "restricted"
+	case ReadOnly:
+		return "read_only"
+	case Sequestered:
+		return "sequestered"
+	default:
+		return "unknown"
+	}
+}
+
+// Capabilities describes what actions are permitted at a given autonomy level.
+type Capabilities struct {
+	// CanExecuteTools indicates whether tool execution is permitted.
+	CanExecuteTools bool
+
+	// ToolsAllowlisted indicates whether only allowlisted tools may run.
+	// Only meaningful when CanExecuteTools is true.
+	ToolsAllowlisted bool
+
+	// CanWrite indicates whether write operations are permitted.
+	CanWrite bool
+
+	// CanRespond indicates whether the agent may produce responses.
+	CanRespond bool
+}
+
+// LevelCapabilities returns the capabilities associated with a given
+// autonomy level.
+func LevelCapabilities(level AutonomyLevel) Capabilities {
+	switch level {
+	case Full:
+		return Capabilities{
+			CanExecuteTools:  true,
+			ToolsAllowlisted: false,
+			CanWrite:         true,
+			CanRespond:       true,
+		}
+	case Restricted:
+		return Capabilities{
+			CanExecuteTools:  true,
+			ToolsAllowlisted: true,
+			CanWrite:         true,
+			CanRespond:       true,
+		}
+	case ReadOnly:
+		return Capabilities{
+			CanExecuteTools:  false,
+			ToolsAllowlisted: false,
+			CanWrite:         false,
+			CanRespond:       true,
+		}
+	case Sequestered:
+		return Capabilities{
+			CanExecuteTools:  false,
+			ToolsAllowlisted: false,
+			CanWrite:         false,
+			CanRespond:       false,
+		}
+	default:
+		// Unknown levels are treated as sequestered for safety.
+		return Capabilities{
+			CanExecuteTools:  false,
+			ToolsAllowlisted: false,
+			CanWrite:         false,
+			CanRespond:       false,
+		}
+	}
+}

--- a/guard/degradation/monitor.go
+++ b/guard/degradation/monitor.go
@@ -1,0 +1,196 @@
+package degradation
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// SecurityEventType identifies the kind of security event recorded.
+type SecurityEventType string
+
+const (
+	// EventGuardBlocked indicates a guard rejected content.
+	EventGuardBlocked SecurityEventType = "guard_blocked"
+
+	// EventInjectionDetected indicates a prompt injection attempt was detected.
+	EventInjectionDetected SecurityEventType = "injection_detected"
+
+	// EventPIILeakage indicates PII was found in output content.
+	EventPIILeakage SecurityEventType = "pii_leakage"
+
+	// EventToolAbuse indicates suspicious tool usage patterns.
+	EventToolAbuse SecurityEventType = "tool_abuse"
+
+	// EventRateLimitHit indicates excessive request volume from an agent.
+	EventRateLimitHit SecurityEventType = "rate_limit_hit"
+
+	// EventCustom indicates a user-defined security event type.
+	EventCustom SecurityEventType = "custom"
+)
+
+// SecurityEvent represents a single security-relevant occurrence recorded by
+// the monitor.
+type SecurityEvent struct {
+	// Type identifies the kind of security event.
+	Type SecurityEventType
+
+	// Severity is the weight of this event, in the range [0.0, 1.0].
+	// Higher values indicate more serious anomalies.
+	Severity float64
+
+	// Timestamp is when the event occurred.
+	Timestamp time.Time
+
+	// Source identifies which component generated the event (e.g., guard name).
+	Source string
+
+	// Metadata carries event-specific key-value pairs.
+	Metadata map[string]any
+}
+
+// defaultWindowSize is the default sliding window for severity computation.
+const defaultWindowSize = 5 * time.Minute
+
+// SecurityMonitor tracks security anomaly signals within a sliding time
+// window and computes an aggregate severity score. It is safe for concurrent
+// use.
+type SecurityMonitor struct {
+	mu         sync.RWMutex
+	events     []SecurityEvent
+	windowSize time.Duration
+	nowFunc    func() time.Time // for testing
+}
+
+// monitorOptions holds configuration for SecurityMonitor.
+type monitorOptions struct {
+	windowSize time.Duration
+	nowFunc    func() time.Time
+}
+
+// MonitorOption configures a SecurityMonitor.
+type MonitorOption func(*monitorOptions)
+
+// WithWindowSize sets the sliding window duration for severity computation.
+// Events older than the window are discarded. Defaults to 5 minutes.
+func WithWindowSize(d time.Duration) MonitorOption {
+	return func(o *monitorOptions) {
+		if d > 0 {
+			o.windowSize = d
+		}
+	}
+}
+
+// withNowFunc overrides the time source for testing. This is unexported
+// because it is only useful in tests.
+func withNowFunc(fn func() time.Time) MonitorOption {
+	return func(o *monitorOptions) {
+		o.nowFunc = fn
+	}
+}
+
+// NewSecurityMonitor creates a SecurityMonitor with the given options.
+func NewSecurityMonitor(opts ...MonitorOption) *SecurityMonitor {
+	o := monitorOptions{
+		windowSize: defaultWindowSize,
+		nowFunc:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &SecurityMonitor{
+		windowSize: o.windowSize,
+		nowFunc:    o.nowFunc,
+	}
+}
+
+// RecordEvent adds a security event to the monitor. The event's Severity is
+// clamped to [0.0, 1.0]. Context is accepted for future tracing integration.
+func (m *SecurityMonitor) RecordEvent(_ context.Context, event SecurityEvent) {
+	if event.Severity < 0 {
+		event.Severity = 0
+	}
+	if event.Severity > 1 {
+		event.Severity = 1
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = m.nowFunc()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+	m.pruneExpiredLocked()
+}
+
+// CurrentSeverity returns the aggregate severity score across all events in
+// the current window. The score is the sum of individual event severities,
+// with newer events weighted more heavily via linear decay. The result is
+// clamped to [0.0, 1.0].
+func (m *SecurityMonitor) CurrentSeverity() float64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	now := m.nowFunc()
+	cutoff := now.Add(-m.windowSize)
+	var total float64
+
+	for _, e := range m.events {
+		if e.Timestamp.Before(cutoff) {
+			continue
+		}
+		age := now.Sub(e.Timestamp)
+		// Linear decay: newer events have weight closer to 1.0.
+		weight := 1.0 - (float64(age) / float64(m.windowSize))
+		if weight < 0 {
+			weight = 0
+		}
+		total += e.Severity * weight
+	}
+
+	if total > 1.0 {
+		total = 1.0
+	}
+	return total
+}
+
+// EventCount returns the number of events currently in the window.
+func (m *SecurityMonitor) EventCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	now := m.nowFunc()
+	cutoff := now.Add(-m.windowSize)
+	count := 0
+	for _, e := range m.events {
+		if !e.Timestamp.Before(cutoff) {
+			count++
+		}
+	}
+	return count
+}
+
+// Reset clears all recorded events.
+func (m *SecurityMonitor) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = nil
+}
+
+// pruneExpiredLocked removes events older than the window. Caller must hold
+// m.mu for writing.
+func (m *SecurityMonitor) pruneExpiredLocked() {
+	cutoff := m.nowFunc().Add(-m.windowSize)
+	n := 0
+	for _, e := range m.events {
+		if !e.Timestamp.Before(cutoff) {
+			m.events[n] = e
+			n++
+		}
+	}
+	// Clear references to allow GC of metadata maps.
+	for i := n; i < len(m.events); i++ {
+		m.events[i] = SecurityEvent{}
+	}
+	m.events = m.events[:n]
+}

--- a/guard/degradation/monitor.go
+++ b/guard/degradation/monitor.go
@@ -128,6 +128,10 @@ func (m *SecurityMonitor) RecordEvent(_ context.Context, event SecurityEvent) {
 // with newer events weighted more heavily via linear decay. The result is
 // clamped to [0.0, 1.0].
 func (m *SecurityMonitor) CurrentSeverity() float64 {
+	m.mu.Lock()
+	m.pruneExpiredLocked()
+	m.mu.Unlock()
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -154,20 +158,14 @@ func (m *SecurityMonitor) CurrentSeverity() float64 {
 	return total
 }
 
-// EventCount returns the number of events currently in the window.
+// EventCount returns the number of events currently in the window. Expired
+// events are pruned on read so a burst of events followed by a quiet period
+// does not retain unbounded memory.
 func (m *SecurityMonitor) EventCount() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	now := m.nowFunc()
-	cutoff := now.Add(-m.windowSize)
-	count := 0
-	for _, e := range m.events {
-		if !e.Timestamp.Before(cutoff) {
-			count++
-		}
-	}
-	return count
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneExpiredLocked()
+	return len(m.events)
 }
 
 // Reset clears all recorded events.

--- a/guard/degradation/policy.go
+++ b/guard/degradation/policy.go
@@ -1,0 +1,76 @@
+package degradation
+
+// DegradationPolicy evaluates a severity score and determines the
+// appropriate autonomy level for agent operation.
+type DegradationPolicy interface {
+	// Evaluate maps a severity score in [0.0, 1.0] to an AutonomyLevel.
+	Evaluate(severity float64) AutonomyLevel
+}
+
+// DefaultThresholds defines the default severity thresholds for level
+// transitions. These are tuned for a balance between safety and usability.
+var DefaultThresholds = LevelThresholds{
+	Restricted:  0.3,
+	ReadOnly:    0.6,
+	Sequestered: 0.85,
+}
+
+// LevelThresholds maps each degraded autonomy level to the minimum severity
+// score that triggers it. The Full level is implicit when severity is below
+// the Restricted threshold.
+type LevelThresholds struct {
+	// Restricted is the minimum severity to enter restricted mode.
+	Restricted float64
+
+	// ReadOnly is the minimum severity to enter read-only mode.
+	ReadOnly float64
+
+	// Sequestered is the minimum severity to enter sequestered mode.
+	Sequestered float64
+}
+
+// ThresholdPolicy is a DegradationPolicy that maps severity ranges to
+// autonomy levels using configurable thresholds.
+type ThresholdPolicy struct {
+	thresholds LevelThresholds
+}
+
+// Compile-time interface check.
+var _ DegradationPolicy = (*ThresholdPolicy)(nil)
+
+// PolicyOption configures a ThresholdPolicy.
+type PolicyOption func(*ThresholdPolicy)
+
+// WithLevelThresholds sets custom severity thresholds for level transitions.
+func WithLevelThresholds(t LevelThresholds) PolicyOption {
+	return func(p *ThresholdPolicy) {
+		p.thresholds = t
+	}
+}
+
+// NewThresholdPolicy creates a ThresholdPolicy with the given options.
+// Without options, DefaultThresholds are used.
+func NewThresholdPolicy(opts ...PolicyOption) *ThresholdPolicy {
+	p := &ThresholdPolicy{
+		thresholds: DefaultThresholds,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Evaluate returns the autonomy level corresponding to the given severity
+// score. Higher severity values produce more restrictive levels.
+func (p *ThresholdPolicy) Evaluate(severity float64) AutonomyLevel {
+	switch {
+	case severity >= p.thresholds.Sequestered:
+		return Sequestered
+	case severity >= p.thresholds.ReadOnly:
+		return ReadOnly
+	case severity >= p.thresholds.Restricted:
+		return Restricted
+	default:
+		return Full
+	}
+}

--- a/guard/degradation/policy.go
+++ b/guard/degradation/policy.go
@@ -1,5 +1,10 @@
 package degradation
 
+import (
+	"log/slog"
+	"sort"
+)
+
 // DegradationPolicy evaluates a severity score and determines the
 // appropriate autonomy level for agent operation.
 type DegradationPolicy interface {
@@ -18,6 +23,12 @@ var DefaultThresholds = LevelThresholds{
 // LevelThresholds maps each degraded autonomy level to the minimum severity
 // score that triggers it. The Full level is implicit when severity is below
 // the Restricted threshold.
+//
+// Thresholds must be monotonically non-decreasing:
+//
+//	0 <= Restricted <= ReadOnly <= Sequestered <= 1
+//
+// NewThresholdPolicy validates this invariant at construction time.
 type LevelThresholds struct {
 	// Restricted is the minimum severity to enter restricted mode.
 	Restricted float64
@@ -50,6 +61,13 @@ func WithLevelThresholds(t LevelThresholds) PolicyOption {
 
 // NewThresholdPolicy creates a ThresholdPolicy with the given options.
 // Without options, DefaultThresholds are used.
+//
+// Thresholds are normalised at construction time: values outside [0,1] are
+// clamped, and non-monotonic configurations (e.g. Restricted=0.8,
+// ReadOnly=0.3) are sorted into ascending order so that Evaluate always
+// tests thresholds in a well-defined sequence. A warning is logged when
+// normalisation adjusts the provided values so misconfiguration is visible
+// without breaking callers.
 func NewThresholdPolicy(opts ...PolicyOption) *ThresholdPolicy {
 	p := &ThresholdPolicy{
 		thresholds: DefaultThresholds,
@@ -57,7 +75,38 @@ func NewThresholdPolicy(opts ...PolicyOption) *ThresholdPolicy {
 	for _, opt := range opts {
 		opt(p)
 	}
+	p.thresholds = normalizeThresholds(p.thresholds)
 	return p
+}
+
+// normalizeThresholds clamps values to [0,1] and sorts them into ascending
+// order so that the invariant Restricted <= ReadOnly <= Sequestered holds
+// regardless of how the LevelThresholds struct was populated.
+func normalizeThresholds(t LevelThresholds) LevelThresholds {
+	orig := t
+	clamp := func(v float64) float64 {
+		if v < 0 {
+			return 0
+		}
+		if v > 1 {
+			return 1
+		}
+		return v
+	}
+	values := []float64{clamp(t.Restricted), clamp(t.ReadOnly), clamp(t.Sequestered)}
+	sort.Float64s(values)
+	normalized := LevelThresholds{
+		Restricted:  values[0],
+		ReadOnly:    values[1],
+		Sequestered: values[2],
+	}
+	if normalized != orig {
+		slog.Default().Warn("degradation: threshold configuration normalized",
+			"original", orig,
+			"normalized", normalized,
+		)
+	}
+	return normalized
 }
 
 // Evaluate returns the autonomy level corresponding to the given severity


### PR DESCRIPTION
## Summary
- guard/degradation package, AutonomyLevel enum, SecurityMonitor with sliding window, RuntimeDegrader middleware

## Linear
- LOO-36: https://linear.app/lookatitude/issue/LOO-36

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)