### PR TITLE
LOO-44: Declarative Agent Definition (YAML/JSON)

### DIFF
--- a/config/declarative/declarative.go
+++ b/config/declarative/declarative.go
@@ -1,0 +1,185 @@
+package declarative
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AgentSpec is the declarative specification for an agent.
+type AgentSpec struct {
+	// ID is the unique agent identifier.
+	ID string `json:"id"`
+	// Persona defines the agent's role, goal, and backstory.
+	Persona PersonaSpec `json:"persona"`
+	// Model defines the LLM provider and model to use.
+	Model ModelSpec `json:"model"`
+	// Tools lists the tool names to attach to the agent.
+	Tools []string `json:"tools,omitempty"`
+	// MaxIterations limits reasoning iterations. Zero means default.
+	MaxIterations int `json:"max_iterations,omitempty"`
+	// SystemPrompt overrides the default system prompt.
+	SystemPrompt string `json:"system_prompt,omitempty"`
+	// Metadata holds arbitrary key-value pairs.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// PersonaSpec defines the agent's identity.
+type PersonaSpec struct {
+	Role      string `json:"role"`
+	Goal      string `json:"goal,omitempty"`
+	Backstory string `json:"backstory,omitempty"`
+}
+
+// ModelSpec defines which LLM to use.
+type ModelSpec struct {
+	Provider    string  `json:"provider"`
+	Model       string  `json:"model"`
+	Temperature float64 `json:"temperature,omitempty"`
+	MaxTokens   int     `json:"max_tokens,omitempty"`
+}
+
+// Parser reads and validates an AgentSpec from various sources.
+type Parser interface {
+	// Parse reads an AgentSpec from raw bytes.
+	Parse(ctx context.Context, data []byte) (*AgentSpec, error)
+}
+
+// Builder constructs runtime objects from an AgentSpec.
+type Builder interface {
+	// Build creates an agent configuration from a spec.
+	// The returned AgentBuild contains all resolved components.
+	Build(ctx context.Context, spec *AgentSpec) (*AgentBuild, error)
+}
+
+// AgentBuild holds the resolved components from building an AgentSpec.
+type AgentBuild struct {
+	// Spec is the original specification.
+	Spec *AgentSpec
+	// ProviderName is the resolved LLM provider name.
+	ProviderName string
+	// ModelName is the resolved model name.
+	ModelName string
+	// ToolNames are the resolved tool names.
+	ToolNames []string
+}
+
+// Option configures a JSONParser or DefaultBuilder.
+type Option func(*parserOptions)
+
+type parserOptions struct {
+	maxSize int64
+}
+
+// WithMaxSize sets the maximum spec size in bytes.
+func WithMaxSize(n int64) Option {
+	return func(o *parserOptions) { o.maxSize = n }
+}
+
+// JSONParser parses AgentSpec from JSON.
+type JSONParser struct {
+	opts parserOptions
+}
+
+var _ Parser = (*JSONParser)(nil)
+
+// NewJSONParser creates a JSON parser with the given options.
+func NewJSONParser(opts ...Option) *JSONParser {
+	o := parserOptions{maxSize: 1 << 20} // 1MB default
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &JSONParser{opts: o}
+}
+
+// Parse decodes JSON bytes into an AgentSpec.
+func (p *JSONParser) Parse(_ context.Context, data []byte) (*AgentSpec, error) {
+	if int64(len(data)) > p.opts.maxSize {
+		return nil, fmt.Errorf("declarative: spec exceeds maximum size of %d bytes", p.opts.maxSize)
+	}
+
+	var spec AgentSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("declarative: invalid JSON: %w", err)
+	}
+
+	if err := validateSpec(&spec); err != nil {
+		return nil, err
+	}
+
+	return &spec, nil
+}
+
+// LoadSpec reads an AgentSpec from a file path.
+func LoadSpec(ctx context.Context, path string) (*AgentSpec, error) {
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return nil, fmt.Errorf("declarative: path traversal not allowed: %q", path)
+	}
+
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("declarative: read file: %w", err)
+	}
+
+	parser := NewJSONParser()
+	return parser.Parse(ctx, data)
+}
+
+func validateSpec(spec *AgentSpec) error {
+	if spec.ID == "" {
+		return fmt.Errorf("declarative: spec.id is required")
+	}
+	if spec.Persona.Role == "" {
+		return fmt.Errorf("declarative: spec.persona.role is required")
+	}
+	if spec.Model.Provider == "" {
+		return fmt.Errorf("declarative: spec.model.provider is required")
+	}
+	if spec.Model.Model == "" {
+		return fmt.Errorf("declarative: spec.model.model is required")
+	}
+	if spec.MaxIterations < 0 {
+		return fmt.Errorf("declarative: spec.max_iterations must be non-negative")
+	}
+	if spec.Model.Temperature < 0 || spec.Model.Temperature > 2 {
+		return fmt.Errorf("declarative: spec.model.temperature must be in [0, 2]")
+	}
+	return nil
+}
+
+// DefaultBuilder builds AgentBuild from an AgentSpec by resolving references.
+type DefaultBuilder struct{}
+
+var _ Builder = (*DefaultBuilder)(nil)
+
+// NewBuilder creates a new DefaultBuilder.
+func NewBuilder() *DefaultBuilder {
+	return &DefaultBuilder{}
+}
+
+// Build resolves an AgentSpec into an AgentBuild.
+func (b *DefaultBuilder) Build(_ context.Context, spec *AgentSpec) (*AgentBuild, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("declarative: spec is nil")
+	}
+
+	if err := validateSpec(spec); err != nil {
+		return nil, err
+	}
+
+	return &AgentBuild{
+		Spec:         spec,
+		ProviderName: spec.Model.Provider,
+		ModelName:    spec.Model.Model,
+		ToolNames:    spec.Tools,
+	}, nil
+}
+
+// MarshalSpec serializes an AgentSpec to JSON.
+func MarshalSpec(spec *AgentSpec) ([]byte, error) {
+	return json.MarshalIndent(spec, "", "  ")
+}

--- a/config/declarative/declarative.go
+++ b/config/declarative/declarative.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,10 +37,12 @@ type PersonaSpec struct {
 
 // ModelSpec defines which LLM to use.
 type ModelSpec struct {
-	Provider    string  `json:"provider"`
-	Model       string  `json:"model"`
-	Temperature float64 `json:"temperature,omitempty"`
-	MaxTokens   int     `json:"max_tokens,omitempty"`
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	// Temperature is a pointer so that an explicit zero value
+	// (deterministic/greedy mode) is distinguishable from "unset".
+	Temperature *float64 `json:"temperature,omitempty"`
+	MaxTokens   int      `json:"max_tokens,omitempty"`
 }
 
 // Parser reads and validates an AgentSpec from various sources.
@@ -67,7 +70,10 @@ type AgentBuild struct {
 	ToolNames []string
 }
 
-// Option configures a JSONParser or DefaultBuilder.
+// defaultMaxSpecSize is the default maximum spec size in bytes (1 MB).
+const defaultMaxSpecSize int64 = 1 << 20
+
+// Option configures a JSONParser.
 type Option func(*parserOptions)
 
 type parserOptions struct {
@@ -88,7 +94,7 @@ var _ Parser = (*JSONParser)(nil)
 
 // NewJSONParser creates a JSON parser with the given options.
 func NewJSONParser(opts ...Option) *JSONParser {
-	o := parserOptions{maxSize: 1 << 20} // 1MB default
+	o := parserOptions{maxSize: defaultMaxSpecSize}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -114,15 +120,36 @@ func (p *JSONParser) Parse(_ context.Context, data []byte) (*AgentSpec, error) {
 }
 
 // LoadSpec reads an AgentSpec from a file path.
+// The file is bounded at defaultMaxSpecSize bytes at the I/O layer to
+// avoid unbounded allocations from very large files or never-ending
+// readers (e.g. named pipes). The raw input path is rejected if it
+// contains any ".." segment — this must happen before filepath.Clean,
+// which would otherwise resolve the traversal away for absolute paths
+// such as "/tmp/../etc/passwd".
 func LoadSpec(ctx context.Context, path string) (*AgentSpec, error) {
-	cleanPath := filepath.Clean(path)
-	if strings.Contains(cleanPath, "..") {
-		return nil, fmt.Errorf("declarative: path traversal not allowed: %q", path)
+	// Reject path traversal in the raw input before cleaning collapses
+	// ".." segments. Split on OS separators so we only catch true parent
+	// references, not legitimate file names that contain "..".
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return nil, fmt.Errorf("declarative: path traversal not allowed: %q", path)
+		}
 	}
+	cleanPath := filepath.Clean(path)
 
-	data, err := os.ReadFile(cleanPath)
+	f, err := os.Open(cleanPath) //nolint:gosec // path is validated above; callers supply trusted config paths
 	if err != nil {
 		return nil, fmt.Errorf("declarative: read file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read at most defaultMaxSpecSize+1 bytes so we can detect overflow.
+	data, err := io.ReadAll(io.LimitReader(f, defaultMaxSpecSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("declarative: read file: %w", err)
+	}
+	if int64(len(data)) > defaultMaxSpecSize {
+		return nil, fmt.Errorf("declarative: spec exceeds maximum size of %d bytes", defaultMaxSpecSize)
 	}
 
 	parser := NewJSONParser()
@@ -145,13 +172,17 @@ func validateSpec(spec *AgentSpec) error {
 	if spec.MaxIterations < 0 {
 		return fmt.Errorf("declarative: spec.max_iterations must be non-negative")
 	}
-	if spec.Model.Temperature < 0 || spec.Model.Temperature > 2 {
-		return fmt.Errorf("declarative: spec.model.temperature must be in [0, 2]")
+	if spec.Model.Temperature != nil {
+		if t := *spec.Model.Temperature; t < 0 || t > 2 {
+			return fmt.Errorf("declarative: spec.model.temperature must be in [0, 2]")
+		}
 	}
 	return nil
 }
 
-// DefaultBuilder builds AgentBuild from an AgentSpec by resolving references.
+// DefaultBuilder builds AgentBuild from an AgentSpec by copying spec
+// fields into the build. It does not perform registry lookups for
+// providers or tools — callers are responsible for resolving names.
 type DefaultBuilder struct{}
 
 var _ Builder = (*DefaultBuilder)(nil)

--- a/config/declarative/declarative_test.go
+++ b/config/declarative/declarative_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -154,9 +155,83 @@ func TestLoadSpec(t *testing.T) {
 }
 
 func TestLoadSpec_PathTraversal(t *testing.T) {
-	_, err := LoadSpec(context.Background(), "/tmp/../etc/passwd")
+	cases := []string{
+		"/tmp/../etc/passwd",
+		"../secret.json",
+		"a/../../etc/passwd",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			_, err := LoadSpec(context.Background(), p)
+			if err == nil {
+				t.Fatalf("expected error for path traversal input %q", p)
+			}
+			if !strings.Contains(err.Error(), "path traversal") {
+				t.Errorf("expected path traversal error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadSpec_MaxSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.json")
+	// Write a file larger than the 1 MB default limit.
+	big := make([]byte, (1<<20)+16)
+	for i := range big {
+		big[i] = 'a'
+	}
+	if err := os.WriteFile(path, big, 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadSpec(context.Background(), path)
 	if err == nil {
-		t.Error("expected error for path traversal")
+		t.Fatal("expected error for oversized file")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("expected size-limit error, got %v", err)
+	}
+}
+
+func TestModelSpec_TemperaturePointer(t *testing.T) {
+	// Explicit zero must round-trip and remain distinguishable from unset.
+	zero := 0.0
+	spec := &AgentSpec{
+		ID:      "t",
+		Persona: PersonaSpec{Role: "R"},
+		Model:   ModelSpec{Provider: "p", Model: "m", Temperature: &zero},
+	}
+	data, err := MarshalSpec(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := NewJSONParser().Parse(context.Background(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Model.Temperature == nil {
+		t.Fatal("expected Temperature to round-trip as non-nil")
+	}
+	if *parsed.Model.Temperature != 0 {
+		t.Errorf("Temperature = %v, want 0", *parsed.Model.Temperature)
+	}
+
+	// Unset temperature must remain nil.
+	spec2 := &AgentSpec{
+		ID:      "t",
+		Persona: PersonaSpec{Role: "R"},
+		Model:   ModelSpec{Provider: "p", Model: "m"},
+	}
+	data2, err := MarshalSpec(spec2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed2, err := NewJSONParser().Parse(context.Background(), data2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed2.Model.Temperature != nil {
+		t.Errorf("Temperature = %v, want nil", *parsed2.Model.Temperature)
 	}
 }
 

--- a/config/declarative/declarative_test.go
+++ b/config/declarative/declarative_test.go
@@ -1,0 +1,184 @@
+package declarative
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestJSONParser_Parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+		wantID  string
+	}{
+		{
+			name: "valid spec",
+			json: `{
+				"id": "test-agent",
+				"persona": {"role": "Assistant"},
+				"model": {"provider": "openai", "model": "gpt-4o"}
+			}`,
+			wantID: "test-agent",
+		},
+		{
+			name: "with tools and options",
+			json: `{
+				"id": "tool-agent",
+				"persona": {"role": "Helper", "goal": "Help users"},
+				"model": {"provider": "anthropic", "model": "claude-3", "temperature": 0.7, "max_tokens": 1000},
+				"tools": ["search", "calculator"],
+				"max_iterations": 5
+			}`,
+			wantID: "tool-agent",
+		},
+		{
+			name:    "missing id",
+			json:    `{"persona": {"role": "Test"}, "model": {"provider": "x", "model": "y"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing role",
+			json:    `{"id": "a", "persona": {}, "model": {"provider": "x", "model": "y"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing provider",
+			json:    `{"id": "a", "persona": {"role": "R"}, "model": {"model": "y"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing model name",
+			json:    `{"id": "a", "persona": {"role": "R"}, "model": {"provider": "x"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			json:    `{invalid`,
+			wantErr: true,
+		},
+		{
+			name:    "negative max_iterations",
+			json:    `{"id": "a", "persona": {"role": "R"}, "model": {"provider": "x", "model": "y"}, "max_iterations": -1}`,
+			wantErr: true,
+		},
+		{
+			name:    "temperature too high",
+			json:    `{"id": "a", "persona": {"role": "R"}, "model": {"provider": "x", "model": "y", "temperature": 3.0}}`,
+			wantErr: true,
+		},
+	}
+
+	parser := NewJSONParser()
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := parser.Parse(ctx, []byte(tt.json))
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if spec.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", spec.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestJSONParser_MaxSize(t *testing.T) {
+	parser := NewJSONParser(WithMaxSize(10))
+	_, err := parser.Parse(context.Background(), make([]byte, 100))
+	if err == nil {
+		t.Error("expected error for oversized input")
+	}
+}
+
+func TestDefaultBuilder_Build(t *testing.T) {
+	builder := NewBuilder()
+	ctx := context.Background()
+
+	spec := &AgentSpec{
+		ID:      "test",
+		Persona: PersonaSpec{Role: "Assistant"},
+		Model:   ModelSpec{Provider: "openai", Model: "gpt-4o"},
+		Tools:   []string{"search"},
+	}
+
+	build, err := builder.Build(ctx, spec)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if build.ProviderName != "openai" {
+		t.Errorf("ProviderName = %q, want openai", build.ProviderName)
+	}
+	if build.ModelName != "gpt-4o" {
+		t.Errorf("ModelName = %q, want gpt-4o", build.ModelName)
+	}
+	if len(build.ToolNames) != 1 || build.ToolNames[0] != "search" {
+		t.Errorf("ToolNames = %v, want [search]", build.ToolNames)
+	}
+}
+
+func TestDefaultBuilder_NilSpec(t *testing.T) {
+	builder := NewBuilder()
+	_, err := builder.Build(context.Background(), nil)
+	if err == nil {
+		t.Error("expected error for nil spec")
+	}
+}
+
+func TestLoadSpec(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.json")
+	data := []byte(`{"id":"file-agent","persona":{"role":"Test"},"model":{"provider":"openai","model":"gpt-4o"}}`)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	spec, err := LoadSpec(context.Background(), path)
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	if spec.ID != "file-agent" {
+		t.Errorf("ID = %q, want file-agent", spec.ID)
+	}
+}
+
+func TestLoadSpec_PathTraversal(t *testing.T) {
+	_, err := LoadSpec(context.Background(), "/tmp/../etc/passwd")
+	if err == nil {
+		t.Error("expected error for path traversal")
+	}
+}
+
+func TestMarshalSpec(t *testing.T) {
+	spec := &AgentSpec{
+		ID:      "test",
+		Persona: PersonaSpec{Role: "Assistant"},
+		Model:   ModelSpec{Provider: "openai", Model: "gpt-4o"},
+	}
+
+	data, err := MarshalSpec(spec)
+	if err != nil {
+		t.Fatalf("MarshalSpec: %v", err)
+	}
+
+	// Round-trip.
+	parser := NewJSONParser()
+	spec2, err := parser.Parse(context.Background(), data)
+	if err != nil {
+		t.Fatalf("Parse round-trip: %v", err)
+	}
+	if spec2.ID != spec.ID {
+		t.Errorf("round-trip ID = %q, want %q", spec2.ID, spec.ID)
+	}
+}

--- a/config/declarative/doc.go
+++ b/config/declarative/doc.go
@@ -1,4 +1,6 @@
 // Package declarative provides a declarative agent definition system.
-// Agents can be defined in JSON and built into agent.Agent instances
-// using a Builder that resolves LLM providers and tools from registries.
+// Agents can be defined in JSON and parsed into AgentSpec values. A
+// DefaultBuilder then copies the specification fields (provider, model,
+// tool names) into an AgentBuild. Registry lookups for concrete LLM
+// providers and tools are the responsibility of the caller.
 package declarative

--- a/config/declarative/doc.go
+++ b/config/declarative/doc.go
@@ -1,0 +1,4 @@
+// Package declarative provides a declarative agent definition system.
+// Agents can be defined in JSON and built into agent.Agent instances
+// using a Builder that resolves LLM providers and tools from registries.
+package declarative


### PR DESCRIPTION
## Summary
- config/declarative package, AgentSpec with JSON schema, Parser, Builder

## Linear
- LOO-44: https://linear.app/lookatitude/issue/LOO-44

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)