### PR TITLE
LOO-38: Cost-Aware Evaluation

### DIFF
--- a/eval/cost/budget.go
+++ b/eval/cost/budget.go
@@ -26,7 +26,9 @@ func WithThreshold(threshold float64) BudgetAlertOption {
 }
 
 // WithOnAlert sets the callback invoked when the threshold is exceeded.
-// The callback receives the current total and the threshold.
+// The callback receives the current total and the threshold. The callback is
+// invoked without holding the internal BudgetAlert mutex, so it is safe to
+// re-enter other BudgetAlert methods (Total, Exceeded, Reset) from within it.
 func WithOnAlert(fn func(total float64, threshold float64)) BudgetAlertOption {
 	return func(b *BudgetAlert) {
 		b.onAlert = fn
@@ -48,20 +50,29 @@ func NewBudgetAlert(opts ...BudgetAlertOption) (*BudgetAlert, error) {
 // Add accumulates cost and fires the alert callback if the threshold is
 // exceeded. The alert fires at most once. Returns true if the threshold
 // has been exceeded (including prior calls).
+//
+// The onAlert callback is invoked after releasing the internal mutex so that
+// the callback may safely call other BudgetAlert methods (Total, Exceeded,
+// Reset) without deadlocking, and so that a slow callback does not block
+// concurrent Add callers.
 func (b *BudgetAlert) Add(amount float64) bool {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	b.total += amount
-
-	if b.total >= b.threshold && !b.fired {
+	total := b.total
+	threshold := b.threshold
+	shouldFire := total >= threshold && !b.fired
+	if shouldFire {
 		b.fired = true
-		if b.onAlert != nil {
-			b.onAlert(b.total, b.threshold)
-		}
+	}
+	callback := b.onAlert
+	exceeded := total >= threshold
+	b.mu.Unlock()
+
+	if shouldFire && callback != nil {
+		callback(total, threshold)
 	}
 
-	return b.total >= b.threshold
+	return exceeded
 }
 
 // Total returns the current cumulative cost.

--- a/eval/cost/budget.go
+++ b/eval/cost/budget.go
@@ -1,0 +1,87 @@
+package cost
+
+import (
+	"fmt"
+	"sync"
+)
+
+// BudgetAlert monitors cumulative evaluation cost and fires a callback when
+// the cost exceeds a configured threshold.
+type BudgetAlert struct {
+	mu        sync.Mutex
+	threshold float64
+	total     float64
+	fired     bool
+	onAlert   func(total float64, threshold float64)
+}
+
+// BudgetAlertOption configures a BudgetAlert.
+type BudgetAlertOption func(*BudgetAlert)
+
+// WithThreshold sets the dollar threshold that triggers the alert.
+func WithThreshold(threshold float64) BudgetAlertOption {
+	return func(b *BudgetAlert) {
+		b.threshold = threshold
+	}
+}
+
+// WithOnAlert sets the callback invoked when the threshold is exceeded.
+// The callback receives the current total and the threshold.
+func WithOnAlert(fn func(total float64, threshold float64)) BudgetAlertOption {
+	return func(b *BudgetAlert) {
+		b.onAlert = fn
+	}
+}
+
+// NewBudgetAlert creates a new BudgetAlert with the given options.
+func NewBudgetAlert(opts ...BudgetAlertOption) (*BudgetAlert, error) {
+	b := &BudgetAlert{}
+	for _, opt := range opts {
+		opt(b)
+	}
+	if b.threshold <= 0 {
+		return nil, fmt.Errorf("budget: threshold must be positive, got %f", b.threshold)
+	}
+	return b, nil
+}
+
+// Add accumulates cost and fires the alert callback if the threshold is
+// exceeded. The alert fires at most once. Returns true if the threshold
+// has been exceeded (including prior calls).
+func (b *BudgetAlert) Add(amount float64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.total += amount
+
+	if b.total >= b.threshold && !b.fired {
+		b.fired = true
+		if b.onAlert != nil {
+			b.onAlert(b.total, b.threshold)
+		}
+	}
+
+	return b.total >= b.threshold
+}
+
+// Total returns the current cumulative cost.
+func (b *BudgetAlert) Total() float64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total
+}
+
+// Exceeded returns whether the threshold has been exceeded.
+func (b *BudgetAlert) Exceeded() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.total >= b.threshold
+}
+
+// Reset clears the accumulated cost and fired state.
+func (b *BudgetAlert) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.total = 0
+	b.fired = false
+}

--- a/eval/cost/cost.go
+++ b/eval/cost/cost.go
@@ -5,24 +5,35 @@ import (
 	"fmt"
 
 	"github.com/lookatitude/beluga-ai/eval"
+	"github.com/lookatitude/beluga-ai/eval/metrics"
 )
 
 // Compile-time interface check.
 var _ eval.Metric = (*CostMetric)(nil)
 
-// ModelPricing defines per-token pricing for a model.
-type ModelPricing struct {
-	// InputTokenPrice is the price per 1 million input tokens in dollars.
-	InputTokenPrice float64
-	// OutputTokenPrice is the price per 1 million output tokens in dollars.
-	OutputTokenPrice float64
-}
+// ModelPricing defines per-token pricing for a model. It is a type alias for
+// metrics.ModelPricing so that callers can share a single pricing map between
+// the eval/metrics.Cost metric and the eval/cost package without duplication.
+type ModelPricing = metrics.ModelPricing
+
+// defaultQPDReference is the default quality-per-dollar value that maps to a
+// normalized score of 1.0. It is intentionally conservative; callers with
+// different cost/quality profiles should use WithQPDReference to override it.
+const defaultQPDReference = 1000.0
+
+// defaultCostReference is the default dollar cost that maps to a normalized
+// score of 0.0 when no quality metric is configured. Costs at or above this
+// value yield a score of 0.0; a cost of 0 yields 1.0. Callers with different
+// budget profiles should use WithCostReference to override it.
+const defaultCostReference = 1.0
 
 // costOptions holds configuration for CostMetric.
 type costOptions struct {
 	pricing       map[string]ModelPricing
 	qualityMetric eval.Metric
 	metricName    string
+	qpdReference  float64
+	costReference float64
 }
 
 // CostOption configures a CostMetric.
@@ -36,7 +47,7 @@ func WithPricing(pricing map[string]ModelPricing) CostOption {
 }
 
 // WithQualityMetric sets the quality metric used for quality-per-dollar
-// computation. If nil, the CostMetric returns only the raw cost.
+// computation. If nil, the CostMetric returns a cost-only normalized score.
 func WithQualityMetric(m eval.Metric) CostOption {
 	return func(o *costOptions) {
 		o.qualityMetric = m
@@ -50,13 +61,38 @@ func WithMetricName(name string) CostOption {
 	}
 }
 
-// CostMetric computes quality-per-dollar by combining a quality metric score
-// with token cost. It reads Metadata["model"], Metadata["input_tokens"], and
+// WithQPDReference sets the quality-per-dollar reference value that maps to a
+// normalized score of 1.0. Values above the reference are clamped to 1.0.
+// Must be positive. Defaults to 1000.
+func WithQPDReference(ref float64) CostOption {
+	return func(o *costOptions) {
+		if ref > 0 {
+			o.qpdReference = ref
+		}
+	}
+}
+
+// WithCostReference sets the dollar cost that maps to a normalized score of
+// 0.0 when no quality metric is configured. Must be positive. Defaults to 1.0.
+func WithCostReference(ref float64) CostOption {
+	return func(o *costOptions) {
+		if ref > 0 {
+			o.costReference = ref
+		}
+	}
+}
+
+// CostMetric computes a normalized cost-aware score for evaluation samples.
+// It reads Metadata["model"], Metadata["input_tokens"], and
 // Metadata["output_tokens"] from the sample.
 //
-// When a quality metric is set, the score is quality / cost (higher is better,
-// clamped to [0, 1] by dividing by a reference of 1000 quality-per-dollar).
-// When no quality metric is set, the score is 1 - normalized_cost.
+// When a quality metric is configured, Score returns quality-per-dollar
+// normalized by the configured QPD reference and clamped to [0, 1].
+//
+// When no quality metric is configured, Score returns a cost-only normalized
+// score (1 - cost/costReference, clamped to [0, 1]): a zero-cost sample scores
+// 1.0 and a sample at or above the cost reference scores 0.0. Use
+// ComputeRawCost for the raw dollar amount (e.g. for budget tracking).
 type CostMetric struct {
 	opts costOptions
 }
@@ -64,8 +100,10 @@ type CostMetric struct {
 // NewCostMetric creates a new CostMetric with the given options.
 func NewCostMetric(opts ...CostOption) *CostMetric {
 	o := costOptions{
-		pricing:    make(map[string]ModelPricing),
-		metricName: "cost_quality",
+		pricing:       make(map[string]ModelPricing),
+		metricName:    "cost_quality",
+		qpdReference:  defaultQPDReference,
+		costReference: defaultCostReference,
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -76,9 +114,12 @@ func NewCostMetric(opts ...CostOption) *CostMetric {
 // Name returns the metric name.
 func (c *CostMetric) Name() string { return c.opts.metricName }
 
-// Score computes the quality-per-dollar score for a sample. If a quality
-// metric is configured, returns quality/cost normalized to [0, 1]. Otherwise
-// returns the raw dollar cost as the score (not normalized).
+// Score computes a normalized cost-aware score for a sample, always in
+// [0.0, 1.0] as required by the eval.Metric contract.
+//
+// If a quality metric is configured, returns quality/cost normalized by the
+// QPD reference. Otherwise returns a cost-only normalized score
+// (1 - cost/costReference).
 func (c *CostMetric) Score(ctx context.Context, sample eval.EvalSample) (float64, error) {
 	cost, err := c.computeCost(sample)
 	if err != nil {
@@ -86,7 +127,14 @@ func (c *CostMetric) Score(ctx context.Context, sample eval.EvalSample) (float64
 	}
 
 	if c.opts.qualityMetric == nil {
-		return cost, nil
+		// Cost-only normalized score: 1.0 at zero cost, 0.0 at or above the
+		// reference. Always in [0, 1] to honor the eval.Metric contract.
+		ref := c.opts.costReference
+		if ref <= 0 {
+			ref = defaultCostReference
+		}
+		score := 1.0 - (cost / ref)
+		return clamp01(score), nil
 	}
 
 	quality, err := c.opts.qualityMetric.Score(ctx, sample)
@@ -101,13 +149,13 @@ func (c *CostMetric) Score(ctx context.Context, sample eval.EvalSample) (float64
 		return 0, nil
 	}
 
-	// Quality per dollar, normalized to [0, 1] using 1000 as reference.
-	qpd := quality / cost
-	score := qpd / 1000.0
-	if score > 1.0 {
-		score = 1.0
+	// Quality per dollar, normalized to [0, 1] using the configured reference.
+	ref := c.opts.qpdReference
+	if ref <= 0 {
+		ref = defaultQPDReference
 	}
-	return score, nil
+	qpd := quality / cost
+	return clamp01(qpd / ref), nil
 }
 
 // ComputeRawCost returns the raw dollar cost for a sample without any
@@ -124,7 +172,7 @@ func (c *CostMetric) computeCost(sample eval.EvalSample) (float64, error) {
 	}
 	model, ok := modelRaw.(string)
 	if !ok {
-		return 0, fmt.Errorf("cost: metadata %q must be a string", "model")
+		return 0, fmt.Errorf("cost: metadata %q must be a string, got %T", "model", modelRaw)
 	}
 
 	pricing, ok := c.opts.pricing[model]
@@ -132,17 +180,36 @@ func (c *CostMetric) computeCost(sample eval.EvalSample) (float64, error) {
 		return 0, fmt.Errorf("cost: no pricing for model %q", model)
 	}
 
-	inputTokens, err := toFloat64(sample.Metadata["input_tokens"])
+	inputRaw, ok := sample.Metadata["input_tokens"]
+	if !ok {
+		return 0, fmt.Errorf("cost: missing metadata key %q", "input_tokens")
+	}
+	inputTokens, err := toFloat64(inputRaw)
 	if err != nil {
 		return 0, fmt.Errorf("cost: input_tokens: %w", err)
 	}
 
-	outputTokens, err := toFloat64(sample.Metadata["output_tokens"])
+	outputRaw, ok := sample.Metadata["output_tokens"]
+	if !ok {
+		return 0, fmt.Errorf("cost: missing metadata key %q", "output_tokens")
+	}
+	outputTokens, err := toFloat64(outputRaw)
 	if err != nil {
 		return 0, fmt.Errorf("cost: output_tokens: %w", err)
 	}
 
 	return (inputTokens*pricing.InputTokenPrice + outputTokens*pricing.OutputTokenPrice) / 1_000_000, nil
+}
+
+// clamp01 clamps a value into [0, 1].
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
 }
 
 // toFloat64 converts numeric interface values to float64.

--- a/eval/cost/cost.go
+++ b/eval/cost/cost.go
@@ -1,0 +1,164 @@
+package cost
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lookatitude/beluga-ai/eval"
+)
+
+// Compile-time interface check.
+var _ eval.Metric = (*CostMetric)(nil)
+
+// ModelPricing defines per-token pricing for a model.
+type ModelPricing struct {
+	// InputTokenPrice is the price per 1 million input tokens in dollars.
+	InputTokenPrice float64
+	// OutputTokenPrice is the price per 1 million output tokens in dollars.
+	OutputTokenPrice float64
+}
+
+// costOptions holds configuration for CostMetric.
+type costOptions struct {
+	pricing       map[string]ModelPricing
+	qualityMetric eval.Metric
+	metricName    string
+}
+
+// CostOption configures a CostMetric.
+type CostOption func(*costOptions)
+
+// WithPricing sets the model pricing map.
+func WithPricing(pricing map[string]ModelPricing) CostOption {
+	return func(o *costOptions) {
+		o.pricing = pricing
+	}
+}
+
+// WithQualityMetric sets the quality metric used for quality-per-dollar
+// computation. If nil, the CostMetric returns only the raw cost.
+func WithQualityMetric(m eval.Metric) CostOption {
+	return func(o *costOptions) {
+		o.qualityMetric = m
+	}
+}
+
+// WithMetricName sets the name returned by Name(). Defaults to "cost_quality".
+func WithMetricName(name string) CostOption {
+	return func(o *costOptions) {
+		o.metricName = name
+	}
+}
+
+// CostMetric computes quality-per-dollar by combining a quality metric score
+// with token cost. It reads Metadata["model"], Metadata["input_tokens"], and
+// Metadata["output_tokens"] from the sample.
+//
+// When a quality metric is set, the score is quality / cost (higher is better,
+// clamped to [0, 1] by dividing by a reference of 1000 quality-per-dollar).
+// When no quality metric is set, the score is 1 - normalized_cost.
+type CostMetric struct {
+	opts costOptions
+}
+
+// NewCostMetric creates a new CostMetric with the given options.
+func NewCostMetric(opts ...CostOption) *CostMetric {
+	o := costOptions{
+		pricing:    make(map[string]ModelPricing),
+		metricName: "cost_quality",
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &CostMetric{opts: o}
+}
+
+// Name returns the metric name.
+func (c *CostMetric) Name() string { return c.opts.metricName }
+
+// Score computes the quality-per-dollar score for a sample. If a quality
+// metric is configured, returns quality/cost normalized to [0, 1]. Otherwise
+// returns the raw dollar cost as the score (not normalized).
+func (c *CostMetric) Score(ctx context.Context, sample eval.EvalSample) (float64, error) {
+	cost, err := c.computeCost(sample)
+	if err != nil {
+		return 0, err
+	}
+
+	if c.opts.qualityMetric == nil {
+		return cost, nil
+	}
+
+	quality, err := c.opts.qualityMetric.Score(ctx, sample)
+	if err != nil {
+		return 0, fmt.Errorf("cost_quality: quality metric: %w", err)
+	}
+
+	if cost <= 0 {
+		if quality > 0 {
+			return 1.0, nil
+		}
+		return 0, nil
+	}
+
+	// Quality per dollar, normalized to [0, 1] using 1000 as reference.
+	qpd := quality / cost
+	score := qpd / 1000.0
+	if score > 1.0 {
+		score = 1.0
+	}
+	return score, nil
+}
+
+// ComputeRawCost returns the raw dollar cost for a sample without any
+// quality normalization. Useful for budget tracking.
+func (c *CostMetric) ComputeRawCost(sample eval.EvalSample) (float64, error) {
+	return c.computeCost(sample)
+}
+
+// computeCost calculates dollar cost from sample metadata.
+func (c *CostMetric) computeCost(sample eval.EvalSample) (float64, error) {
+	modelRaw, ok := sample.Metadata["model"]
+	if !ok {
+		return 0, fmt.Errorf("cost: missing metadata key %q", "model")
+	}
+	model, ok := modelRaw.(string)
+	if !ok {
+		return 0, fmt.Errorf("cost: metadata %q must be a string", "model")
+	}
+
+	pricing, ok := c.opts.pricing[model]
+	if !ok {
+		return 0, fmt.Errorf("cost: no pricing for model %q", model)
+	}
+
+	inputTokens, err := toFloat64(sample.Metadata["input_tokens"])
+	if err != nil {
+		return 0, fmt.Errorf("cost: input_tokens: %w", err)
+	}
+
+	outputTokens, err := toFloat64(sample.Metadata["output_tokens"])
+	if err != nil {
+		return 0, fmt.Errorf("cost: output_tokens: %w", err)
+	}
+
+	return (inputTokens*pricing.InputTokenPrice + outputTokens*pricing.OutputTokenPrice) / 1_000_000, nil
+}
+
+// toFloat64 converts numeric interface values to float64.
+func toFloat64(v any) (float64, error) {
+	switch n := v.(type) {
+	case float64:
+		return n, nil
+	case float32:
+		return float64(n), nil
+	case int:
+		return float64(n), nil
+	case int64:
+		return float64(n), nil
+	case int32:
+		return float64(n), nil
+	default:
+		return 0, fmt.Errorf("unsupported numeric type %T", v)
+	}
+}

--- a/eval/cost/cost_test.go
+++ b/eval/cost/cost_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lookatitude/beluga-ai/eval"
 	"github.com/stretchr/testify/assert"
@@ -53,9 +54,19 @@ func TestCostMetric_Score(t *testing.T) {
 		tolerance float64
 	}{
 		{
-			name:      "raw cost no quality metric",
+			name: "cost-only normalized score (no quality metric)",
+			// cost = (1000*5 + 500*15) / 1e6 = 0.0125 dollars;
+			// with default cost reference 1.0, score = 1 - 0.0125 = 0.9875.
 			sample:    sampleWithMeta("gpt-4o", 1000, 500),
-			wantScore: (1000*5.0 + 500*15.0) / 1_000_000, // 0.0125
+			wantScore: 0.9875,
+			tolerance: 0.0001,
+		},
+		{
+			name: "cost-only score clamps to zero above reference",
+			// cost = 12.5 dollars, well above the default 1.0 reference, so
+			// the normalized score is clamped to 0 and must stay in [0, 1].
+			sample:    sampleWithMeta("gpt-4o", 1_000_000, 500_000),
+			wantScore: 0.0,
 			tolerance: 0.0001,
 		},
 		{
@@ -224,6 +235,46 @@ func TestBudgetAlert(t *testing.T) {
 	t.Run("invalid threshold", func(t *testing.T) {
 		_, err := NewBudgetAlert(WithThreshold(0))
 		require.Error(t, err)
+	})
+
+	t.Run("callback may re-enter other methods without deadlock", func(t *testing.T) {
+		// Regression test: onAlert must not be invoked while the internal
+		// mutex is held, otherwise re-entrant calls to Total/Exceeded/Reset
+		// from within the callback would deadlock. We gate the test on a
+		// timeout so a regression surfaces as a failure rather than a hung
+		// suite.
+		var alert *BudgetAlert
+		var observedTotal float64
+		var observedExceeded bool
+		var err error
+		alert, err = NewBudgetAlert(
+			WithThreshold(1.0),
+			WithOnAlert(func(_, _ float64) {
+				// These re-entrant calls would deadlock if Add still held
+				// the mutex when invoking the callback.
+				observedTotal = alert.Total()
+				observedExceeded = alert.Exceeded()
+				alert.Reset()
+			}),
+		)
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			alert.Add(2.0)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Add deadlocked: callback was invoked while mutex was held")
+		}
+
+		assert.InDelta(t, 2.0, observedTotal, 0.001)
+		assert.True(t, observedExceeded)
+		// Reset ran from within the callback.
+		assert.InDelta(t, 0.0, alert.Total(), 0.001)
 	})
 }
 

--- a/eval/cost/cost_test.go
+++ b/eval/cost/cost_test.go
@@ -1,0 +1,281 @@
+package cost
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/eval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// staticMetric is a test metric that always returns a fixed score.
+type staticMetric struct {
+	name  string
+	score float64
+	err   error
+}
+
+func (m *staticMetric) Name() string { return m.name }
+func (m *staticMetric) Score(_ context.Context, _ eval.EvalSample) (float64, error) {
+	return m.score, m.err
+}
+
+func sampleWithMeta(model string, inputTokens, outputTokens int) eval.EvalSample {
+	return eval.EvalSample{
+		Input:  "test",
+		Output: "test output",
+		Metadata: map[string]any{
+			"model":         model,
+			"input_tokens":  inputTokens,
+			"output_tokens": outputTokens,
+		},
+	}
+}
+
+func TestCostMetric_Name(t *testing.T) {
+	cm := NewCostMetric(WithMetricName("my-cost"))
+	assert.Equal(t, "my-cost", cm.Name())
+}
+
+func TestCostMetric_Score(t *testing.T) {
+	pricing := map[string]ModelPricing{
+		"gpt-4o": {InputTokenPrice: 5.0, OutputTokenPrice: 15.0},
+	}
+
+	tests := []struct {
+		name      string
+		sample    eval.EvalSample
+		quality   eval.Metric
+		wantScore float64
+		wantErr   bool
+		tolerance float64
+	}{
+		{
+			name:      "raw cost no quality metric",
+			sample:    sampleWithMeta("gpt-4o", 1000, 500),
+			wantScore: (1000*5.0 + 500*15.0) / 1_000_000, // 0.0125
+			tolerance: 0.0001,
+		},
+		{
+			name:      "quality per dollar",
+			sample:    sampleWithMeta("gpt-4o", 1000, 500),
+			quality:   &staticMetric{name: "q", score: 0.8},
+			wantScore: (0.8 / 0.0125) / 1000.0, // 0.064
+			tolerance: 0.001,
+		},
+		{
+			name:    "missing model",
+			sample:  eval.EvalSample{Metadata: map[string]any{"input_tokens": 100, "output_tokens": 50}},
+			wantErr: true,
+		},
+		{
+			name:    "unknown model",
+			sample:  sampleWithMeta("unknown", 100, 50),
+			wantErr: true,
+		},
+		{
+			name:    "quality metric error",
+			sample:  sampleWithMeta("gpt-4o", 100, 50),
+			quality: &staticMetric{name: "q", err: errors.New("fail")},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []CostOption{WithPricing(pricing)}
+			if tt.quality != nil {
+				opts = append(opts, WithQualityMetric(tt.quality))
+			}
+			cm := NewCostMetric(opts...)
+
+			score, err := cm.Score(context.Background(), tt.sample)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, tt.wantScore, score, tt.tolerance)
+		})
+	}
+}
+
+func TestCostMetric_ComputeRawCost(t *testing.T) {
+	pricing := map[string]ModelPricing{
+		"gpt-4o": {InputTokenPrice: 5.0, OutputTokenPrice: 15.0},
+	}
+	cm := NewCostMetric(WithPricing(pricing))
+
+	cost, err := cm.ComputeRawCost(sampleWithMeta("gpt-4o", 1_000_000, 500_000))
+	require.NoError(t, err)
+	assert.InDelta(t, 12.5, cost, 0.001) // 5.0 + 7.5
+}
+
+func TestParetoAnalyzer_Analyze(t *testing.T) {
+	tests := []struct {
+		name        string
+		configs     []ConfigResult
+		wantOptimal int
+		wantDom     int
+	}{
+		{
+			name:        "empty",
+			configs:     nil,
+			wantOptimal: 0,
+			wantDom:     0,
+		},
+		{
+			name: "single config",
+			configs: []ConfigResult{
+				{Name: "a", Quality: 0.8, Cost: 1.0},
+			},
+			wantOptimal: 1,
+			wantDom:     0,
+		},
+		{
+			name: "clear domination",
+			configs: []ConfigResult{
+				{Name: "a", Quality: 0.9, Cost: 1.0}, // dominates b
+				{Name: "b", Quality: 0.5, Cost: 2.0}, // dominated
+			},
+			wantOptimal: 1,
+			wantDom:     1,
+		},
+		{
+			name: "pareto front",
+			configs: []ConfigResult{
+				{Name: "cheap", Quality: 0.6, Cost: 0.5},
+				{Name: "balanced", Quality: 0.8, Cost: 1.0},
+				{Name: "premium", Quality: 0.95, Cost: 3.0},
+				{Name: "waste", Quality: 0.5, Cost: 2.0}, // dominated by balanced
+			},
+			wantOptimal: 3,
+			wantDom:     1,
+		},
+		{
+			name: "identical configs",
+			configs: []ConfigResult{
+				{Name: "a", Quality: 0.8, Cost: 1.0},
+				{Name: "b", Quality: 0.8, Cost: 1.0},
+			},
+			wantOptimal: 2,
+			wantDom:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analyzer := NewParetoAnalyzer()
+			result := analyzer.Analyze(tt.configs)
+			assert.Len(t, result.Optimal, tt.wantOptimal)
+			assert.Len(t, result.Dominated, tt.wantDom)
+		})
+	}
+}
+
+func TestBudgetAlert(t *testing.T) {
+	t.Run("fires on threshold", func(t *testing.T) {
+		var alertTotal, alertThreshold float64
+		alert, err := NewBudgetAlert(
+			WithThreshold(1.0),
+			WithOnAlert(func(total, threshold float64) {
+				alertTotal = total
+				alertThreshold = threshold
+			}),
+		)
+		require.NoError(t, err)
+
+		assert.False(t, alert.Add(0.5))
+		assert.False(t, alert.Exceeded())
+
+		assert.True(t, alert.Add(0.6))
+		assert.True(t, alert.Exceeded())
+		assert.InDelta(t, 1.1, alertTotal, 0.001)
+		assert.InDelta(t, 1.0, alertThreshold, 0.001)
+	})
+
+	t.Run("fires only once", func(t *testing.T) {
+		fireCount := 0
+		alert, err := NewBudgetAlert(
+			WithThreshold(1.0),
+			WithOnAlert(func(_, _ float64) { fireCount++ }),
+		)
+		require.NoError(t, err)
+
+		alert.Add(2.0)
+		alert.Add(3.0)
+		assert.Equal(t, 1, fireCount)
+	})
+
+	t.Run("reset", func(t *testing.T) {
+		alert, err := NewBudgetAlert(WithThreshold(1.0))
+		require.NoError(t, err)
+
+		alert.Add(2.0)
+		assert.True(t, alert.Exceeded())
+
+		alert.Reset()
+		assert.False(t, alert.Exceeded())
+		assert.InDelta(t, 0.0, alert.Total(), 0.001)
+	})
+
+	t.Run("invalid threshold", func(t *testing.T) {
+		_, err := NewBudgetAlert(WithThreshold(0))
+		require.Error(t, err)
+	})
+}
+
+func TestGenerateReport(t *testing.T) {
+	configs := []ConfigResult{
+		{Name: "cheap", Quality: 0.75, Cost: 0.01},
+		{Name: "premium", Quality: 0.95, Cost: 0.10},
+		{Name: "waste", Quality: 0.5, Cost: 0.20},
+	}
+
+	report := GenerateReport(configs)
+	assert.InDelta(t, 0.31, report.TotalCost, 0.001)
+	assert.True(t, report.AverageQuality > 0)
+	assert.True(t, report.QualityPerDollar > 0)
+	assert.True(t, len(report.ParetoOptimal) >= 1)
+	assert.True(t, len(report.Recommendations) >= 1)
+
+	str := report.String()
+	assert.Contains(t, str, "Cost Report")
+	assert.Contains(t, str, "Pareto-Optimal")
+}
+
+func TestGenerateReport_Empty(t *testing.T) {
+	report := GenerateReport(nil)
+	assert.Equal(t, 0.0, report.TotalCost)
+	assert.Empty(t, report.ParetoOptimal)
+}
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    float64
+		wantErr bool
+	}{
+		{"float64", float64(1.5), 1.5, false},
+		{"float32", float32(1.5), 1.5, false},
+		{"int", 42, 42.0, false},
+		{"int64", int64(42), 42.0, false},
+		{"int32", int32(42), 42.0, false},
+		{"string", "42", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toFloat64(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, tt.want, got, 0.01)
+		})
+	}
+}

--- a/eval/cost/doc.go
+++ b/eval/cost/doc.go
@@ -1,0 +1,14 @@
+// Package cost provides cost-aware evaluation capabilities for comparing
+// model configurations on a quality-per-dollar basis.
+//
+// It includes a CostMetric that computes quality-per-dollar, a ParetoAnalyzer
+// that identifies Pareto-optimal configurations, a BudgetAlert that fires
+// when evaluation cost exceeds a threshold, and a CostReport with optimization
+// recommendations.
+//
+// Key types:
+//   - CostMetric: Computes quality-per-dollar from quality score and token cost
+//   - ParetoAnalyzer: Identifies Pareto-optimal model configurations
+//   - BudgetAlert: Fires when cumulative cost exceeds a threshold
+//   - CostReport: Aggregated analysis with optimization recommendations
+package cost

--- a/eval/cost/pareto.go
+++ b/eval/cost/pareto.go
@@ -1,0 +1,85 @@
+package cost
+
+import (
+	"sort"
+)
+
+// ConfigResult represents a model configuration's evaluation result for
+// Pareto analysis.
+type ConfigResult struct {
+	// Name identifies the configuration (e.g., "gpt-4o", "claude-3-haiku").
+	Name string
+
+	// Quality is the average quality score in [0.0, 1.0].
+	Quality float64
+
+	// Cost is the total dollar cost of the evaluation run.
+	Cost float64
+}
+
+// ParetoResult contains the output of a Pareto analysis.
+type ParetoResult struct {
+	// Optimal contains the Pareto-optimal configurations. A configuration
+	// is Pareto-optimal if no other configuration has both higher quality
+	// and lower cost.
+	Optimal []ConfigResult
+
+	// Dominated contains configurations that are dominated by at least
+	// one optimal configuration.
+	Dominated []ConfigResult
+}
+
+// ParetoAnalyzer identifies Pareto-optimal model configurations from a set
+// of quality-cost pairs.
+type ParetoAnalyzer struct{}
+
+// NewParetoAnalyzer creates a new ParetoAnalyzer.
+func NewParetoAnalyzer() *ParetoAnalyzer {
+	return &ParetoAnalyzer{}
+}
+
+// Analyze finds the Pareto-optimal configurations. A configuration is
+// Pareto-optimal if no other configuration has strictly higher quality and
+// strictly lower (or equal) cost, or strictly lower cost and strictly higher
+// (or equal) quality.
+func (p *ParetoAnalyzer) Analyze(configs []ConfigResult) *ParetoResult {
+	if len(configs) == 0 {
+		return &ParetoResult{}
+	}
+
+	// Sort by cost ascending, then quality descending for stable output.
+	sorted := make([]ConfigResult, len(configs))
+	copy(sorted, configs)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Cost != sorted[j].Cost {
+			return sorted[i].Cost < sorted[j].Cost
+		}
+		return sorted[i].Quality > sorted[j].Quality
+	})
+
+	result := &ParetoResult{}
+
+	for i, c := range sorted {
+		dominated := false
+		for j, other := range sorted {
+			if i == j {
+				continue
+			}
+			// c is dominated if other has >= quality and <= cost, with at
+			// least one strict inequality.
+			if other.Quality >= c.Quality && other.Cost <= c.Cost {
+				if other.Quality > c.Quality || other.Cost < c.Cost {
+					dominated = true
+					break
+				}
+			}
+		}
+		if dominated {
+			result.Dominated = append(result.Dominated, c)
+		} else {
+			result.Optimal = append(result.Optimal, c)
+		}
+	}
+
+	return result
+}

--- a/eval/cost/report.go
+++ b/eval/cost/report.go
@@ -1,0 +1,142 @@
+package cost
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CostReport provides aggregated cost analysis with optimization
+// recommendations.
+type CostReport struct {
+	// TotalCost is the sum of all sample costs in dollars.
+	TotalCost float64
+
+	// AverageQuality is the mean quality score across all samples.
+	AverageQuality float64
+
+	// QualityPerDollar is the ratio of average quality to total cost.
+	QualityPerDollar float64
+
+	// ConfigResults contains per-configuration results used for analysis.
+	ConfigResults []ConfigResult
+
+	// ParetoOptimal contains the Pareto-optimal configurations.
+	ParetoOptimal []ConfigResult
+
+	// Recommendations contains human-readable optimization suggestions.
+	Recommendations []string
+}
+
+// GenerateReport creates a CostReport from a set of configuration results.
+// It runs Pareto analysis and generates optimization recommendations.
+func GenerateReport(configs []ConfigResult) *CostReport {
+	if len(configs) == 0 {
+		return &CostReport{}
+	}
+
+	report := &CostReport{
+		ConfigResults: configs,
+	}
+
+	// Compute totals.
+	var totalCost, totalQuality float64
+	for _, c := range configs {
+		totalCost += c.Cost
+		totalQuality += c.Quality
+	}
+	report.TotalCost = totalCost
+	report.AverageQuality = totalQuality / float64(len(configs))
+	if totalCost > 0 {
+		report.QualityPerDollar = report.AverageQuality / totalCost
+	}
+
+	// Run Pareto analysis.
+	analyzer := NewParetoAnalyzer()
+	paretoResult := analyzer.Analyze(configs)
+	report.ParetoOptimal = paretoResult.Optimal
+
+	// Generate recommendations.
+	report.Recommendations = generateRecommendations(configs, paretoResult)
+
+	return report
+}
+
+// String returns a formatted text representation of the report.
+func (r *CostReport) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Cost Report\n")
+	fmt.Fprintf(&b, "===========\n")
+	fmt.Fprintf(&b, "Total Cost:         $%.4f\n", r.TotalCost)
+	fmt.Fprintf(&b, "Average Quality:    %.3f\n", r.AverageQuality)
+	fmt.Fprintf(&b, "Quality per Dollar: %.2f\n", r.QualityPerDollar)
+
+	if len(r.ParetoOptimal) > 0 {
+		b.WriteString("\nPareto-Optimal Configurations:\n")
+		for _, c := range r.ParetoOptimal {
+			fmt.Fprintf(&b, "  - %s (quality=%.3f, cost=$%.4f)\n", c.Name, c.Quality, c.Cost)
+		}
+	}
+
+	if len(r.Recommendations) > 0 {
+		b.WriteString("\nRecommendations:\n")
+		for _, rec := range r.Recommendations {
+			fmt.Fprintf(&b, "  - %s\n", rec)
+		}
+	}
+
+	return b.String()
+}
+
+// generateRecommendations produces optimization suggestions from the analysis.
+func generateRecommendations(configs []ConfigResult, pareto *ParetoResult) []string {
+	var recs []string
+
+	if len(pareto.Dominated) > 0 {
+		names := make([]string, len(pareto.Dominated))
+		for i, c := range pareto.Dominated {
+			names[i] = c.Name
+		}
+		recs = append(recs, fmt.Sprintf(
+			"Consider removing dominated configurations: %s",
+			strings.Join(names, ", "),
+		))
+	}
+
+	// Find best quality-per-dollar among optimal configs.
+	var bestQPD float64
+	var bestName string
+	for _, c := range pareto.Optimal {
+		if c.Cost > 0 {
+			qpd := c.Quality / c.Cost
+			if qpd > bestQPD {
+				bestQPD = qpd
+				bestName = c.Name
+			}
+		}
+	}
+	if bestName != "" {
+		recs = append(recs, fmt.Sprintf(
+			"Best quality-per-dollar: %s (%.2f quality/$)",
+			bestName, bestQPD,
+		))
+	}
+
+	// Find cheapest option with quality above 0.7.
+	var cheapest *ConfigResult
+	for i := range configs {
+		c := configs[i]
+		if c.Quality >= 0.7 {
+			if cheapest == nil || c.Cost < cheapest.Cost {
+				cheapest = &c
+			}
+		}
+	}
+	if cheapest != nil {
+		recs = append(recs, fmt.Sprintf(
+			"Cheapest option with quality >= 0.7: %s ($%.4f, quality=%.3f)",
+			cheapest.Name, cheapest.Cost, cheapest.Quality,
+		))
+	}
+
+	return recs
+}


### PR DESCRIPTION
## Summary
- eval/cost package, CostMetric quality-per-dollar, ParetoAnalyzer, BudgetAlert, optimization recommendations

## Linear
- LOO-38: https://linear.app/lookatitude/issue/LOO-38

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)