### PR TITLE
LOO-39: LLM-as-Judge Evaluation

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -118,7 +118,9 @@ jobs:
           FAIL_COUNT=$(grep -c '"Action":"fail"' test-output.json 2>/dev/null || echo "0")
 
           if [ -f coverage.out ]; then
-            COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+            # Extract coverage percentage and truncate to integer to satisfy
+            # GITHUB_OUTPUT format requirements (decimal values are rejected).
+            COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%' | awk -F'.' '{print $1}')
           else
             COVERAGE="0"
           fi

--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -113,14 +113,24 @@ jobs:
         id: test_result
         if: always()
         run: |
-          TEST_COUNT=$(grep -c '"Test":' test-output.json 2>/dev/null | head -1 || echo "0")
-          PASS_COUNT=$(grep -c '"Action":"pass"' test-output.json 2>/dev/null || echo "0")
-          FAIL_COUNT=$(grep -c '"Action":"fail"' test-output.json 2>/dev/null || echo "0")
+          # Counts — use `|| true` to tolerate zero matches under pipefail,
+          # and `tr -dc '0-9'` to guarantee a single numeric token (no stray
+          # lines, no trailing newline) for downstream arithmetic and
+          # $GITHUB_OUTPUT formatting.
+          TEST_COUNT=$(grep -c '"Test":' test-output.json 2>/dev/null || true)
+          TEST_COUNT=$(printf '%s' "${TEST_COUNT}" | tr -dc '0-9')
+          TEST_COUNT=${TEST_COUNT:-0}
+          FAIL_COUNT=$(grep -c '"Action":"fail"' test-output.json 2>/dev/null || true)
+          FAIL_COUNT=$(printf '%s' "${FAIL_COUNT}" | tr -dc '0-9')
+          FAIL_COUNT=${FAIL_COUNT:-0}
 
           if [ -f coverage.out ]; then
-            # Extract coverage percentage and truncate to integer to satisfy
-            # GITHUB_OUTPUT format requirements (decimal values are rejected).
-            COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%' | awk -F'.' '{print $1}')
+            # Match only the final "total:" summary line — function names
+            # containing the substring "total" would otherwise produce a
+            # multi-line value and break $GITHUB_OUTPUT. Truncate the float
+            # to an integer because GHA rejects decimal values.
+            COVERAGE=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%","",$3); split($3,a,"."); print a[1]; exit}')
+            COVERAGE=${COVERAGE:-0}
           else
             COVERAGE="0"
           fi
@@ -170,8 +180,12 @@ jobs:
         id: integration_result
         if: always()
         run: |
-          TEST_COUNT=$(grep -c '"Test":' integration-output.json 2>/dev/null | head -1 || echo "0")
-          FAIL_COUNT=$(grep -c '"Action":"fail"' integration-output.json 2>/dev/null || echo "0")
+          TEST_COUNT=$(grep -c '"Test":' integration-output.json 2>/dev/null || true)
+          TEST_COUNT=$(printf '%s' "${TEST_COUNT}" | tr -dc '0-9')
+          TEST_COUNT=${TEST_COUNT:-0}
+          FAIL_COUNT=$(grep -c '"Action":"fail"' integration-output.json 2>/dev/null || true)
+          FAIL_COUNT=$(printf '%s' "${FAIL_COUNT}" | tr -dc '0-9')
+          FAIL_COUNT=${FAIL_COUNT:-0}
 
           if [ "$FAIL_COUNT" -gt 0 ]; then
             echo "status=failing" >> $GITHUB_OUTPUT

--- a/eval/judge/batch.go
+++ b/eval/judge/batch.go
@@ -80,14 +80,21 @@ func (b *BatchJudge) Evaluate(ctx context.Context, samples []eval.EvalSample) (*
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
+dispatch:
 	for i, sample := range samples {
 		if ctx.Err() != nil {
 			break
 		}
 
-		wg.Add(1)
-		sem <- struct{}{}
+		// Acquire a slot, respecting context cancellation so a cancelled
+		// context is noticed even when all parallel slots are in use.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break dispatch
+		}
 
+		wg.Add(1)
 		go func(idx int, s eval.EvalSample) {
 			defer wg.Done()
 			defer func() { <-sem }()

--- a/eval/judge/batch.go
+++ b/eval/judge/batch.go
@@ -1,0 +1,113 @@
+package judge
+
+import (
+	"context"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/eval"
+)
+
+// batchOptions holds configuration for BatchJudge.
+type batchOptions struct {
+	metric   *JudgeMetric
+	parallel int
+	onResult func(index int, score float64, err error)
+}
+
+// BatchOption configures a BatchJudge.
+type BatchOption func(*batchOptions)
+
+// WithJudgeMetric sets the JudgeMetric used for batch evaluation.
+func WithJudgeMetric(m *JudgeMetric) BatchOption {
+	return func(o *batchOptions) {
+		o.metric = m
+	}
+}
+
+// WithParallel sets the maximum number of concurrent evaluations.
+// Defaults to 4.
+func WithParallel(n int) BatchOption {
+	return func(o *batchOptions) {
+		if n > 0 {
+			o.parallel = n
+		}
+	}
+}
+
+// WithOnResult sets a callback invoked after each sample is scored.
+func WithOnResult(fn func(index int, score float64, err error)) BatchOption {
+	return func(o *batchOptions) {
+		o.onResult = fn
+	}
+}
+
+// BatchResult contains scores for a batch evaluation run.
+type BatchResult struct {
+	// Scores maps sample index to score. Missing entries indicate errors.
+	Scores map[int]float64
+
+	// Errors maps sample index to error for failed evaluations.
+	Errors map[int]error
+}
+
+// BatchJudge evaluates multiple samples concurrently with bounded parallelism.
+type BatchJudge struct {
+	opts batchOptions
+}
+
+// NewBatchJudge creates a new BatchJudge with the given options.
+func NewBatchJudge(opts ...BatchOption) (*BatchJudge, error) {
+	o := batchOptions{parallel: 4}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.metric == nil {
+		return nil, core.NewError("judge.batch.new", core.ErrInvalidInput, "judge metric is required", nil)
+	}
+	return &BatchJudge{opts: o}, nil
+}
+
+// Evaluate scores all samples concurrently using the configured JudgeMetric
+// and returns the aggregated results.
+func (b *BatchJudge) Evaluate(ctx context.Context, samples []eval.EvalSample) (*BatchResult, error) {
+	result := &BatchResult{
+		Scores: make(map[int]float64, len(samples)),
+		Errors: make(map[int]error),
+	}
+
+	sem := make(chan struct{}, b.opts.parallel)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i, sample := range samples {
+		if ctx.Err() != nil {
+			break
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+
+		go func(idx int, s eval.EvalSample) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			score, err := b.opts.metric.Score(ctx, s)
+
+			mu.Lock()
+			if err != nil {
+				result.Errors[idx] = err
+			} else {
+				result.Scores[idx] = score
+			}
+			mu.Unlock()
+
+			if b.opts.onResult != nil {
+				b.opts.onResult(idx, score, err)
+			}
+		}(i, sample)
+	}
+
+	wg.Wait()
+	return result, nil
+}

--- a/eval/judge/consistency.go
+++ b/eval/judge/consistency.go
@@ -1,0 +1,213 @@
+package judge
+
+import (
+	"context"
+	"math"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/eval"
+	"github.com/lookatitude/beluga-ai/llm"
+)
+
+// consistencyOptions holds configuration for ConsistencyChecker.
+type consistencyOptions struct {
+	rubric   *Rubric
+	models   []llm.ChatModel
+	repeats  int
+	parallel int
+}
+
+// ConsistencyOption configures a ConsistencyChecker.
+type ConsistencyOption func(*consistencyOptions)
+
+// WithConsistencyRubric sets the rubric used for consistency checking.
+func WithConsistencyRubric(r *Rubric) ConsistencyOption {
+	return func(o *consistencyOptions) {
+		o.rubric = r
+	}
+}
+
+// WithModels sets the LLM models used for cross-model agreement.
+func WithModels(models ...llm.ChatModel) ConsistencyOption {
+	return func(o *consistencyOptions) {
+		o.models = models
+	}
+}
+
+// WithRepeats sets how many times each model evaluates each sample.
+// Defaults to 3.
+func WithRepeats(n int) ConsistencyOption {
+	return func(o *consistencyOptions) {
+		if n > 0 {
+			o.repeats = n
+		}
+	}
+}
+
+// WithConsistencyParallel sets the concurrency limit for consistency checking.
+// Defaults to 2.
+func WithConsistencyParallel(n int) ConsistencyOption {
+	return func(o *consistencyOptions) {
+		if n > 0 {
+			o.parallel = n
+		}
+	}
+}
+
+// ConsistencyResult holds the results of a consistency check for a single sample.
+type ConsistencyResult struct {
+	// Scores maps model ID to the list of scores from repeated evaluations.
+	Scores map[string][]float64
+
+	// MeanScore is the overall mean across all models and repeats.
+	MeanScore float64
+
+	// StdDev is the standard deviation across all scores.
+	StdDev float64
+
+	// Agreement is the fraction of score pairs within 0.1 of each other,
+	// representing cross-model agreement. Range [0.0, 1.0].
+	Agreement float64
+}
+
+// ConsistencyChecker validates scoring reliability by running repeated
+// evaluations with one or more LLM judges and computing agreement metrics.
+type ConsistencyChecker struct {
+	opts consistencyOptions
+}
+
+// NewConsistencyChecker creates a new ConsistencyChecker with the given options.
+func NewConsistencyChecker(opts ...ConsistencyOption) (*ConsistencyChecker, error) {
+	o := consistencyOptions{
+		repeats:  3,
+		parallel: 2,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if len(o.models) == 0 {
+		return nil, core.NewError("judge.consistency.new", core.ErrInvalidInput, "at least one model is required", nil)
+	}
+	if o.rubric == nil {
+		return nil, core.NewError("judge.consistency.new", core.ErrInvalidInput, "rubric is required", nil)
+	}
+	if err := o.rubric.Validate(); err != nil {
+		return nil, core.NewError("judge.consistency.new", core.ErrInvalidInput, "invalid rubric", err)
+	}
+	return &ConsistencyChecker{opts: o}, nil
+}
+
+// Check evaluates a single sample with all models, each repeated the
+// configured number of times, and returns agreement metrics.
+func (c *ConsistencyChecker) Check(ctx context.Context, sample eval.EvalSample) (*ConsistencyResult, error) {
+	type scoreEntry struct {
+		modelID string
+		score   float64
+		err     error
+	}
+
+	results := make(chan scoreEntry, len(c.opts.models)*c.opts.repeats)
+	sem := make(chan struct{}, c.opts.parallel)
+	var wg sync.WaitGroup
+
+	for _, model := range c.opts.models {
+		metric, err := NewJudgeMetric(
+			WithModel(model),
+			WithRubric(c.opts.rubric),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for r := 0; r < c.opts.repeats; r++ {
+			wg.Add(1)
+			sem <- struct{}{}
+
+			go func(m llm.ChatModel, jm *JudgeMetric) {
+				defer wg.Done()
+				defer func() { <-sem }()
+
+				score, err := jm.Score(ctx, sample)
+				results <- scoreEntry{modelID: m.ModelID(), score: score, err: err}
+			}(model, metric)
+		}
+	}
+
+	wg.Wait()
+	close(results)
+
+	scoresByModel := make(map[string][]float64)
+	var allScores []float64
+
+	for entry := range results {
+		if entry.err != nil {
+			continue
+		}
+		scoresByModel[entry.modelID] = append(scoresByModel[entry.modelID], entry.score)
+		allScores = append(allScores, entry.score)
+	}
+
+	if len(allScores) == 0 {
+		return nil, core.NewError("judge.consistency.check", core.ErrToolFailed, "all evaluations failed", nil)
+	}
+
+	mean := computeMean(allScores)
+	stddev := computeStdDev(allScores, mean)
+	agreement := computeAgreement(allScores)
+
+	return &ConsistencyResult{
+		Scores:    scoresByModel,
+		MeanScore: mean,
+		StdDev:    stddev,
+		Agreement: agreement,
+	}, nil
+}
+
+// computeMean returns the arithmetic mean of scores.
+func computeMean(scores []float64) float64 {
+	if len(scores) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, s := range scores {
+		sum += s
+	}
+	return sum / float64(len(scores))
+}
+
+// computeStdDev returns the population standard deviation.
+func computeStdDev(scores []float64, mean float64) float64 {
+	if len(scores) == 0 {
+		return 0
+	}
+	var sumSq float64
+	for _, s := range scores {
+		d := s - mean
+		sumSq += d * d
+	}
+	return math.Sqrt(sumSq / float64(len(scores)))
+}
+
+// computeAgreement returns the fraction of all score pairs within 0.1 of
+// each other.
+func computeAgreement(scores []float64) float64 {
+	n := len(scores)
+	if n < 2 {
+		return 1.0
+	}
+	total := 0
+	agree := 0
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			total++
+			if math.Abs(scores[i]-scores[j]) <= 0.1 {
+				agree++
+			}
+		}
+	}
+	if total == 0 {
+		return 1.0
+	}
+	return float64(agree) / float64(total)
+}

--- a/eval/judge/consistency.go
+++ b/eval/judge/consistency.go
@@ -107,23 +107,38 @@ func (c *ConsistencyChecker) Check(ctx context.Context, sample eval.EvalSample) 
 		err     error
 	}
 
-	results := make(chan scoreEntry, len(c.opts.models)*c.opts.repeats)
-	sem := make(chan struct{}, c.opts.parallel)
-	var wg sync.WaitGroup
-
-	for _, model := range c.opts.models {
-		metric, err := NewJudgeMetric(
+	// Build all JudgeMetric instances eagerly before launching any goroutines
+	// so that a construction failure for a later model does not leave earlier
+	// goroutines running unobserved LLM calls.
+	metrics := make([]*JudgeMetric, len(c.opts.models))
+	for i, model := range c.opts.models {
+		m, err := NewJudgeMetric(
 			WithModel(model),
 			WithRubric(c.opts.rubric),
 		)
 		if err != nil {
 			return nil, err
 		}
+		metrics[i] = m
+	}
 
+	results := make(chan scoreEntry, len(c.opts.models)*c.opts.repeats)
+	sem := make(chan struct{}, c.opts.parallel)
+	var wg sync.WaitGroup
+
+dispatch:
+	for i, model := range c.opts.models {
+		metric := metrics[i]
 		for r := 0; r < c.opts.repeats; r++ {
-			wg.Add(1)
-			sem <- struct{}{}
+			// Acquire a slot, respecting context cancellation so a cancelled
+			// context is noticed even when all parallel slots are in use.
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				break dispatch
+			}
 
+			wg.Add(1)
 			go func(m llm.ChatModel, jm *JudgeMetric) {
 				defer wg.Done()
 				defer func() { <-sem }()

--- a/eval/judge/doc.go
+++ b/eval/judge/doc.go
@@ -1,0 +1,13 @@
+// Package judge provides LLM-as-Judge evaluation capabilities.
+//
+// It implements eval.Metric using an LLM to score samples against structured
+// rubrics. BatchJudge enables concurrent evaluation with rate limiting, and
+// ConsistencyChecker validates scoring reliability through repeated evaluation
+// and cross-model agreement analysis.
+//
+// Key types:
+//   - JudgeMetric: Evaluates samples using an LLM judge and a rubric
+//   - Rubric: Defines scoring criteria with levels and weights
+//   - BatchJudge: Concurrent evaluation with bounded parallelism
+//   - ConsistencyChecker: Repeated eval + cross-model agreement
+package judge

--- a/eval/judge/judge.go
+++ b/eval/judge/judge.go
@@ -1,0 +1,185 @@
+package judge
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/core"
+	"github.com/lookatitude/beluga-ai/eval"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+const judgePromptTemplate = `You are an expert evaluation judge. Score the following AI-generated response using the rubric below.
+
+%s
+
+Input/Question: %s
+
+AI Response: %s
+
+%s
+
+For each criterion, respond with ONLY the criterion name followed by a colon and the numeric score.
+Example format:
+accuracy: 0.8
+clarity: 1.0
+
+Respond with scores for ALL criteria, one per line.`
+
+// Compile-time interface check.
+var _ eval.Metric = (*JudgeMetric)(nil)
+
+// judgeOptions holds configuration for JudgeMetric.
+type judgeOptions struct {
+	rubric     *Rubric
+	model      llm.ChatModel
+	metricName string
+	systemMsg  string
+}
+
+// JudgeOption configures a JudgeMetric.
+type JudgeOption func(*judgeOptions)
+
+// WithRubric sets the evaluation rubric.
+func WithRubric(r *Rubric) JudgeOption {
+	return func(o *judgeOptions) {
+		o.rubric = r
+	}
+}
+
+// WithModel sets the LLM used as judge.
+func WithModel(m llm.ChatModel) JudgeOption {
+	return func(o *judgeOptions) {
+		o.model = m
+	}
+}
+
+// WithMetricName sets the name returned by Name(). Defaults to "judge".
+func WithMetricName(name string) JudgeOption {
+	return func(o *judgeOptions) {
+		o.metricName = name
+	}
+}
+
+// WithSystemMessage sets an optional system message prepended to the judge prompt.
+func WithSystemMessage(msg string) JudgeOption {
+	return func(o *judgeOptions) {
+		o.systemMsg = msg
+	}
+}
+
+// JudgeMetric evaluates samples using an LLM as judge against a structured
+// rubric. It implements eval.Metric, returning a weighted average score
+// across all rubric criteria.
+type JudgeMetric struct {
+	opts judgeOptions
+}
+
+// NewJudgeMetric creates a new JudgeMetric with the given options.
+func NewJudgeMetric(opts ...JudgeOption) (*JudgeMetric, error) {
+	o := judgeOptions{metricName: "judge"}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.model == nil {
+		return nil, core.NewError("judge.new", core.ErrInvalidInput, "model is required", nil)
+	}
+	if o.rubric == nil {
+		return nil, core.NewError("judge.new", core.ErrInvalidInput, "rubric is required", nil)
+	}
+	if err := o.rubric.Validate(); err != nil {
+		return nil, core.NewError("judge.new", core.ErrInvalidInput, "invalid rubric", err)
+	}
+	return &JudgeMetric{opts: o}, nil
+}
+
+// Name returns the metric name.
+func (j *JudgeMetric) Name() string { return j.opts.metricName }
+
+// Score evaluates a single sample using the LLM judge and returns a weighted
+// average score in [0.0, 1.0].
+func (j *JudgeMetric) Score(ctx context.Context, sample eval.EvalSample) (float64, error) {
+	expectedCtx := ""
+	if sample.ExpectedOutput != "" {
+		expectedCtx = fmt.Sprintf("Expected/Reference Answer: %s", sample.ExpectedOutput)
+	}
+
+	prompt := fmt.Sprintf(judgePromptTemplate,
+		j.opts.rubric.ToPrompt(),
+		sample.Input,
+		sample.Output,
+		expectedCtx,
+	)
+
+	var msgs []schema.Message
+	if j.opts.systemMsg != "" {
+		msgs = append(msgs, schema.NewSystemMessage(j.opts.systemMsg))
+	}
+	msgs = append(msgs, schema.NewHumanMessage(prompt))
+
+	resp, err := j.opts.model.Generate(ctx, msgs)
+	if err != nil {
+		return 0, fmt.Errorf("judge: llm generate: %w", err)
+	}
+
+	scores, err := parseJudgeResponse(resp.Text(), j.opts.rubric)
+	if err != nil {
+		return 0, fmt.Errorf("judge: parse response: %w", err)
+	}
+
+	return weightedAverage(scores, j.opts.rubric), nil
+}
+
+// parseJudgeResponse extracts per-criterion scores from the LLM response.
+func parseJudgeResponse(text string, rubric *Rubric) (map[string]float64, error) {
+	scores := make(map[string]float64)
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		valStr := strings.TrimSpace(parts[1])
+		val, err := strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			continue
+		}
+		if val < 0 {
+			val = 0
+		}
+		if val > 1 {
+			val = 1
+		}
+		scores[name] = val
+	}
+
+	// Verify we got scores for all criteria.
+	for _, c := range rubric.Criteria {
+		if _, ok := scores[c.Name]; !ok {
+			return nil, fmt.Errorf("missing score for criterion %q", c.Name)
+		}
+	}
+	return scores, nil
+}
+
+// weightedAverage computes the weighted average across all criteria.
+func weightedAverage(scores map[string]float64, rubric *Rubric) float64 {
+	totalWeight := rubric.totalWeight()
+	if totalWeight == 0 {
+		return 0
+	}
+	var sum float64
+	for _, c := range rubric.Criteria {
+		sum += scores[c.Name] * c.Weight
+	}
+	return sum / totalWeight
+}

--- a/eval/judge/judge.go
+++ b/eval/judge/judge.go
@@ -122,12 +122,12 @@ func (j *JudgeMetric) Score(ctx context.Context, sample eval.EvalSample) (float6
 
 	resp, err := j.opts.model.Generate(ctx, msgs)
 	if err != nil {
-		return 0, fmt.Errorf("judge: llm generate: %w", err)
+		return 0, core.NewError("judge.score", core.ErrToolFailed, "llm generate failed", err)
 	}
 
 	scores, err := parseJudgeResponse(resp.Text(), j.opts.rubric)
 	if err != nil {
-		return 0, fmt.Errorf("judge: parse response: %w", err)
+		return 0, core.NewError("judge.score", core.ErrInvalidInput, "parse response failed", err)
 	}
 
 	return weightedAverage(scores, j.opts.rubric), nil

--- a/eval/judge/judge_test.go
+++ b/eval/judge/judge_test.go
@@ -194,6 +194,35 @@ func TestRubric_Validate(t *testing.T) {
 			}},
 			wantErr: true,
 		},
+		{
+			name: "duplicate criterion name",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "a", Weight: 1, Levels: []ScoreLevel{{Label: "x", Score: 0.5}}},
+				{Name: "a", Weight: 1, Levels: []ScoreLevel{{Label: "y", Score: 0.5}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "score level above 1",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "a", Weight: 1, Levels: []ScoreLevel{{Label: "x", Score: 1.5}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "score level below 0",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "a", Weight: 1, Levels: []ScoreLevel{{Label: "x", Score: -0.1}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "empty criterion name",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "", Weight: 1, Levels: []ScoreLevel{{Label: "x", Score: 0.5}}},
+			}},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,6 +288,31 @@ func TestBatchJudge_OnResultCallback(t *testing.T) {
 	_, err = batch.Evaluate(context.Background(), []eval.EvalSample{{Input: "q", Output: "a"}})
 	require.NoError(t, err)
 	assert.Equal(t, 1, callbackCount)
+}
+
+func TestBatchJudge_ContextCancellation(t *testing.T) {
+	model := newMock(mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.5\nclarity: 0.5")))
+	jm, err := NewJudgeMetric(WithModel(model), WithRubric(testRubric()))
+	require.NoError(t, err)
+
+	// Use parallelism 1 so the semaphore is contended, exercising the
+	// select-on-ctx.Done() path in the dispatch loop.
+	batch, err := NewBatchJudge(WithJudgeMetric(jm), WithParallel(1))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately so dispatch sees it.
+
+	samples := []eval.EvalSample{
+		{Input: "q1", Output: "a1"},
+		{Input: "q2", Output: "a2"},
+	}
+
+	// Should complete without blocking or panicking even when context is cancelled.
+	result, err := batch.Evaluate(ctx, samples)
+	require.NoError(t, err) // Evaluate always returns nil error.
+	// At least no samples should fail due to panics; partial results are fine.
+	assert.NotNil(t, result)
 }
 
 func TestConsistencyChecker_Check(t *testing.T) {

--- a/eval/judge/judge_test.go
+++ b/eval/judge/judge_test.go
@@ -1,0 +1,368 @@
+package judge
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/eval"
+	"github.com/lookatitude/beluga-ai/internal/testutil/mockllm"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockChatModel adapts mockllm.MockChatModel to llm.ChatModel.
+type mockChatModel struct {
+	*mockllm.MockChatModel
+}
+
+func (m *mockChatModel) Generate(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) (*schema.AIMessage, error) {
+	return m.MockChatModel.Generate(ctx, msgs)
+}
+
+func (m *mockChatModel) Stream(ctx context.Context, msgs []schema.Message, opts ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
+	return m.MockChatModel.Stream(ctx, msgs)
+}
+
+func (m *mockChatModel) BindTools(tools []schema.ToolDefinition) llm.ChatModel {
+	return &mockChatModel{m.MockChatModel.BindTools(tools)}
+}
+
+func newMock(opts ...mockllm.Option) *mockChatModel {
+	return &mockChatModel{mockllm.New(opts...)}
+}
+
+func testRubric() *Rubric {
+	return &Rubric{
+		Name:        "test-rubric",
+		Description: "A test rubric",
+		Criteria: []Criterion{
+			{
+				Name:        "accuracy",
+				Description: "How accurate is the response",
+				Weight:      2.0,
+				Levels: []ScoreLevel{
+					{Label: "poor", Score: 0.0, Description: "Inaccurate"},
+					{Label: "good", Score: 0.5, Description: "Partially accurate"},
+					{Label: "excellent", Score: 1.0, Description: "Fully accurate"},
+				},
+			},
+			{
+				Name:        "clarity",
+				Description: "How clear is the response",
+				Weight:      1.0,
+				Levels: []ScoreLevel{
+					{Label: "poor", Score: 0.0, Description: "Unclear"},
+					{Label: "excellent", Score: 1.0, Description: "Clear"},
+				},
+			},
+		},
+	}
+}
+
+func TestJudgeMetric_Name(t *testing.T) {
+	model := newMock(mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.8\nclarity: 0.9")))
+	jm, err := NewJudgeMetric(WithModel(model), WithRubric(testRubric()), WithMetricName("my-judge"))
+	require.NoError(t, err)
+	assert.Equal(t, "my-judge", jm.Name())
+}
+
+func TestJudgeMetric_Score(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantScore float64
+		wantErr   bool
+		modelErr  error
+		tolerance float64
+	}{
+		{
+			name:      "perfect scores",
+			response:  "accuracy: 1.0\nclarity: 1.0",
+			wantScore: 1.0,
+			tolerance: 0.001,
+		},
+		{
+			name:      "weighted average",
+			response:  "accuracy: 0.8\nclarity: 0.5",
+			wantScore: (0.8*2.0 + 0.5*1.0) / 3.0, // ~0.7
+			tolerance: 0.001,
+		},
+		{
+			name:      "zero scores",
+			response:  "accuracy: 0.0\nclarity: 0.0",
+			wantScore: 0.0,
+			tolerance: 0.001,
+		},
+		{
+			name:     "missing criterion",
+			response: "accuracy: 0.8",
+			wantErr:  true,
+		},
+		{
+			name:     "llm error",
+			modelErr: errors.New("api error"),
+			wantErr:  true,
+		},
+		{
+			name:      "clamp scores above 1",
+			response:  "accuracy: 1.5\nclarity: 0.5",
+			wantScore: (1.0*2.0 + 0.5*1.0) / 3.0,
+			tolerance: 0.001,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []mockllm.Option
+			if tt.modelErr != nil {
+				opts = append(opts, mockllm.WithError(tt.modelErr))
+			} else {
+				opts = append(opts, mockllm.WithResponse(schema.NewAIMessage(tt.response)))
+			}
+			model := newMock(opts...)
+			jm, err := NewJudgeMetric(WithModel(model), WithRubric(testRubric()))
+			require.NoError(t, err)
+
+			score, err := jm.Score(context.Background(), eval.EvalSample{
+				Input:  "What is Go?",
+				Output: "Go is a programming language.",
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, tt.wantScore, score, tt.tolerance)
+		})
+	}
+}
+
+func TestNewJudgeMetric_Validation(t *testing.T) {
+	model := newMock()
+
+	t.Run("no model", func(t *testing.T) {
+		_, err := NewJudgeMetric(WithRubric(testRubric()))
+		require.Error(t, err)
+	})
+
+	t.Run("no rubric", func(t *testing.T) {
+		_, err := NewJudgeMetric(WithModel(model))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid rubric", func(t *testing.T) {
+		_, err := NewJudgeMetric(WithModel(model), WithRubric(&Rubric{Name: ""}))
+		require.Error(t, err)
+	})
+}
+
+func TestRubric_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		rubric  *Rubric
+		wantErr bool
+	}{
+		{
+			name:   "valid rubric",
+			rubric: testRubric(),
+		},
+		{
+			name:    "empty name",
+			rubric:  &Rubric{Name: "", Criteria: []Criterion{{Name: "a", Weight: 1, Levels: []ScoreLevel{{Label: "x", Score: 1}}}}},
+			wantErr: true,
+		},
+		{
+			name:    "no criteria",
+			rubric:  &Rubric{Name: "test"},
+			wantErr: true,
+		},
+		{
+			name: "zero weight",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "a", Weight: 0, Levels: []ScoreLevel{{Label: "x", Score: 1}}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "no levels",
+			rubric: &Rubric{Name: "test", Criteria: []Criterion{
+				{Name: "a", Weight: 1},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rubric.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRubric_ToPrompt(t *testing.T) {
+	rubric := testRubric()
+	prompt := rubric.ToPrompt()
+	assert.Contains(t, prompt, "test-rubric")
+	assert.Contains(t, prompt, "accuracy")
+	assert.Contains(t, prompt, "clarity")
+	assert.Contains(t, prompt, "excellent")
+}
+
+func TestBatchJudge_Evaluate(t *testing.T) {
+	model := newMock(mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.9\nclarity: 0.8")))
+	jm, err := NewJudgeMetric(WithModel(model), WithRubric(testRubric()))
+	require.NoError(t, err)
+
+	batch, err := NewBatchJudge(WithJudgeMetric(jm), WithParallel(2))
+	require.NoError(t, err)
+
+	samples := []eval.EvalSample{
+		{Input: "q1", Output: "a1"},
+		{Input: "q2", Output: "a2"},
+		{Input: "q3", Output: "a3"},
+	}
+
+	result, err := batch.Evaluate(context.Background(), samples)
+	require.NoError(t, err)
+	assert.Len(t, result.Scores, 3)
+	assert.Empty(t, result.Errors)
+}
+
+func TestBatchJudge_NoMetric(t *testing.T) {
+	_, err := NewBatchJudge()
+	require.Error(t, err)
+}
+
+func TestBatchJudge_OnResultCallback(t *testing.T) {
+	model := newMock(mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.5\nclarity: 0.5")))
+	jm, err := NewJudgeMetric(WithModel(model), WithRubric(testRubric()))
+	require.NoError(t, err)
+
+	var callbackCount int
+	batch, err := NewBatchJudge(
+		WithJudgeMetric(jm),
+		WithOnResult(func(index int, score float64, err error) {
+			callbackCount++
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = batch.Evaluate(context.Background(), []eval.EvalSample{{Input: "q", Output: "a"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, callbackCount)
+}
+
+func TestConsistencyChecker_Check(t *testing.T) {
+	model1 := newMock(
+		mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.8\nclarity: 0.9")),
+		mockllm.WithModelID("model-1"),
+	)
+	model2 := newMock(
+		mockllm.WithResponse(schema.NewAIMessage("accuracy: 0.8\nclarity: 0.9")),
+		mockllm.WithModelID("model-2"),
+	)
+
+	checker, err := NewConsistencyChecker(
+		WithConsistencyRubric(testRubric()),
+		WithModels(model1, model2),
+		WithRepeats(2),
+		WithConsistencyParallel(2),
+	)
+	require.NoError(t, err)
+
+	result, err := checker.Check(context.Background(), eval.EvalSample{
+		Input:  "What is Go?",
+		Output: "Go is a programming language.",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.MeanScore > 0)
+	assert.True(t, result.Agreement > 0)
+	assert.Len(t, result.Scores, 2)
+}
+
+func TestConsistencyChecker_Validation(t *testing.T) {
+	model := newMock()
+
+	t.Run("no models", func(t *testing.T) {
+		_, err := NewConsistencyChecker(WithConsistencyRubric(testRubric()))
+		require.Error(t, err)
+	})
+
+	t.Run("no rubric", func(t *testing.T) {
+		_, err := NewConsistencyChecker(WithModels(model))
+		require.Error(t, err)
+	})
+}
+
+func TestComputeAgreement(t *testing.T) {
+	tests := []struct {
+		name   string
+		scores []float64
+		want   float64
+	}{
+		{"single score", []float64{0.5}, 1.0},
+		{"identical", []float64{0.5, 0.5, 0.5}, 1.0},
+		{"within threshold", []float64{0.5, 0.55, 0.6}, 1.0},
+		{"mixed agreement", []float64{0.0, 0.5, 1.0}, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeAgreement(tt.scores)
+			assert.InDelta(t, tt.want, got, 0.01)
+		})
+	}
+}
+
+func TestParseJudgeResponse(t *testing.T) {
+	rubric := testRubric()
+
+	tests := []struct {
+		name    string
+		text    string
+		want    map[string]float64
+		wantErr bool
+	}{
+		{
+			name: "valid response",
+			text: "accuracy: 0.8\nclarity: 0.9",
+			want: map[string]float64{"accuracy": 0.8, "clarity": 0.9},
+		},
+		{
+			name: "with extra whitespace",
+			text: "  accuracy : 0.8 \n  clarity : 0.9  \n",
+			want: map[string]float64{"accuracy": 0.8, "clarity": 0.9},
+		},
+		{
+			name:    "missing criterion",
+			text:    "accuracy: 0.8",
+			wantErr: true,
+		},
+		{
+			name: "ignores unparseable lines",
+			text: "Some preamble\naccuracy: 0.8\nclarity: 0.9\nDone!",
+			want: map[string]float64{"accuracy": 0.8, "clarity": 0.9},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseJudgeResponse(tt.text, rubric)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/eval/judge/rubric.go
+++ b/eval/judge/rubric.go
@@ -57,10 +57,15 @@ func (r *Rubric) Validate() error {
 	if len(r.Criteria) == 0 {
 		return fmt.Errorf("rubric %q must have at least one criterion", r.Name)
 	}
+	seen := make(map[string]bool, len(r.Criteria))
 	for _, c := range r.Criteria {
 		if c.Name == "" {
 			return fmt.Errorf("rubric %q: criterion name must not be empty", r.Name)
 		}
+		if seen[c.Name] {
+			return fmt.Errorf("rubric %q: duplicate criterion name %q", r.Name, c.Name)
+		}
+		seen[c.Name] = true
 		if c.Weight <= 0 {
 			return fmt.Errorf("rubric %q: criterion %q weight must be positive, got %f", r.Name, c.Name, c.Weight)
 		}

--- a/eval/judge/rubric.go
+++ b/eval/judge/rubric.go
@@ -72,6 +72,11 @@ func (r *Rubric) Validate() error {
 		if len(c.Levels) == 0 {
 			return fmt.Errorf("rubric %q: criterion %q must have at least one level", r.Name, c.Name)
 		}
+		for _, l := range c.Levels {
+			if l.Score < 0 || l.Score > 1 {
+				return fmt.Errorf("rubric %q: criterion %q level %q score %f out of [0,1]", r.Name, c.Name, l.Label, l.Score)
+			}
+		}
 	}
 	return nil
 }

--- a/eval/judge/rubric.go
+++ b/eval/judge/rubric.go
@@ -1,0 +1,102 @@
+package judge
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ScoreLevel defines a named score level within a criterion, such as
+// "excellent" = 1.0 or "poor" = 0.0.
+type ScoreLevel struct {
+	// Label is a human-readable name for this level (e.g., "excellent", "poor").
+	Label string
+
+	// Score is the numeric value for this level, in [0.0, 1.0].
+	Score float64
+
+	// Description explains what qualifies for this level.
+	Description string
+}
+
+// Criterion defines a single evaluation dimension with weighted score levels.
+type Criterion struct {
+	// Name identifies this criterion (e.g., "accuracy", "clarity").
+	Name string
+
+	// Description explains what this criterion measures.
+	Description string
+
+	// Weight is the relative importance of this criterion. Weights are
+	// normalized across all criteria in a rubric.
+	Weight float64
+
+	// Levels defines the possible score levels for this criterion,
+	// ordered from lowest to highest.
+	Levels []ScoreLevel
+}
+
+// Rubric defines a complete evaluation rubric with multiple weighted criteria.
+// Each criterion has score levels that the LLM judge selects from.
+type Rubric struct {
+	// Name identifies this rubric.
+	Name string
+
+	// Description provides context for the LLM judge about what is being evaluated.
+	Description string
+
+	// Criteria contains the evaluation dimensions.
+	Criteria []Criterion
+}
+
+// Validate checks that the rubric is well-formed: non-empty name, at least
+// one criterion, each criterion has at least one level, and weights are positive.
+func (r *Rubric) Validate() error {
+	if r.Name == "" {
+		return fmt.Errorf("rubric name must not be empty")
+	}
+	if len(r.Criteria) == 0 {
+		return fmt.Errorf("rubric %q must have at least one criterion", r.Name)
+	}
+	for _, c := range r.Criteria {
+		if c.Name == "" {
+			return fmt.Errorf("rubric %q: criterion name must not be empty", r.Name)
+		}
+		if c.Weight <= 0 {
+			return fmt.Errorf("rubric %q: criterion %q weight must be positive, got %f", r.Name, c.Name, c.Weight)
+		}
+		if len(c.Levels) == 0 {
+			return fmt.Errorf("rubric %q: criterion %q must have at least one level", r.Name, c.Name)
+		}
+	}
+	return nil
+}
+
+// ToPrompt renders the rubric as a text prompt suitable for an LLM judge.
+func (r *Rubric) ToPrompt() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Evaluation Rubric: %s\n", r.Name)
+	if r.Description != "" {
+		fmt.Fprintf(&b, "%s\n", r.Description)
+	}
+	b.WriteString("\nCriteria:\n")
+	for i, c := range r.Criteria {
+		fmt.Fprintf(&b, "\n%d. %s (weight: %.1f)\n", i+1, c.Name, c.Weight)
+		if c.Description != "" {
+			fmt.Fprintf(&b, "   %s\n", c.Description)
+		}
+		b.WriteString("   Score levels:\n")
+		for _, l := range c.Levels {
+			fmt.Fprintf(&b, "   - %s (%.1f): %s\n", l.Label, l.Score, l.Description)
+		}
+	}
+	return b.String()
+}
+
+// totalWeight returns the sum of all criterion weights.
+func (r *Rubric) totalWeight() float64 {
+	var total float64
+	for _, c := range r.Criteria {
+		total += c.Weight
+	}
+	return total
+}


### PR DESCRIPTION
## Summary
- eval/judge package, Rubric with criteria, JudgeMetric, BatchJudge, ConsistencyChecker (cross-model agreement)

## Linear
- LOO-39: https://linear.app/lookatitude/issue/LOO-39

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)