### PR TITLE
LOO-52: Context Engineering as Explicit Discipline

### DIFF
--- a/llm/context/context.go
+++ b/llm/context/context.go
@@ -1,0 +1,357 @@
+package context
+
+import (
+	gocontext "context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// ContextStep is a single step in the context engineering pipeline.
+// Each step transforms the context items in some way.
+type ContextStep interface {
+	// Process transforms the context items and returns the result.
+	Process(ctx gocontext.Context, items []ContextItem) ([]ContextItem, error)
+	// Name returns the step name for logging and debugging.
+	Name() string
+}
+
+// ContextPipeline orchestrates a sequence of ContextSteps to prepare
+// optimal LLM context.
+type ContextPipeline interface {
+	// Execute runs all pipeline steps in order.
+	Execute(ctx gocontext.Context, input PipelineInput) (PipelineOutput, error)
+}
+
+// ContextItem is a single piece of context that may be included in the
+// LLM prompt. Items have a score for ranking.
+type ContextItem struct {
+	// ID uniquely identifies this item.
+	ID string
+	// Type classifies the item (e.g., "message", "document", "tool_result").
+	Type string
+	// Content is the textual content.
+	Content string
+	// Score is the relevance score in [0.0, 1.0].
+	Score float64
+	// Metadata holds extra attributes.
+	Metadata map[string]any
+}
+
+// PipelineInput is the input to a context pipeline.
+type PipelineInput struct {
+	// Query is the current user query.
+	Query string
+	// Messages are the existing conversation messages.
+	Messages []schema.Message
+	// MaxTokens is the target context window budget.
+	MaxTokens int
+	// Metadata holds extra attributes.
+	Metadata map[string]any
+}
+
+// PipelineOutput is the result of running the context pipeline.
+type PipelineOutput struct {
+	// Items are the selected and ordered context items.
+	Items []ContextItem
+	// Messages are the final prepared messages for the LLM.
+	Messages []schema.Message
+	// TokenEstimate is the estimated token count.
+	TokenEstimate int
+	// StepsExecuted lists the steps that ran.
+	StepsExecuted []string
+}
+
+// Option configures a DefaultPipeline.
+type Option func(*pipelineOptions)
+
+type pipelineOptions struct {
+	steps     []ContextStep
+	maxTokens int
+}
+
+// WithStep adds a step to the pipeline.
+func WithStep(step ContextStep) Option {
+	return func(o *pipelineOptions) { o.steps = append(o.steps, step) }
+}
+
+// WithMaxTokens sets the default maximum token budget.
+func WithMaxTokens(n int) Option {
+	return func(o *pipelineOptions) { o.maxTokens = n }
+}
+
+// DefaultPipeline is the standard context pipeline implementation.
+type DefaultPipeline struct {
+	opts pipelineOptions
+}
+
+var _ ContextPipeline = (*DefaultPipeline)(nil)
+
+// NewPipeline creates a context pipeline with the given options.
+func NewPipeline(opts ...Option) *DefaultPipeline {
+	o := pipelineOptions{maxTokens: 4096}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &DefaultPipeline{opts: o}
+}
+
+// Execute runs all pipeline steps in sequence.
+func (p *DefaultPipeline) Execute(ctx gocontext.Context, input PipelineInput) (PipelineOutput, error) {
+	if input.MaxTokens <= 0 {
+		input.MaxTokens = p.opts.maxTokens
+	}
+
+	// Convert messages to context items.
+	items := messagesToItems(input.Messages)
+
+	var stepsExecuted []string
+
+	for _, step := range p.opts.steps {
+		if err := ctx.Err(); err != nil {
+			return PipelineOutput{}, err
+		}
+
+		var err error
+		items, err = step.Process(ctx, items)
+		if err != nil {
+			return PipelineOutput{}, fmt.Errorf("context: step %q: %w", step.Name(), err)
+		}
+		stepsExecuted = append(stepsExecuted, step.Name())
+	}
+
+	tokenEstimate := estimateTokens(items)
+
+	return PipelineOutput{
+		Items:         items,
+		Messages:      input.Messages,
+		TokenEstimate: tokenEstimate,
+		StepsExecuted: stepsExecuted,
+	}, nil
+}
+
+func messagesToItems(msgs []schema.Message) []ContextItem {
+	items := make([]ContextItem, 0, len(msgs))
+	for i, m := range msgs {
+		content := ""
+		for _, p := range m.GetContent() {
+			if tp, ok := p.(schema.TextPart); ok {
+				content += tp.Text
+			}
+		}
+		items = append(items, ContextItem{
+			ID:      fmt.Sprintf("msg-%d", i),
+			Type:    "message",
+			Content: content,
+			Score:   1.0,
+			Metadata: map[string]any{
+				"role":  string(m.GetRole()),
+				"index": i,
+			},
+		})
+	}
+	return items
+}
+
+func estimateTokens(items []ContextItem) int {
+	total := 0
+	for _, item := range items {
+		total += len(item.Content) / 4 // Rough: 4 chars per token.
+	}
+	if total == 0 {
+		total = 1
+	}
+	return total
+}
+
+// PipelineBuilder fluently constructs a ContextPipeline.
+type PipelineBuilder struct {
+	opts []Option
+}
+
+// NewBuilder creates a pipeline builder.
+func NewBuilder() *PipelineBuilder {
+	return &PipelineBuilder{}
+}
+
+// WithRetrieve adds a retrieve step.
+func (b *PipelineBuilder) WithRetrieve(step ContextStep) *PipelineBuilder {
+	b.opts = append(b.opts, WithStep(step))
+	return b
+}
+
+// WithRank adds a ranking step.
+func (b *PipelineBuilder) WithRank(step ContextStep) *PipelineBuilder {
+	b.opts = append(b.opts, WithStep(step))
+	return b
+}
+
+// WithFilter adds a filtering step.
+func (b *PipelineBuilder) WithFilter(step ContextStep) *PipelineBuilder {
+	b.opts = append(b.opts, WithStep(step))
+	return b
+}
+
+// WithStructure adds a structuring step.
+func (b *PipelineBuilder) WithStructure(step ContextStep) *PipelineBuilder {
+	b.opts = append(b.opts, WithStep(step))
+	return b
+}
+
+// SetMaxTokens sets the token budget.
+func (b *PipelineBuilder) SetMaxTokens(n int) *PipelineBuilder {
+	b.opts = append(b.opts, WithMaxTokens(n))
+	return b
+}
+
+// Build creates the configured pipeline.
+func (b *PipelineBuilder) Build() *DefaultPipeline {
+	return NewPipeline(b.opts...)
+}
+
+// RelevanceRanker ranks context items by their relevance score.
+type RelevanceRanker struct{}
+
+var _ ContextStep = (*RelevanceRanker)(nil)
+
+// Name returns the step name.
+func (r *RelevanceRanker) Name() string { return "relevance_rank" }
+
+// Process sorts items by score descending.
+func (r *RelevanceRanker) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
+	result := make([]ContextItem, len(items))
+	copy(result, items)
+	sort.Slice(result, func(i, j int) bool { return result[i].Score > result[j].Score })
+	return result, nil
+}
+
+// TokenBudgetFilter removes items that exceed the token budget.
+type TokenBudgetFilter struct {
+	maxTokens int
+}
+
+var _ ContextStep = (*TokenBudgetFilter)(nil)
+
+// NewTokenBudgetFilter creates a filter with the given token limit.
+func NewTokenBudgetFilter(maxTokens int) *TokenBudgetFilter {
+	return &TokenBudgetFilter{maxTokens: maxTokens}
+}
+
+// Name returns the step name.
+func (f *TokenBudgetFilter) Name() string { return "token_budget_filter" }
+
+// Process removes items from the end until within budget.
+func (f *TokenBudgetFilter) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
+	var result []ContextItem
+	used := 0
+	for _, item := range items {
+		tokens := len(item.Content) / 4
+		if tokens == 0 {
+			tokens = 1
+		}
+		if used+tokens > f.maxTokens {
+			continue
+		}
+		used += tokens
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+// DuplicateFilter removes items with duplicate content.
+type DuplicateFilter struct{}
+
+var _ ContextStep = (*DuplicateFilter)(nil)
+
+// Name returns the step name.
+func (f *DuplicateFilter) Name() string { return "duplicate_filter" }
+
+// Process removes duplicate items based on content.
+func (f *DuplicateFilter) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
+	seen := make(map[string]bool)
+	var result []ContextItem
+	for _, item := range items {
+		if seen[item.Content] {
+			continue
+		}
+		seen[item.Content] = true
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+// RecencyBooster increases scores for more recent items.
+type RecencyBooster struct {
+	boost float64
+}
+
+var _ ContextStep = (*RecencyBooster)(nil)
+
+// NewRecencyBooster creates a booster that adds the given value to recent items.
+func NewRecencyBooster(boost float64) *RecencyBooster {
+	return &RecencyBooster{boost: boost}
+}
+
+// Name returns the step name.
+func (b *RecencyBooster) Name() string { return "recency_boost" }
+
+// Process increases scores for items later in the list.
+func (b *RecencyBooster) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
+	result := make([]ContextItem, len(items))
+	copy(result, items)
+	for i := range result {
+		// More recent items (higher index) get more boost.
+		fraction := float64(i) / float64(max(1, len(result)-1))
+		result[i].Score += b.boost * fraction
+		if result[i].Score > 1.0 {
+			result[i].Score = 1.0
+		}
+	}
+	return result, nil
+}
+
+// Factory creates a ContextStep.
+type Factory func() (ContextStep, error)
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]Factory)
+)
+
+// Register adds a step factory to the global registry.
+func Register(name string, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry[name] = f
+}
+
+// NewStep creates a ContextStep by name from the registry.
+func NewStep(name string) (ContextStep, error) {
+	registryMu.RLock()
+	f, ok := registry[name]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("context: unknown step %q (registered: %v)", name, ListSteps())
+	}
+	return f()
+}
+
+// ListSteps returns the names of all registered steps, sorted alphabetically.
+func ListSteps() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func init() {
+	Register("relevance_rank", func() (ContextStep, error) { return &RelevanceRanker{}, nil })
+	Register("duplicate_filter", func() (ContextStep, error) { return &DuplicateFilter{}, nil })
+	Register("recency_boost", func() (ContextStep, error) { return NewRecencyBooster(0.2), nil })
+}

--- a/llm/context/context.go
+++ b/llm/context/context.go
@@ -56,7 +56,10 @@ type PipelineInput struct {
 type PipelineOutput struct {
 	// Items are the selected and ordered context items.
 	Items []ContextItem
-	// Messages are the final prepared messages for the LLM.
+	// Messages are the final prepared messages for the LLM, reconstructed
+	// from Items whose "source" metadata key is "message". Items added by
+	// pipeline steps that do not originate from a schema.Message are not
+	// included here and must be consumed via Items directly.
 	Messages []schema.Message
 	// TokenEstimate is the estimated token count.
 	TokenEstimate int
@@ -126,10 +129,34 @@ func (p *DefaultPipeline) Execute(ctx gocontext.Context, input PipelineInput) (P
 
 	return PipelineOutput{
 		Items:         items,
-		Messages:      input.Messages,
+		Messages:      itemsToMessages(items, input.Messages),
 		TokenEstimate: tokenEstimate,
 		StepsExecuted: stepsExecuted,
 	}, nil
+}
+
+// itemsToMessages rebuilds the ordered message slice from the pipeline's
+// remaining items. Only items that originated from the input messages
+// (identified by the "source"="message" and "index" metadata set in
+// messagesToItems) are included, preserving the order in which the pipeline
+// left them.
+func itemsToMessages(items []ContextItem, original []schema.Message) []schema.Message {
+	result := make([]schema.Message, 0, len(items))
+	for _, it := range items {
+		if it.Metadata == nil {
+			continue
+		}
+		src, _ := it.Metadata["source"].(string)
+		if src != "message" {
+			continue
+		}
+		idx, ok := it.Metadata["index"].(int)
+		if !ok || idx < 0 || idx >= len(original) {
+			continue
+		}
+		result = append(result, original[idx])
+	}
+	return result
 }
 
 func messagesToItems(msgs []schema.Message) []ContextItem {
@@ -147,8 +174,9 @@ func messagesToItems(msgs []schema.Message) []ContextItem {
 			Content: content,
 			Score:   1.0,
 			Metadata: map[string]any{
-				"role":  string(m.GetRole()),
-				"index": i,
+				"source": "message",
+				"role":   string(m.GetRole()),
+				"index":  i,
 			},
 		})
 	}
@@ -242,7 +270,9 @@ func NewTokenBudgetFilter(maxTokens int) *TokenBudgetFilter {
 // Name returns the step name.
 func (f *TokenBudgetFilter) Name() string { return "token_budget_filter" }
 
-// Process removes items from the end until within budget.
+// Process keeps items in their original order until the token budget is
+// exhausted. Items that individually exceed the remaining budget are
+// skipped; subsequent smaller items may still be included (greedy packing).
 func (f *TokenBudgetFilter) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
 	var result []ContextItem
 	used := 0
@@ -321,6 +351,10 @@ var (
 )
 
 // Register adds a step factory to the global registry.
+//
+// Register MUST only be called from package init() functions. Calling it
+// after program start is unsupported and may race with concurrent NewStep
+// lookups. Third-party steps should self-register via their own init().
 func Register(name string, f Factory) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
@@ -352,6 +386,7 @@ func ListSteps() []string {
 
 func init() {
 	Register("relevance_rank", func() (ContextStep, error) { return &RelevanceRanker{}, nil })
+	Register("token_budget_filter", func() (ContextStep, error) { return NewTokenBudgetFilter(4096), nil })
 	Register("duplicate_filter", func() (ContextStep, error) { return &DuplicateFilter{}, nil })
 	Register("recency_boost", func() (ContextStep, error) { return NewRecencyBooster(0.2), nil })
 }

--- a/llm/context/context_test.go
+++ b/llm/context/context_test.go
@@ -73,9 +73,9 @@ func TestRelevanceRanker(t *testing.T) {
 func TestTokenBudgetFilter(t *testing.T) {
 	filter := NewTokenBudgetFilter(10) // Very small budget.
 	items := []ContextItem{
-		{ID: "1", Content: "short"},                                    // ~1 token
+		{ID: "1", Content: "short"},                                  // ~1 token
 		{ID: "2", Content: "this is a much longer piece of content"}, // ~8 tokens
-		{ID: "3", Content: "another longer content here"},              // ~6 tokens
+		{ID: "3", Content: "another longer content here"},            // ~6 tokens
 	}
 
 	result, err := filter.Process(gocontext.Background(), items)
@@ -160,22 +160,89 @@ func TestPipelineBuilder(t *testing.T) {
 
 func TestStepRegistry(t *testing.T) {
 	names := ListSteps()
-	if len(names) < 3 {
-		t.Errorf("expected at least 3 registered steps, got %d", len(names))
+	wantAll := []string{"relevance_rank", "token_budget_filter", "duplicate_filter", "recency_boost"}
+	if len(names) < len(wantAll) {
+		t.Errorf("expected at least %d registered steps, got %d: %v", len(wantAll), len(names), names)
+	}
+	present := make(map[string]bool, len(names))
+	for _, n := range names {
+		present[n] = true
+	}
+	for _, want := range wantAll {
+		if !present[want] {
+			t.Errorf("expected step %q to be registered, got %v", want, names)
+		}
 	}
 
-	step, err := NewStep("relevance_rank")
-	if err != nil {
-		t.Fatalf("NewStep: %v", err)
-	}
-	if step.Name() != "relevance_rank" {
-		t.Errorf("Name = %q, want relevance_rank", step.Name())
+	for _, want := range wantAll {
+		step, err := NewStep(want)
+		if err != nil {
+			t.Fatalf("NewStep(%q): %v", want, err)
+		}
+		if step.Name() != want {
+			t.Errorf("Name = %q, want %q", step.Name(), want)
+		}
 	}
 
-	_, err = NewStep("nonexistent")
+	_, err := NewStep("nonexistent")
 	if err == nil {
 		t.Error("expected error for unknown step")
 	}
+}
+
+func TestPipelineOutput_MessagesReflectFiltering(t *testing.T) {
+	// Drop the first message via a custom step; ensure output.Messages
+	// no longer includes it.
+	dropFirst := stepFunc{name: "drop_first", fn: func(items []ContextItem) []ContextItem {
+		if len(items) == 0 {
+			return items
+		}
+		return items[1:]
+	}}
+
+	pipeline := NewPipeline(WithStep(dropFirst))
+	input := PipelineInput{
+		Messages: []schema.Message{
+			schema.NewHumanMessage("first"),
+			schema.NewAIMessage("second"),
+			schema.NewHumanMessage("third"),
+		},
+		MaxTokens: 1000,
+	}
+
+	output, err := pipeline.Execute(gocontext.Background(), input)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(output.Messages) != 2 {
+		t.Fatalf("output.Messages = %d, want 2 (first dropped)", len(output.Messages))
+	}
+	if got := textOf(output.Messages[0]); got != "second" {
+		t.Errorf("output.Messages[0] = %q, want %q", got, "second")
+	}
+	if got := textOf(output.Messages[1]); got != "third" {
+		t.Errorf("output.Messages[1] = %q, want %q", got, "third")
+	}
+}
+
+type stepFunc struct {
+	name string
+	fn   func([]ContextItem) []ContextItem
+}
+
+func (s stepFunc) Name() string { return s.name }
+func (s stepFunc) Process(_ gocontext.Context, items []ContextItem) ([]ContextItem, error) {
+	return s.fn(items), nil
+}
+
+func textOf(m schema.Message) string {
+	out := ""
+	for _, p := range m.GetContent() {
+		if tp, ok := p.(schema.TextPart); ok {
+			out += tp.Text
+		}
+	}
+	return out
 }
 
 func TestStepNames(t *testing.T) {

--- a/llm/context/context_test.go
+++ b/llm/context/context_test.go
@@ -1,0 +1,196 @@
+package context
+
+import (
+	gocontext "context"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+func TestDefaultPipeline_Execute(t *testing.T) {
+	pipeline := NewPipeline(
+		WithStep(&RecencyBooster{boost: 0.1}),
+		WithStep(&RelevanceRanker{}),
+	)
+
+	input := PipelineInput{
+		Query: "test query",
+		Messages: []schema.Message{
+			schema.NewHumanMessage("hello"),
+			schema.NewAIMessage("hi there"),
+		},
+		MaxTokens: 1000,
+	}
+
+	output, err := pipeline.Execute(gocontext.Background(), input)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(output.Items) == 0 {
+		t.Error("expected items in output")
+	}
+	if len(output.StepsExecuted) != 2 {
+		t.Errorf("StepsExecuted = %d, want 2", len(output.StepsExecuted))
+	}
+	if output.TokenEstimate <= 0 {
+		t.Errorf("TokenEstimate = %d, want > 0", output.TokenEstimate)
+	}
+}
+
+func TestDefaultPipeline_ContextCancellation(t *testing.T) {
+	ctx, cancel := gocontext.WithCancel(gocontext.Background())
+	cancel()
+
+	pipeline := NewPipeline(WithStep(&RelevanceRanker{}))
+	_, err := pipeline.Execute(ctx, PipelineInput{MaxTokens: 100})
+	if err == nil {
+		t.Error("expected context cancellation error")
+	}
+}
+
+func TestRelevanceRanker(t *testing.T) {
+	ranker := &RelevanceRanker{}
+	items := []ContextItem{
+		{ID: "1", Score: 0.3},
+		{ID: "2", Score: 0.9},
+		{ID: "3", Score: 0.5},
+	}
+
+	result, err := ranker.Process(gocontext.Background(), items)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	if result[0].ID != "2" {
+		t.Errorf("first item = %q, want 2 (highest score)", result[0].ID)
+	}
+	if result[2].ID != "1" {
+		t.Errorf("last item = %q, want 1 (lowest score)", result[2].ID)
+	}
+}
+
+func TestTokenBudgetFilter(t *testing.T) {
+	filter := NewTokenBudgetFilter(10) // Very small budget.
+	items := []ContextItem{
+		{ID: "1", Content: "short"},                                    // ~1 token
+		{ID: "2", Content: "this is a much longer piece of content"}, // ~8 tokens
+		{ID: "3", Content: "another longer content here"},              // ~6 tokens
+	}
+
+	result, err := filter.Process(gocontext.Background(), items)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	totalTokens := 0
+	for _, item := range result {
+		tokens := len(item.Content) / 4
+		if tokens == 0 {
+			tokens = 1
+		}
+		totalTokens += tokens
+	}
+
+	if totalTokens > 10 {
+		t.Errorf("total tokens = %d, exceeds budget of 10", totalTokens)
+	}
+}
+
+func TestDuplicateFilter(t *testing.T) {
+	filter := &DuplicateFilter{}
+	items := []ContextItem{
+		{ID: "1", Content: "hello"},
+		{ID: "2", Content: "world"},
+		{ID: "3", Content: "hello"}, // duplicate
+	}
+
+	result, err := filter.Process(gocontext.Background(), items)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("items = %d, want 2 (duplicate removed)", len(result))
+	}
+}
+
+func TestRecencyBooster(t *testing.T) {
+	booster := NewRecencyBooster(0.5)
+	items := []ContextItem{
+		{ID: "1", Score: 0.5},
+		{ID: "2", Score: 0.5},
+		{ID: "3", Score: 0.5},
+	}
+
+	result, err := booster.Process(gocontext.Background(), items)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// Last item should have highest score (most boosted).
+	if result[2].Score <= result[0].Score {
+		t.Errorf("last item score (%f) should be > first item score (%f)", result[2].Score, result[0].Score)
+	}
+}
+
+func TestPipelineBuilder(t *testing.T) {
+	pipeline := NewBuilder().
+		WithRetrieve(&DuplicateFilter{}). // Using as placeholder steps.
+		WithRank(&RelevanceRanker{}).
+		WithFilter(NewTokenBudgetFilter(1000)).
+		WithStructure(&RecencyBooster{boost: 0.1}).
+		SetMaxTokens(2000).
+		Build()
+
+	input := PipelineInput{
+		Query:    "test",
+		Messages: []schema.Message{schema.NewHumanMessage("hello")},
+	}
+
+	output, err := pipeline.Execute(gocontext.Background(), input)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(output.StepsExecuted) != 4 {
+		t.Errorf("StepsExecuted = %d, want 4", len(output.StepsExecuted))
+	}
+}
+
+func TestStepRegistry(t *testing.T) {
+	names := ListSteps()
+	if len(names) < 3 {
+		t.Errorf("expected at least 3 registered steps, got %d", len(names))
+	}
+
+	step, err := NewStep("relevance_rank")
+	if err != nil {
+		t.Fatalf("NewStep: %v", err)
+	}
+	if step.Name() != "relevance_rank" {
+		t.Errorf("Name = %q, want relevance_rank", step.Name())
+	}
+
+	_, err = NewStep("nonexistent")
+	if err == nil {
+		t.Error("expected error for unknown step")
+	}
+}
+
+func TestStepNames(t *testing.T) {
+	steps := []ContextStep{
+		&RelevanceRanker{},
+		NewTokenBudgetFilter(100),
+		&DuplicateFilter{},
+		NewRecencyBooster(0.1),
+	}
+
+	expectedNames := []string{"relevance_rank", "token_budget_filter", "duplicate_filter", "recency_boost"}
+
+	for i, step := range steps {
+		if step.Name() != expectedNames[i] {
+			t.Errorf("step %d Name = %q, want %q", i, step.Name(), expectedNames[i])
+		}
+	}
+}

--- a/llm/context/doc.go
+++ b/llm/context/doc.go
@@ -1,0 +1,5 @@
+// Package context provides a context engineering pipeline for preparing
+// optimal LLM input. It implements a multi-step pipeline with Retrieve,
+// Rank, Filter, and Structure steps that can be composed to build the
+// best possible context window for each request.
+package context


### PR DESCRIPTION
## Summary
- llm/context package, ContextPipeline, RelevanceRanker, TokenBudgetFilter, DuplicateFilter, RecencyBooster

## Linear
- LOO-52: https://linear.app/lookatitude/issue/LOO-52

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)