### PR TITLE
LOO-46: Speaker Diarization

### DIFF
--- a/voice/diarization/diarization.go
+++ b/voice/diarization/diarization.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// speakerSilence is the sentinel SpeakerID used internally by the
+// EnergyDiarizer to mark low-energy (silence) windows. It is never
+// emitted as part of a returned SpeakerSegment — callers only see
+// real speaker IDs.
+const speakerSilence = "silence"
+
 // Diarizer identifies different speakers within audio data.
 type Diarizer interface {
 	// Diarize processes audio data and returns speaker segments.
@@ -166,19 +172,23 @@ func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...Diar
 
 	// Simple energy-based segmentation: split audio into fixed-size windows
 	// and assign speakers based on energy level patterns.
-	bytesPerSample := 2 // 16-bit PCM
+	bytesPerSample := 2                   // 16-bit PCM
 	samplesPerWindow := o.sampleRate / 10 // 100ms windows
 	windowBytes := samplesPerWindow * bytesPerSample
 
-	if windowBytes <= 0 {
-		windowBytes = 3200 // fallback
+	// Guard against zero/negative sample rate to prevent divide-by-zero
+	// panics in the window offset calculation below. Reset both the
+	// window size and sample rate to sensible defaults.
+	if windowBytes <= 0 || o.sampleRate <= 0 {
+		if o.sampleRate <= 0 {
+			o.sampleRate = 16000
+		}
+		windowBytes = 3200 // fallback (100ms @ 16kHz, 16-bit PCM)
 	}
 
 	var segments []SpeakerSegment
 	var currentSpeaker string
 	var segStart time.Duration
-
-	windowDuration := time.Duration(float64(samplesPerWindow) / float64(o.sampleRate) * float64(time.Second))
 
 	for i := 0; i < len(audio); i += windowBytes {
 		if err := ctx.Err(); err != nil {
@@ -197,7 +207,7 @@ func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...Diar
 		windowStart := time.Duration(i/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
 
 		if speaker != currentSpeaker {
-			if currentSpeaker != "" {
+			if currentSpeaker != "" && currentSpeaker != speakerSilence {
 				seg := SpeakerSegment{
 					SpeakerID:  currentSpeaker,
 					Start:      segStart,
@@ -211,12 +221,10 @@ func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...Diar
 			currentSpeaker = speaker
 			segStart = windowStart
 		}
-
-		_ = windowDuration // used for calculation
 	}
 
-	// Close final segment.
-	if currentSpeaker != "" {
+	// Close final segment. Skip silence — it is not a real speaker.
+	if currentSpeaker != "" && currentSpeaker != speakerSilence {
 		totalDuration := time.Duration(len(audio)/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
 		seg := SpeakerSegment{
 			SpeakerID:  currentSpeaker,
@@ -249,9 +257,11 @@ func assignSpeaker(energy float64, maxSpeakers int) string {
 	if maxSpeakers <= 0 {
 		maxSpeakers = 2
 	}
-	// Simple threshold-based assignment.
+	// Simple threshold-based assignment. Low-energy windows are tagged
+	// with the silence sentinel so the caller can filter them out rather
+	// than emit them as real speaker segments.
 	if energy < 100 {
-		return "silence"
+		return speakerSilence
 	}
 	// Use energy level to assign speakers.
 	speakerIdx := int(energy/10000) % maxSpeakers

--- a/voice/diarization/diarization.go
+++ b/voice/diarization/diarization.go
@@ -1,0 +1,311 @@
+package diarization
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Diarizer identifies different speakers within audio data.
+type Diarizer interface {
+	// Diarize processes audio data and returns speaker segments.
+	Diarize(ctx context.Context, audio []byte, opts ...DiarizeOption) ([]SpeakerSegment, error)
+}
+
+// SpeakerTracker maintains speaker identity across multiple diarization calls,
+// allowing consistent speaker IDs across a session.
+type SpeakerTracker interface {
+	// Track assigns consistent speaker IDs to segments based on prior observations.
+	Track(ctx context.Context, segments []SpeakerSegment) ([]SpeakerSegment, error)
+	// Reset clears all tracked speaker state.
+	Reset(ctx context.Context) error
+}
+
+// SpeakerSegment represents a time-bounded segment attributed to a speaker.
+type SpeakerSegment struct {
+	// SpeakerID identifies the speaker.
+	SpeakerID string `json:"speaker_id"`
+	// Start is the start time of the segment relative to audio start.
+	Start time.Duration `json:"start"`
+	// End is the end time of the segment relative to audio start.
+	End time.Duration `json:"end"`
+	// Confidence is the diarization confidence score in [0.0, 1.0].
+	Confidence float64 `json:"confidence"`
+	// Text is the optional transcript for this segment.
+	Text string `json:"text,omitempty"`
+	// Metadata holds extra attributes.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Duration returns the length of the segment.
+func (s SpeakerSegment) Duration() time.Duration {
+	return s.End - s.Start
+}
+
+// DiarizeOption configures a diarization call.
+type DiarizeOption func(*diarizeOptions)
+
+type diarizeOptions struct {
+	maxSpeakers int
+	minSegment  time.Duration
+	sampleRate  int
+}
+
+// WithMaxSpeakers sets the maximum number of speakers to detect.
+func WithMaxSpeakers(n int) DiarizeOption {
+	return func(o *diarizeOptions) { o.maxSpeakers = n }
+}
+
+// WithMinSegmentDuration sets the minimum segment duration.
+func WithMinSegmentDuration(d time.Duration) DiarizeOption {
+	return func(o *diarizeOptions) { o.minSegment = d }
+}
+
+// WithSampleRate sets the audio sample rate.
+func WithSampleRate(rate int) DiarizeOption {
+	return func(o *diarizeOptions) { o.sampleRate = rate }
+}
+
+// Factory creates a Diarizer from a Config.
+type Factory func(cfg Config) (Diarizer, error)
+
+// Config holds configuration for creating a Diarizer.
+type Config struct {
+	// MaxSpeakers is the default maximum number of speakers.
+	MaxSpeakers int
+	// MinSegmentDuration is the default minimum segment duration.
+	MinSegmentDuration time.Duration
+	// SampleRate is the default audio sample rate.
+	SampleRate int
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]Factory)
+)
+
+// Register adds a diarizer factory to the global registry.
+func Register(name string, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = f
+}
+
+// New creates a Diarizer by name from the registry.
+func New(name string, cfg Config) (Diarizer, error) {
+	registryMu.RLock()
+	f, ok := registry[name]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("diarization: unknown diarizer %q (registered: %v)", name, List())
+	}
+	return f(cfg)
+}
+
+// List returns the names of all registered diarizers, sorted alphabetically.
+func List() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// EnergyDiarizer is a simple energy-based diarizer that detects speaker
+// changes based on audio energy levels. Suitable for testing and as a
+// baseline; production use requires a provider-backed implementation.
+type EnergyDiarizer struct {
+	maxSpeakers int
+	minSegment  time.Duration
+	sampleRate  int
+}
+
+var _ Diarizer = (*EnergyDiarizer)(nil)
+
+// NewEnergyDiarizer creates an energy-based diarizer.
+func NewEnergyDiarizer(cfg Config) *EnergyDiarizer {
+	if cfg.MaxSpeakers <= 0 {
+		cfg.MaxSpeakers = 2
+	}
+	if cfg.MinSegmentDuration <= 0 {
+		cfg.MinSegmentDuration = 500 * time.Millisecond
+	}
+	if cfg.SampleRate <= 0 {
+		cfg.SampleRate = 16000
+	}
+	return &EnergyDiarizer{
+		maxSpeakers: cfg.MaxSpeakers,
+		minSegment:  cfg.MinSegmentDuration,
+		sampleRate:  cfg.SampleRate,
+	}
+}
+
+// Diarize segments audio based on energy levels.
+func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...DiarizeOption) ([]SpeakerSegment, error) {
+	o := &diarizeOptions{
+		maxSpeakers: d.maxSpeakers,
+		minSegment:  d.minSegment,
+		sampleRate:  d.sampleRate,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if len(audio) == 0 {
+		return nil, nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Simple energy-based segmentation: split audio into fixed-size windows
+	// and assign speakers based on energy level patterns.
+	bytesPerSample := 2 // 16-bit PCM
+	samplesPerWindow := o.sampleRate / 10 // 100ms windows
+	windowBytes := samplesPerWindow * bytesPerSample
+
+	if windowBytes <= 0 {
+		windowBytes = 3200 // fallback
+	}
+
+	var segments []SpeakerSegment
+	var currentSpeaker string
+	var segStart time.Duration
+
+	windowDuration := time.Duration(float64(samplesPerWindow) / float64(o.sampleRate) * float64(time.Second))
+
+	for i := 0; i < len(audio); i += windowBytes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		end := i + windowBytes
+		if end > len(audio) {
+			end = len(audio)
+		}
+		window := audio[i:end]
+
+		energy := computeEnergy(window)
+		speaker := assignSpeaker(energy, o.maxSpeakers)
+
+		windowStart := time.Duration(i/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
+
+		if speaker != currentSpeaker {
+			if currentSpeaker != "" {
+				seg := SpeakerSegment{
+					SpeakerID:  currentSpeaker,
+					Start:      segStart,
+					End:        windowStart,
+					Confidence: 0.7,
+				}
+				if seg.Duration() >= o.minSegment {
+					segments = append(segments, seg)
+				}
+			}
+			currentSpeaker = speaker
+			segStart = windowStart
+		}
+
+		_ = windowDuration // used for calculation
+	}
+
+	// Close final segment.
+	if currentSpeaker != "" {
+		totalDuration := time.Duration(len(audio)/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
+		seg := SpeakerSegment{
+			SpeakerID:  currentSpeaker,
+			Start:      segStart,
+			End:        totalDuration,
+			Confidence: 0.7,
+		}
+		if seg.Duration() >= o.minSegment {
+			segments = append(segments, seg)
+		}
+	}
+
+	return segments, nil
+}
+
+func computeEnergy(window []byte) float64 {
+	var sum float64
+	for i := 0; i+1 < len(window); i += 2 {
+		sample := int16(window[i]) | int16(window[i+1])<<8
+		sum += float64(sample) * float64(sample)
+	}
+	n := len(window) / 2
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+func assignSpeaker(energy float64, maxSpeakers int) string {
+	if maxSpeakers <= 0 {
+		maxSpeakers = 2
+	}
+	// Simple threshold-based assignment.
+	if energy < 100 {
+		return "silence"
+	}
+	// Use energy level to assign speakers.
+	speakerIdx := int(energy/10000) % maxSpeakers
+	return fmt.Sprintf("speaker-%d", speakerIdx)
+}
+
+// InMemorySpeakerTracker tracks speakers across calls using in-memory state.
+type InMemorySpeakerTracker struct {
+	mu      sync.Mutex
+	mapping map[string]string // provider speaker ID -> stable ID
+	counter int
+}
+
+var _ SpeakerTracker = (*InMemorySpeakerTracker)(nil)
+
+// NewSpeakerTracker creates an in-memory speaker tracker.
+func NewSpeakerTracker() *InMemorySpeakerTracker {
+	return &InMemorySpeakerTracker{
+		mapping: make(map[string]string),
+	}
+}
+
+// Track assigns consistent IDs to speaker segments.
+func (t *InMemorySpeakerTracker) Track(_ context.Context, segments []SpeakerSegment) ([]SpeakerSegment, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result := make([]SpeakerSegment, len(segments))
+	copy(result, segments)
+
+	for i, seg := range result {
+		stableID, ok := t.mapping[seg.SpeakerID]
+		if !ok {
+			t.counter++
+			stableID = fmt.Sprintf("speaker-%d", t.counter)
+			t.mapping[seg.SpeakerID] = stableID
+		}
+		result[i].SpeakerID = stableID
+	}
+
+	return result, nil
+}
+
+// Reset clears all tracked state.
+func (t *InMemorySpeakerTracker) Reset(_ context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mapping = make(map[string]string)
+	t.counter = 0
+	return nil
+}
+
+func init() {
+	Register("energy", func(cfg Config) (Diarizer, error) {
+		return NewEnergyDiarizer(cfg), nil
+	})
+}

--- a/voice/diarization/diarization.go
+++ b/voice/diarization/diarization.go
@@ -151,8 +151,14 @@ func NewEnergyDiarizer(cfg Config) *EnergyDiarizer {
 	}
 }
 
-// Diarize segments audio based on energy levels.
-func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...DiarizeOption) ([]SpeakerSegment, error) {
+// bytesPerSample is the PCM sample width used by the energy diarizer
+// (16-bit little-endian).
+const bytesPerSample = 2
+
+// resolveOptions applies the variadic options on top of the diarizer's
+// defaults and normalises any zero/negative values so the window-offset
+// math below cannot divide by zero.
+func (d *EnergyDiarizer) resolveOptions(opts []DiarizeOption) *diarizeOptions {
 	o := &diarizeOptions{
 		maxSpeakers: d.maxSpeakers,
 		minSegment:  d.minSegment,
@@ -161,34 +167,61 @@ func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...Diar
 	for _, opt := range opts {
 		opt(o)
 	}
+	if o.sampleRate <= 0 {
+		o.sampleRate = 16000
+	}
+	if o.maxSpeakers <= 0 {
+		o.maxSpeakers = 2
+	}
+	return o
+}
 
+// windowBytesFor returns the byte size of a 100ms window for the given
+// sample rate, with a safe fallback.
+func windowBytesFor(sampleRate int) int {
+	wb := (sampleRate / 10) * bytesPerSample
+	if wb <= 0 {
+		return 3200 // fallback: 100ms @ 16kHz, 16-bit PCM
+	}
+	return wb
+}
+
+// offsetDuration converts a byte offset in the PCM stream to a duration
+// relative to the start of the audio.
+func offsetDuration(byteOffset, sampleRate int) time.Duration {
+	return time.Duration(byteOffset/bytesPerSample) * time.Second / time.Duration(sampleRate)
+}
+
+// emitSegment appends seg to segments when it corresponds to a real
+// speaker (not silence) and meets the minimum duration. It returns the
+// possibly-updated segment slice.
+func emitSegment(segments []SpeakerSegment, seg SpeakerSegment, minSegment time.Duration) []SpeakerSegment {
+	if seg.SpeakerID == "" || seg.SpeakerID == speakerSilence {
+		return segments
+	}
+	if seg.Duration() < minSegment {
+		return segments
+	}
+	return append(segments, seg)
+}
+
+// Diarize segments audio based on energy levels.
+func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...DiarizeOption) ([]SpeakerSegment, error) {
 	if len(audio) == 0 {
 		return nil, nil
 	}
-
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	// Simple energy-based segmentation: split audio into fixed-size windows
-	// and assign speakers based on energy level patterns.
-	bytesPerSample := 2                   // 16-bit PCM
-	samplesPerWindow := o.sampleRate / 10 // 100ms windows
-	windowBytes := samplesPerWindow * bytesPerSample
+	o := d.resolveOptions(opts)
+	windowBytes := windowBytesFor(o.sampleRate)
 
-	// Guard against zero/negative sample rate to prevent divide-by-zero
-	// panics in the window offset calculation below. Reset both the
-	// window size and sample rate to sensible defaults.
-	if windowBytes <= 0 || o.sampleRate <= 0 {
-		if o.sampleRate <= 0 {
-			o.sampleRate = 16000
-		}
-		windowBytes = 3200 // fallback (100ms @ 16kHz, 16-bit PCM)
-	}
-
-	var segments []SpeakerSegment
-	var currentSpeaker string
-	var segStart time.Duration
+	var (
+		segments       []SpeakerSegment
+		currentSpeaker string
+		segStart       time.Duration
+	)
 
 	for i := 0; i < len(audio); i += windowBytes {
 		if err := ctx.Err(); err != nil {
@@ -199,43 +232,30 @@ func (d *EnergyDiarizer) Diarize(ctx context.Context, audio []byte, opts ...Diar
 		if end > len(audio) {
 			end = len(audio)
 		}
-		window := audio[i:end]
 
-		energy := computeEnergy(window)
-		speaker := assignSpeaker(energy, o.maxSpeakers)
+		speaker := assignSpeaker(computeEnergy(audio[i:end]), o.maxSpeakers)
+		windowStart := offsetDuration(i, o.sampleRate)
 
-		windowStart := time.Duration(i/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
-
-		if speaker != currentSpeaker {
-			if currentSpeaker != "" && currentSpeaker != speakerSilence {
-				seg := SpeakerSegment{
-					SpeakerID:  currentSpeaker,
-					Start:      segStart,
-					End:        windowStart,
-					Confidence: 0.7,
-				}
-				if seg.Duration() >= o.minSegment {
-					segments = append(segments, seg)
-				}
-			}
-			currentSpeaker = speaker
-			segStart = windowStart
+		if speaker == currentSpeaker {
+			continue
 		}
-	}
-
-	// Close final segment. Skip silence — it is not a real speaker.
-	if currentSpeaker != "" && currentSpeaker != speakerSilence {
-		totalDuration := time.Duration(len(audio)/bytesPerSample) * time.Second / time.Duration(o.sampleRate)
-		seg := SpeakerSegment{
+		segments = emitSegment(segments, SpeakerSegment{
 			SpeakerID:  currentSpeaker,
 			Start:      segStart,
-			End:        totalDuration,
+			End:        windowStart,
 			Confidence: 0.7,
-		}
-		if seg.Duration() >= o.minSegment {
-			segments = append(segments, seg)
-		}
+		}, o.minSegment)
+		currentSpeaker = speaker
+		segStart = windowStart
 	}
+
+	// Close final segment.
+	segments = emitSegment(segments, SpeakerSegment{
+		SpeakerID:  currentSpeaker,
+		Start:      segStart,
+		End:        offsetDuration(len(audio), o.sampleRate),
+		Confidence: 0.7,
+	}, o.minSegment)
 
 	return segments, nil
 }

--- a/voice/diarization/diarization_test.go
+++ b/voice/diarization/diarization_test.go
@@ -1,0 +1,181 @@
+package diarization
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEnergyDiarizer_EmptyAudio(t *testing.T) {
+	d := NewEnergyDiarizer(Config{})
+	segments, err := d.Diarize(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if segments != nil {
+		t.Errorf("expected nil segments for empty audio, got %v", segments)
+	}
+}
+
+func TestEnergyDiarizer_BasicAudio(t *testing.T) {
+	d := NewEnergyDiarizer(Config{
+		MaxSpeakers:        2,
+		MinSegmentDuration: 100 * time.Millisecond,
+		SampleRate:         16000,
+	})
+
+	// Generate 1 second of 16-bit PCM audio (16000 samples * 2 bytes).
+	audio := make([]byte, 32000)
+	// Fill with varying energy levels.
+	for i := 0; i < len(audio); i += 2 {
+		val := byte((i / 6400) * 50) // Change energy at different points.
+		audio[i] = val
+		audio[i+1] = 0
+	}
+
+	segments, err := d.Diarize(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have at least one segment.
+	if len(segments) == 0 {
+		t.Error("expected at least one segment")
+	}
+
+	// Verify segments have valid fields.
+	for _, seg := range segments {
+		if seg.SpeakerID == "" {
+			t.Error("segment has empty speaker ID")
+		}
+		if seg.End <= seg.Start {
+			t.Errorf("segment end (%v) <= start (%v)", seg.End, seg.Start)
+		}
+		if seg.Confidence <= 0 || seg.Confidence > 1 {
+			t.Errorf("confidence = %v, want (0, 1]", seg.Confidence)
+		}
+	}
+}
+
+func TestEnergyDiarizer_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d := NewEnergyDiarizer(Config{SampleRate: 16000})
+	audio := make([]byte, 32000)
+
+	_, err := d.Diarize(ctx, audio)
+	if err == nil {
+		t.Error("expected context cancellation error")
+	}
+}
+
+func TestEnergyDiarizer_WithOptions(t *testing.T) {
+	d := NewEnergyDiarizer(Config{SampleRate: 16000})
+	audio := make([]byte, 64000) // 2 seconds
+	for i := 0; i < len(audio); i += 2 {
+		audio[i] = byte(i % 256)
+		audio[i+1] = 0
+	}
+
+	segments, err := d.Diarize(context.Background(), audio,
+		WithMaxSpeakers(3),
+		WithMinSegmentDuration(50*time.Millisecond),
+		WithSampleRate(16000),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(segments) == 0 {
+		t.Error("expected segments with options")
+	}
+}
+
+func TestSpeakerSegment_Duration(t *testing.T) {
+	seg := SpeakerSegment{
+		Start: 1 * time.Second,
+		End:   3 * time.Second,
+	}
+	if seg.Duration() != 2*time.Second {
+		t.Errorf("Duration = %v, want 2s", seg.Duration())
+	}
+}
+
+func TestInMemorySpeakerTracker(t *testing.T) {
+	tracker := NewSpeakerTracker()
+	ctx := context.Background()
+
+	segments1 := []SpeakerSegment{
+		{SpeakerID: "raw-1", Start: 0, End: time.Second},
+		{SpeakerID: "raw-2", Start: time.Second, End: 2 * time.Second},
+	}
+
+	tracked1, err := tracker.Track(ctx, segments1)
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	if tracked1[0].SpeakerID == "raw-1" {
+		t.Error("expected speaker ID to be remapped")
+	}
+
+	// Same raw IDs should get same stable IDs.
+	segments2 := []SpeakerSegment{
+		{SpeakerID: "raw-1", Start: 2 * time.Second, End: 3 * time.Second},
+	}
+
+	tracked2, err := tracker.Track(ctx, segments2)
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	if tracked2[0].SpeakerID != tracked1[0].SpeakerID {
+		t.Errorf("same raw ID should get same stable ID: %q vs %q",
+			tracked2[0].SpeakerID, tracked1[0].SpeakerID)
+	}
+
+	// Reset should clear mappings.
+	if err := tracker.Reset(ctx); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	tracked3, err := tracker.Track(ctx, segments1)
+	if err != nil {
+		t.Fatalf("Track after reset: %v", err)
+	}
+
+	// After reset, IDs restart.
+	if tracked3[0].SpeakerID != tracked1[0].SpeakerID {
+		// This is OK - just checking it's a valid stable ID.
+		if tracked3[0].SpeakerID == "" {
+			t.Error("expected non-empty speaker ID after reset")
+		}
+	}
+}
+
+func TestRegistry(t *testing.T) {
+	names := List()
+	found := false
+	for _, n := range names {
+		if n == "energy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'energy' in registry")
+	}
+
+	d, err := New("energy", Config{})
+	if err != nil {
+		t.Fatalf("New(energy): %v", err)
+	}
+	if d == nil {
+		t.Error("expected non-nil diarizer")
+	}
+
+	_, err = New("nonexistent", Config{})
+	if err == nil {
+		t.Error("expected error for unknown diarizer")
+	}
+}

--- a/voice/diarization/diarization_test.go
+++ b/voice/diarization/diarization_test.go
@@ -92,6 +92,51 @@ func TestEnergyDiarizer_WithOptions(t *testing.T) {
 	}
 }
 
+func TestEnergyDiarizer_ZeroSampleRateDoesNotPanic(t *testing.T) {
+	// Regression: previously, passing WithSampleRate(0) would leave
+	// o.sampleRate at 0 and cause a divide-by-zero panic in the
+	// per-window offset calculation. It must now fall back safely.
+	d := NewEnergyDiarizer(Config{SampleRate: 16000})
+	audio := make([]byte, 32000)
+	for i := 0; i < len(audio); i += 2 {
+		audio[i] = byte((i / 4000) * 40)
+		audio[i+1] = 0
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Diarize panicked with WithSampleRate(0): %v", r)
+		}
+	}()
+
+	if _, err := d.Diarize(context.Background(), audio, WithSampleRate(0)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnergyDiarizer_SilenceNotEmittedAsSpeaker(t *testing.T) {
+	// All-zero audio should be treated as silence and produce no
+	// speaker segments — silence is not a speaker.
+	d := NewEnergyDiarizer(Config{
+		MaxSpeakers:        2,
+		MinSegmentDuration: 10 * time.Millisecond,
+		SampleRate:         16000,
+	})
+
+	audio := make([]byte, 32000) // 1s of pure silence
+
+	segments, err := d.Diarize(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, seg := range segments {
+		if seg.SpeakerID == speakerSilence {
+			t.Errorf("silence should not be emitted as a SpeakerSegment, got %+v", seg)
+		}
+	}
+}
+
 func TestSpeakerSegment_Duration(t *testing.T) {
 	seg := SpeakerSegment{
 		Start: 1 * time.Second,

--- a/voice/diarization/doc.go
+++ b/voice/diarization/doc.go
@@ -1,0 +1,4 @@
+// Package diarization provides speaker diarization for voice pipelines.
+// It identifies and tracks different speakers within audio streams,
+// producing labeled speaker segments.
+package diarization


### PR DESCRIPTION
## Summary
- voice/diarization package, Diarizer interface, EnergyDiarizer, SpeakerTracker

## Linear
- LOO-46: https://linear.app/lookatitude/issue/LOO-46

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)