### PR TITLE
LOO-51: Agent File Format / Portable Serialization

### DIFF
--- a/config/agentfile/agentfile.go
+++ b/config/agentfile/agentfile.go
@@ -1,0 +1,238 @@
+package agentfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// AgentFile represents the .af agent file format.
+type AgentFile struct {
+	// Version is the file format version.
+	Version string `json:"version"`
+	// Agent contains the agent specification.
+	Agent AgentDef `json:"agent"`
+	// CreatedAt is when this file was created.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is when this file was last modified.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AgentDef defines an agent within an AgentFile.
+type AgentDef struct {
+	// ID is the unique agent identifier.
+	ID string `json:"id"`
+	// Name is a human-readable name.
+	Name string `json:"name"`
+	// Description explains the agent's purpose.
+	Description string `json:"description,omitempty"`
+	// Persona defines the agent's role and behavior.
+	Persona PersonaDef `json:"persona"`
+	// Model defines the LLM configuration.
+	Model ModelDef `json:"model"`
+	// Tools lists tool configurations.
+	Tools []ToolDef `json:"tools,omitempty"`
+	// Settings holds additional configuration.
+	Settings map[string]any `json:"settings,omitempty"`
+}
+
+// PersonaDef defines persona within an AgentFile.
+type PersonaDef struct {
+	Role      string `json:"role"`
+	Goal      string `json:"goal,omitempty"`
+	Backstory string `json:"backstory,omitempty"`
+}
+
+// ModelDef defines model configuration within an AgentFile.
+type ModelDef struct {
+	Provider    string  `json:"provider"`
+	Model       string  `json:"model"`
+	Temperature float64 `json:"temperature,omitempty"`
+	MaxTokens   int     `json:"max_tokens,omitempty"`
+}
+
+// ToolDef defines a tool reference within an AgentFile.
+type ToolDef struct {
+	Name   string         `json:"name"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+// Serializer writes AgentFiles to bytes.
+type Serializer interface {
+	// Serialize converts an AgentFile to bytes.
+	Serialize(af *AgentFile) ([]byte, error)
+}
+
+// Deserializer reads AgentFiles from bytes.
+type Deserializer interface {
+	// Deserialize converts bytes to an AgentFile.
+	Deserialize(data []byte) (*AgentFile, error)
+}
+
+// VersionMigrator migrates AgentFiles between format versions.
+type VersionMigrator interface {
+	// Migrate updates an AgentFile to the target version.
+	Migrate(af *AgentFile, targetVersion string) (*AgentFile, error)
+	// SupportedVersions returns the versions this migrator can handle.
+	SupportedVersions() []string
+}
+
+// CurrentVersion is the current agent file format version.
+const CurrentVersion = "1.0"
+
+// JSONSerializer implements Serializer for JSON format.
+type JSONSerializer struct{}
+
+var _ Serializer = (*JSONSerializer)(nil)
+
+// Serialize writes an AgentFile as JSON.
+func (s *JSONSerializer) Serialize(af *AgentFile) ([]byte, error) {
+	if af == nil {
+		return nil, fmt.Errorf("agentfile: nil agent file")
+	}
+	return json.MarshalIndent(af, "", "  ")
+}
+
+// JSONDeserializer implements Deserializer for JSON format.
+type JSONDeserializer struct {
+	maxSize int64
+}
+
+var _ Deserializer = (*JSONDeserializer)(nil)
+
+// Option configures a JSONDeserializer.
+type Option func(*JSONDeserializer)
+
+// WithMaxSize sets the maximum file size in bytes.
+func WithMaxSize(n int64) Option {
+	return func(d *JSONDeserializer) { d.maxSize = n }
+}
+
+// NewDeserializer creates a JSON deserializer.
+func NewDeserializer(opts ...Option) *JSONDeserializer {
+	d := &JSONDeserializer{maxSize: 1 << 20} // 1MB default
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// Deserialize reads an AgentFile from JSON bytes.
+func (d *JSONDeserializer) Deserialize(data []byte) (*AgentFile, error) {
+	if int64(len(data)) > d.maxSize {
+		return nil, fmt.Errorf("agentfile: data exceeds maximum size of %d bytes", d.maxSize)
+	}
+
+	var af AgentFile
+	if err := json.Unmarshal(data, &af); err != nil {
+		return nil, fmt.Errorf("agentfile: invalid JSON: %w", err)
+	}
+
+	if err := validate(&af); err != nil {
+		return nil, err
+	}
+
+	return &af, nil
+}
+
+func validate(af *AgentFile) error {
+	if af.Version == "" {
+		return fmt.Errorf("agentfile: version is required")
+	}
+	if af.Agent.ID == "" {
+		return fmt.Errorf("agentfile: agent.id is required")
+	}
+	if af.Agent.Persona.Role == "" {
+		return fmt.Errorf("agentfile: agent.persona.role is required")
+	}
+	if af.Agent.Model.Provider == "" {
+		return fmt.Errorf("agentfile: agent.model.provider is required")
+	}
+	if af.Agent.Model.Model == "" {
+		return fmt.Errorf("agentfile: agent.model.model is required")
+	}
+	return nil
+}
+
+// DefaultMigrator handles version migrations for the .af format.
+type DefaultMigrator struct{}
+
+var _ VersionMigrator = (*DefaultMigrator)(nil)
+
+// NewMigrator creates a new version migrator.
+func NewMigrator() *DefaultMigrator {
+	return &DefaultMigrator{}
+}
+
+// Migrate updates an AgentFile to the target version.
+func (m *DefaultMigrator) Migrate(af *AgentFile, targetVersion string) (*AgentFile, error) {
+	if af == nil {
+		return nil, fmt.Errorf("agentfile: nil agent file")
+	}
+
+	if af.Version == targetVersion {
+		return af, nil
+	}
+
+	result := *af
+	result.Version = targetVersion
+	result.UpdatedAt = time.Now()
+
+	return &result, nil
+}
+
+// SupportedVersions returns the versions supported by this migrator.
+func (m *DefaultMigrator) SupportedVersions() []string {
+	return []string{"0.1", "1.0"}
+}
+
+// Save writes an AgentFile to disk.
+func Save(path string, af *AgentFile) error {
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return fmt.Errorf("agentfile: path traversal not allowed: %q", path)
+	}
+
+	s := &JSONSerializer{}
+	data, err := s.Serialize(af)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(cleanPath, data, 0600)
+}
+
+// Load reads an AgentFile from disk.
+func Load(path string) (*AgentFile, error) {
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return nil, fmt.Errorf("agentfile: path traversal not allowed: %q", path)
+	}
+
+	data, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("agentfile: read file: %w", err)
+	}
+
+	d := NewDeserializer()
+	return d.Deserialize(data)
+}
+
+// NewAgentFile creates a new AgentFile with defaults.
+func NewAgentFile(id, role, provider, model string) *AgentFile {
+	now := time.Now()
+	return &AgentFile{
+		Version: CurrentVersion,
+		Agent: AgentDef{
+			ID:      id,
+			Name:    id,
+			Persona: PersonaDef{Role: role},
+			Model:   ModelDef{Provider: provider, Model: model},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}

--- a/config/agentfile/agentfile.go
+++ b/config/agentfile/agentfile.go
@@ -1,6 +1,7 @@
 package agentfile
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -63,19 +64,19 @@ type ToolDef struct {
 // Serializer writes AgentFiles to bytes.
 type Serializer interface {
 	// Serialize converts an AgentFile to bytes.
-	Serialize(af *AgentFile) ([]byte, error)
+	Serialize(ctx context.Context, af *AgentFile) ([]byte, error)
 }
 
 // Deserializer reads AgentFiles from bytes.
 type Deserializer interface {
 	// Deserialize converts bytes to an AgentFile.
-	Deserialize(data []byte) (*AgentFile, error)
+	Deserialize(ctx context.Context, data []byte) (*AgentFile, error)
 }
 
 // VersionMigrator migrates AgentFiles between format versions.
 type VersionMigrator interface {
 	// Migrate updates an AgentFile to the target version.
-	Migrate(af *AgentFile, targetVersion string) (*AgentFile, error)
+	Migrate(ctx context.Context, af *AgentFile, targetVersion string) (*AgentFile, error)
 	// SupportedVersions returns the versions this migrator can handle.
 	SupportedVersions() []string
 }
@@ -83,13 +84,19 @@ type VersionMigrator interface {
 // CurrentVersion is the current agent file format version.
 const CurrentVersion = "1.0"
 
+// maxFileSize is the maximum allowed agent file size (1 MB).
+const maxFileSize int64 = 1 << 20
+
 // JSONSerializer implements Serializer for JSON format.
 type JSONSerializer struct{}
 
 var _ Serializer = (*JSONSerializer)(nil)
 
 // Serialize writes an AgentFile as JSON.
-func (s *JSONSerializer) Serialize(af *AgentFile) ([]byte, error) {
+func (s *JSONSerializer) Serialize(ctx context.Context, af *AgentFile) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if af == nil {
 		return nil, fmt.Errorf("agentfile: nil agent file")
 	}
@@ -113,7 +120,7 @@ func WithMaxSize(n int64) Option {
 
 // NewDeserializer creates a JSON deserializer.
 func NewDeserializer(opts ...Option) *JSONDeserializer {
-	d := &JSONDeserializer{maxSize: 1 << 20} // 1MB default
+	d := &JSONDeserializer{maxSize: maxFileSize} // 1MB default
 	for _, opt := range opts {
 		opt(d)
 	}
@@ -121,7 +128,10 @@ func NewDeserializer(opts ...Option) *JSONDeserializer {
 }
 
 // Deserialize reads an AgentFile from JSON bytes.
-func (d *JSONDeserializer) Deserialize(data []byte) (*AgentFile, error) {
+func (d *JSONDeserializer) Deserialize(ctx context.Context, data []byte) (*AgentFile, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if int64(len(data)) > d.maxSize {
 		return nil, fmt.Errorf("agentfile: data exceeds maximum size of %d bytes", d.maxSize)
 	}
@@ -167,21 +177,50 @@ func NewMigrator() *DefaultMigrator {
 	return &DefaultMigrator{}
 }
 
+// deepCopy returns a deep copy of an AgentFile via JSON round-trip, ensuring
+// that map and slice fields are not aliased between the original and the copy.
+func deepCopy(af *AgentFile) (*AgentFile, error) {
+	b, err := json.Marshal(af)
+	if err != nil {
+		return nil, fmt.Errorf("agentfile: deep copy marshal: %w", err)
+	}
+	var cp AgentFile
+	if err := json.Unmarshal(b, &cp); err != nil {
+		return nil, fmt.Errorf("agentfile: deep copy unmarshal: %w", err)
+	}
+	return &cp, nil
+}
+
 // Migrate updates an AgentFile to the target version.
-func (m *DefaultMigrator) Migrate(af *AgentFile, targetVersion string) (*AgentFile, error) {
+func (m *DefaultMigrator) Migrate(ctx context.Context, af *AgentFile, targetVersion string) (*AgentFile, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if af == nil {
 		return nil, fmt.Errorf("agentfile: nil agent file")
 	}
 
-	if af.Version == targetVersion {
-		return af, nil
+	supported := map[string]bool{}
+	for _, v := range m.SupportedVersions() {
+		supported[v] = true
+	}
+	if !supported[targetVersion] {
+		return nil, fmt.Errorf("agentfile: unsupported target version %q", targetVersion)
 	}
 
-	result := *af
+	result, err := deepCopy(af)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Version == targetVersion {
+		return result, nil
+	}
+
 	result.Version = targetVersion
 	result.UpdatedAt = time.Now()
 
-	return &result, nil
+	return result, nil
 }
 
 // SupportedVersions returns the versions supported by this migrator.
@@ -190,35 +229,55 @@ func (m *DefaultMigrator) SupportedVersions() []string {
 }
 
 // Save writes an AgentFile to disk.
-func Save(path string, af *AgentFile) error {
-	cleanPath := filepath.Clean(path)
-	if strings.Contains(cleanPath, "..") {
+func Save(ctx context.Context, path string, af *AgentFile) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Check the original path before cleaning so that traversal segments are
+	// not silently collapsed by filepath.Clean.
+	if strings.Contains(path, "..") {
 		return fmt.Errorf("agentfile: path traversal not allowed: %q", path)
 	}
+	cleanPath := filepath.Clean(path)
 
 	s := &JSONSerializer{}
-	data, err := s.Serialize(af)
+	data, err := s.Serialize(ctx, af)
 	if err != nil {
 		return err
 	}
 
-	return os.WriteFile(cleanPath, data, 0600)
+	return os.WriteFile(cleanPath, data, 0600) //nolint:gosec // G304: path is validated and cleaned above
 }
 
 // Load reads an AgentFile from disk.
-func Load(path string) (*AgentFile, error) {
-	cleanPath := filepath.Clean(path)
-	if strings.Contains(cleanPath, "..") {
+func Load(ctx context.Context, path string) (*AgentFile, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// Check the original path before cleaning so that traversal segments are
+	// not silently collapsed by filepath.Clean.
+	if strings.Contains(path, "..") {
 		return nil, fmt.Errorf("agentfile: path traversal not allowed: %q", path)
 	}
+	cleanPath := filepath.Clean(path)
 
-	data, err := os.ReadFile(cleanPath)
+	// Enforce the size limit before reading to avoid unbounded allocations
+	// from external input.
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("agentfile: stat file: %w", err)
+	}
+	if info.Size() > maxFileSize {
+		return nil, fmt.Errorf("agentfile: file exceeds maximum size of %d bytes", maxFileSize)
+	}
+
+	data, err := os.ReadFile(cleanPath) //nolint:gosec // G304: path is validated and cleaned above
 	if err != nil {
 		return nil, fmt.Errorf("agentfile: read file: %w", err)
 	}
 
 	d := NewDeserializer()
-	return d.Deserialize(data)
+	return d.Deserialize(ctx, data)
 }
 
 // NewAgentFile creates a new AgentFile with defaults.

--- a/config/agentfile/agentfile_test.go
+++ b/config/agentfile/agentfile_test.go
@@ -1,17 +1,17 @@
 package agentfile
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestJSONSerializer_Serialize(t *testing.T) {
 	af := NewAgentFile("test-agent", "Assistant", "openai", "gpt-4o")
 	s := &JSONSerializer{}
 
-	data, err := s.Serialize(af)
+	data, err := s.Serialize(context.Background(), af)
 	if err != nil {
 		t.Fatalf("Serialize: %v", err)
 	}
@@ -22,7 +22,7 @@ func TestJSONSerializer_Serialize(t *testing.T) {
 
 func TestJSONSerializer_NilInput(t *testing.T) {
 	s := &JSONSerializer{}
-	_, err := s.Serialize(nil)
+	_, err := s.Serialize(context.Background(), nil)
 	if err == nil {
 		t.Error("expected error for nil input")
 	}
@@ -67,7 +67,7 @@ func TestJSONDeserializer_Deserialize(t *testing.T) {
 	d := NewDeserializer()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			af, err := d.Deserialize([]byte(tt.json))
+			af, err := d.Deserialize(context.Background(), []byte(tt.json))
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error")
@@ -86,7 +86,7 @@ func TestJSONDeserializer_Deserialize(t *testing.T) {
 
 func TestJSONDeserializer_MaxSize(t *testing.T) {
 	d := NewDeserializer(WithMaxSize(10))
-	_, err := d.Deserialize(make([]byte, 100))
+	_, err := d.Deserialize(context.Background(), make([]byte, 100))
 	if err == nil {
 		t.Error("expected error for oversized input")
 	}
@@ -95,16 +95,16 @@ func TestJSONDeserializer_MaxSize(t *testing.T) {
 func TestRoundTrip(t *testing.T) {
 	af := NewAgentFile("round-trip", "Tester", "anthropic", "claude-3")
 	af.Agent.Description = "Test agent"
-	af.Agent.Tools = []ToolDef{{Name: "search", Config: map[string]any{"api_key_env": "SEARCH_KEY"}}}
+	af.Agent.Tools = []ToolDef{{Name: "search", Config: map[string]any{"api_key_env": "SEARCH_KEY"}}} //nolint:gosec // G101: false positive - env var name, not a credential
 
 	s := &JSONSerializer{}
-	data, err := s.Serialize(af)
+	data, err := s.Serialize(context.Background(), af)
 	if err != nil {
 		t.Fatalf("Serialize: %v", err)
 	}
 
 	d := NewDeserializer()
-	af2, err := d.Deserialize(data)
+	af2, err := d.Deserialize(context.Background(), data)
 	if err != nil {
 		t.Fatalf("Deserialize: %v", err)
 	}
@@ -122,6 +122,7 @@ func TestRoundTrip(t *testing.T) {
 
 func TestDefaultMigrator(t *testing.T) {
 	migrator := NewMigrator()
+	ctx := context.Background()
 
 	af := &AgentFile{
 		Version: "0.1",
@@ -132,7 +133,7 @@ func TestDefaultMigrator(t *testing.T) {
 		},
 	}
 
-	migrated, err := migrator.Migrate(af, "1.0")
+	migrated, err := migrator.Migrate(ctx, af, "1.0")
 	if err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestDefaultMigrator(t *testing.T) {
 	}
 
 	// Same version should be no-op.
-	same, err := migrator.Migrate(af, "0.1")
+	same, err := migrator.Migrate(ctx, af, "0.1")
 	if err != nil {
 		t.Fatalf("Migrate same: %v", err)
 	}
@@ -157,22 +158,66 @@ func TestDefaultMigrator(t *testing.T) {
 
 func TestDefaultMigrator_NilInput(t *testing.T) {
 	migrator := NewMigrator()
-	_, err := migrator.Migrate(nil, "1.0")
+	_, err := migrator.Migrate(context.Background(), nil, "1.0")
 	if err == nil {
 		t.Error("expected error for nil input")
+	}
+}
+
+func TestDefaultMigrator_UnsupportedVersion(t *testing.T) {
+	migrator := NewMigrator()
+	af := NewAgentFile("test", "R", "x", "y")
+	_, err := migrator.Migrate(context.Background(), af, "99.9")
+	if err == nil {
+		t.Error("expected error for unsupported target version")
+	}
+}
+
+func TestDefaultMigrator_DeepCopy(t *testing.T) {
+	migrator := NewMigrator()
+	af := &AgentFile{
+		Version: "0.1",
+		Agent: AgentDef{
+			ID:       "test",
+			Persona:  PersonaDef{Role: "Helper"},
+			Model:    ModelDef{Provider: "openai", Model: "gpt-4o"},
+			Settings: map[string]any{"k": "v"},
+			Tools:    []ToolDef{{Name: "t1", Config: map[string]any{"a": 1}}},
+		},
+	}
+
+	migrated, err := migrator.Migrate(context.Background(), af, "1.0")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Mutating the migrated copy must not affect the original.
+	migrated.Agent.Settings["k"] = "other"
+	migrated.Agent.Tools[0].Config["a"] = 999
+	migrated.Agent.Tools = append(migrated.Agent.Tools, ToolDef{Name: "t2"})
+
+	if af.Agent.Settings["k"] != "v" {
+		t.Errorf("original Settings mutated: %v", af.Agent.Settings)
+	}
+	if af.Agent.Tools[0].Config["a"] != 1 {
+		t.Errorf("original Tool config mutated: %v", af.Agent.Tools[0].Config)
+	}
+	if len(af.Agent.Tools) != 1 {
+		t.Errorf("original Tools slice mutated: len=%d", len(af.Agent.Tools))
 	}
 }
 
 func TestSaveAndLoad(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.af")
+	ctx := context.Background()
 
 	af := NewAgentFile("save-test", "Helper", "openai", "gpt-4o")
-	if err := Save(path, af); err != nil {
+	if err := Save(ctx, path, af); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
-	loaded, err := Load(path)
+	loaded, err := Load(ctx, path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -183,23 +228,40 @@ func TestSaveAndLoad(t *testing.T) {
 
 func TestSave_PathTraversal(t *testing.T) {
 	af := NewAgentFile("test", "R", "x", "y")
-	err := Save("/tmp/../etc/test.af", af)
+	err := Save(context.Background(), "/tmp/../etc/test.af", af)
 	if err == nil {
 		t.Error("expected error for path traversal")
 	}
 }
 
 func TestLoad_PathTraversal(t *testing.T) {
-	_, err := Load("/tmp/../etc/test.af")
+	_, err := Load(context.Background(), "/tmp/../etc/test.af")
 	if err == nil {
 		t.Error("expected error for path traversal")
 	}
 }
 
 func TestLoad_NotFound(t *testing.T) {
-	_, err := Load("/nonexistent/path/file.af")
+	_, err := Load(context.Background(), "/nonexistent/path/file.af")
 	if err == nil {
 		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoad_ExceedsMaxSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.af")
+
+	// Write a file larger than 1 MB to ensure the stat-based size guard fires
+	// before ReadFile allocates memory.
+	big := make([]byte, (1<<20)+1)
+	if err := os.WriteFile(path, big, 0600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, err := Load(context.Background(), path)
+	if err == nil {
+		t.Error("expected error for oversized file")
 	}
 }
 
@@ -214,7 +276,4 @@ func TestNewAgentFile(t *testing.T) {
 	if af.CreatedAt.IsZero() {
 		t.Error("CreatedAt should be set")
 	}
-
-	_ = time.Now() // ensure no unused import
-	_ = os.TempDir()
 }

--- a/config/agentfile/agentfile_test.go
+++ b/config/agentfile/agentfile_test.go
@@ -1,0 +1,220 @@
+package agentfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestJSONSerializer_Serialize(t *testing.T) {
+	af := NewAgentFile("test-agent", "Assistant", "openai", "gpt-4o")
+	s := &JSONSerializer{}
+
+	data, err := s.Serialize(af)
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty output")
+	}
+}
+
+func TestJSONSerializer_NilInput(t *testing.T) {
+	s := &JSONSerializer{}
+	_, err := s.Serialize(nil)
+	if err == nil {
+		t.Error("expected error for nil input")
+	}
+}
+
+func TestJSONDeserializer_Deserialize(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+		wantID  string
+	}{
+		{
+			name: "valid agent file",
+			json: `{
+				"version": "1.0",
+				"agent": {
+					"id": "test",
+					"persona": {"role": "Helper"},
+					"model": {"provider": "openai", "model": "gpt-4o"}
+				}
+			}`,
+			wantID: "test",
+		},
+		{
+			name:    "missing version",
+			json:    `{"agent": {"id": "test", "persona": {"role": "R"}, "model": {"provider": "x", "model": "y"}}}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing agent id",
+			json:    `{"version": "1.0", "agent": {"persona": {"role": "R"}, "model": {"provider": "x", "model": "y"}}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			json:    `{invalid`,
+			wantErr: true,
+		},
+	}
+
+	d := NewDeserializer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			af, err := d.Deserialize([]byte(tt.json))
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Deserialize: %v", err)
+			}
+			if af.Agent.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", af.Agent.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestJSONDeserializer_MaxSize(t *testing.T) {
+	d := NewDeserializer(WithMaxSize(10))
+	_, err := d.Deserialize(make([]byte, 100))
+	if err == nil {
+		t.Error("expected error for oversized input")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	af := NewAgentFile("round-trip", "Tester", "anthropic", "claude-3")
+	af.Agent.Description = "Test agent"
+	af.Agent.Tools = []ToolDef{{Name: "search", Config: map[string]any{"api_key_env": "SEARCH_KEY"}}}
+
+	s := &JSONSerializer{}
+	data, err := s.Serialize(af)
+	if err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+
+	d := NewDeserializer()
+	af2, err := d.Deserialize(data)
+	if err != nil {
+		t.Fatalf("Deserialize: %v", err)
+	}
+
+	if af2.Agent.ID != "round-trip" {
+		t.Errorf("ID = %q, want round-trip", af2.Agent.ID)
+	}
+	if af2.Agent.Description != "Test agent" {
+		t.Errorf("Description = %q, want Test agent", af2.Agent.Description)
+	}
+	if len(af2.Agent.Tools) != 1 {
+		t.Errorf("Tools = %d, want 1", len(af2.Agent.Tools))
+	}
+}
+
+func TestDefaultMigrator(t *testing.T) {
+	migrator := NewMigrator()
+
+	af := &AgentFile{
+		Version: "0.1",
+		Agent: AgentDef{
+			ID:      "test",
+			Persona: PersonaDef{Role: "Helper"},
+			Model:   ModelDef{Provider: "openai", Model: "gpt-4o"},
+		},
+	}
+
+	migrated, err := migrator.Migrate(af, "1.0")
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if migrated.Version != "1.0" {
+		t.Errorf("Version = %q, want 1.0", migrated.Version)
+	}
+
+	// Same version should be no-op.
+	same, err := migrator.Migrate(af, "0.1")
+	if err != nil {
+		t.Fatalf("Migrate same: %v", err)
+	}
+	if same.Version != "0.1" {
+		t.Errorf("Version = %q, want 0.1", same.Version)
+	}
+
+	versions := migrator.SupportedVersions()
+	if len(versions) == 0 {
+		t.Error("expected supported versions")
+	}
+}
+
+func TestDefaultMigrator_NilInput(t *testing.T) {
+	migrator := NewMigrator()
+	_, err := migrator.Migrate(nil, "1.0")
+	if err == nil {
+		t.Error("expected error for nil input")
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.af")
+
+	af := NewAgentFile("save-test", "Helper", "openai", "gpt-4o")
+	if err := Save(path, af); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Agent.ID != "save-test" {
+		t.Errorf("ID = %q, want save-test", loaded.Agent.ID)
+	}
+}
+
+func TestSave_PathTraversal(t *testing.T) {
+	af := NewAgentFile("test", "R", "x", "y")
+	err := Save("/tmp/../etc/test.af", af)
+	if err == nil {
+		t.Error("expected error for path traversal")
+	}
+}
+
+func TestLoad_PathTraversal(t *testing.T) {
+	_, err := Load("/tmp/../etc/test.af")
+	if err == nil {
+		t.Error("expected error for path traversal")
+	}
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	_, err := Load("/nonexistent/path/file.af")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestNewAgentFile(t *testing.T) {
+	af := NewAgentFile("my-agent", "Coder", "openai", "gpt-4o")
+	if af.Version != CurrentVersion {
+		t.Errorf("Version = %q, want %q", af.Version, CurrentVersion)
+	}
+	if af.Agent.ID != "my-agent" {
+		t.Errorf("ID = %q, want my-agent", af.Agent.ID)
+	}
+	if af.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+
+	_ = time.Now() // ensure no unused import
+	_ = os.TempDir()
+}

--- a/config/agentfile/doc.go
+++ b/config/agentfile/doc.go
@@ -1,0 +1,3 @@
+// Package agentfile provides the Agent File (.af) format for serializing
+// and deserializing agent configurations with version migration support.
+package agentfile


### PR DESCRIPTION
## Summary
- config/agentfile package (.af format), JSONSerializer/Deserializer, VersionMigrator

## Linear
- LOO-51: https://linear.app/lookatitude/issue/LOO-51

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)