### PR TITLE
LOO-54: Code-as-Action Agents (CodeAct Pattern)

### DIFF
--- a/agent/codeact/agent.go
+++ b/agent/codeact/agent.go
@@ -221,86 +221,128 @@ func (a *CodeActAgent) Stream(ctx context.Context, input string, opts ...agent.O
 	return func(yield func(agent.Event, error) bool) {
 		// If we don't have a planner, fall back to the base agent behaviour.
 		if a.planner == nil {
-			for event, err := range a.base.Stream(ctx, input, opts...) {
-				if !yield(event, err) {
-					return
-				}
-				if err != nil {
-					return
-				}
-			}
+			a.streamFromBase(ctx, input, opts, yield)
+			return
+		}
+		a.runPlanActObserve(ctx, input, yield)
+	}
+}
+
+// streamFromBase forwards events from the wrapped BaseAgent unchanged. Used
+// when no planner is configured.
+func (a *CodeActAgent) streamFromBase(ctx context.Context, input string, opts []agent.Option, yield func(agent.Event, error) bool) {
+	for event, err := range a.base.Stream(ctx, input, opts...) {
+		if !yield(event, err) {
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// runPlanActObserve drives the plan → act → observe loop until the planner
+// emits ActionFinish, max iterations is reached, the context is cancelled, or
+// the consumer stops iterating.
+func (a *CodeActAgent) runPlanActObserve(ctx context.Context, input string, yield func(agent.Event, error) bool) {
+	state := a.initialPlannerState(input)
+
+	for i := 0; i < a.maxIterations; i++ {
+		if err := ctx.Err(); err != nil {
+			yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
+			return
+		}
+		state.Iteration = i
+
+		actions, err := a.planOrReplan(ctx, i, state)
+		if err != nil {
+			yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
 			return
 		}
 
-		// Build initial messages from persona + input.
-		var messages []schema.Message
-		if !a.base.Persona().IsEmpty() {
-			if sysMsg := a.base.Persona().ToSystemMessage(); sysMsg != nil {
-				messages = append(messages, sysMsg)
-			}
+		done, stop := a.dispatchActions(ctx, actions, &state, yield)
+		if stop || done {
+			return
 		}
-		messages = append(messages, schema.NewHumanMessage(input))
+	}
 
-		state := agent.PlannerState{
-			Input:    input,
-			Messages: messages,
-			Tools:    a.base.Tools(),
-			Metadata: make(map[string]any),
+	yield(
+		agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: "maximum iterations exceeded"},
+		fmt.Errorf("codeact agent: reached maximum iterations (%d)", a.maxIterations),
+	)
+}
+
+// initialPlannerState builds the starting PlannerState from persona + input.
+func (a *CodeActAgent) initialPlannerState(input string) agent.PlannerState {
+	var messages []schema.Message
+	if !a.base.Persona().IsEmpty() {
+		if sysMsg := a.base.Persona().ToSystemMessage(); sysMsg != nil {
+			messages = append(messages, sysMsg)
 		}
+	}
+	messages = append(messages, schema.NewHumanMessage(input))
 
-		for i := 0; i < a.maxIterations; i++ {
-			if err := ctx.Err(); err != nil {
-				yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
-				return
-			}
-			state.Iteration = i
+	return agent.PlannerState{
+		Input:    input,
+		Messages: messages,
+		Tools:    a.base.Tools(),
+		Metadata: make(map[string]any),
+	}
+}
 
-			var actions []agent.Action
-			var err error
-			if i == 0 {
-				actions, err = a.planner.Plan(ctx, state)
-			} else {
-				actions, err = a.planner.Replan(ctx, state)
-			}
-			if err != nil {
-				yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
-				return
-			}
+// planOrReplan calls Plan on the first iteration and Replan thereafter.
+func (a *CodeActAgent) planOrReplan(ctx context.Context, iteration int, state agent.PlannerState) ([]agent.Action, error) {
+	if iteration == 0 {
+		return a.planner.Plan(ctx, state)
+	}
+	return a.planner.Replan(ctx, state)
+}
 
-			done := false
-			for _, action := range actions {
-				if action.Type == ActionCode {
-					obs, stop := a.handleCodeAction(ctx, action, yield)
-					state.Observations = append(state.Observations, obs)
-					if stop {
-						return
-					}
-					continue
-				}
-
-				switch action.Type {
-				case agent.ActionFinish, agent.ActionRespond:
-					if action.Message != "" {
-						if !yield(agent.Event{Type: agent.EventText, AgentID: a.ID(), Text: action.Message}, nil) {
-							return
-						}
-					}
-					if action.Type == agent.ActionFinish {
-						yield(agent.Event{Type: agent.EventDone, AgentID: a.ID(), Text: action.Message}, nil)
-						done = true
-					}
-				default:
-					// Unsupported action type in the codeact loop.
-					yield(agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: fmt.Sprintf("unsupported action type: %s", action.Type)}, fmt.Errorf("unsupported action type: %s", action.Type))
-					return
-				}
-				if done {
-					return
-				}
+// dispatchActions processes each action returned from the planner. It returns
+// (done, stop): done=true when the loop should terminate normally, stop=true
+// when the consumer signalled that iteration should stop.
+func (a *CodeActAgent) dispatchActions(ctx context.Context, actions []agent.Action, state *agent.PlannerState, yield func(agent.Event, error) bool) (done, stop bool) {
+	for _, action := range actions {
+		if action.Type == ActionCode {
+			obs, shouldStop := a.handleCodeAction(ctx, action, yield)
+			state.Observations = append(state.Observations, obs)
+			if shouldStop {
+				return false, true
 			}
+			continue
 		}
 
-		yield(agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: "maximum iterations exceeded"}, fmt.Errorf("codeact agent: reached maximum iterations (%d)", a.maxIterations))
+		finished, shouldStop := a.handleNonCodeAction(action, yield)
+		if shouldStop {
+			return false, true
+		}
+		if finished {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+// handleNonCodeAction dispatches Finish/Respond actions and reports unsupported
+// types. finished=true when the loop should terminate, stop=true when the
+// consumer asked to stop iterating.
+func (a *CodeActAgent) handleNonCodeAction(action agent.Action, yield func(agent.Event, error) bool) (finished, stop bool) {
+	switch action.Type {
+	case agent.ActionFinish, agent.ActionRespond:
+		if action.Message != "" {
+			if !yield(agent.Event{Type: agent.EventText, AgentID: a.ID(), Text: action.Message}, nil) {
+				return false, true
+			}
+		}
+		if action.Type == agent.ActionFinish {
+			yield(agent.Event{Type: agent.EventDone, AgentID: a.ID(), Text: action.Message}, nil)
+			return true, false
+		}
+		return false, false
+	default:
+		msg := fmt.Sprintf("unsupported action type: %s", action.Type)
+		yield(agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: msg}, fmt.Errorf("%s", msg))
+		return false, true
 	}
 }
 

--- a/agent/codeact/agent.go
+++ b/agent/codeact/agent.go
@@ -1,0 +1,256 @@
+package codeact
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"strings"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// EventCodeExec is the event type for code execution events.
+const EventCodeExec agent.EventType = "code_exec"
+
+// EventCodeResult is the event type for code execution result events.
+const EventCodeResult agent.EventType = "code_result"
+
+// CodeActAgent wraps a BaseAgent with a CodeExecutor. It intercepts ActionCode
+// actions from the planner and routes them to the executor instead of the
+// standard tool execution path.
+type CodeActAgent struct {
+	base     *agent.BaseAgent
+	executor CodeExecutor
+	language string
+	timeout  time.Duration
+	hooks    CodeActHooks
+}
+
+// Compile-time interface check.
+var _ agent.Agent = (*CodeActAgent)(nil)
+
+// AgentOption configures a CodeActAgent.
+type AgentOption func(*agentOptions)
+
+type agentOptions struct {
+	executor       CodeExecutor
+	language       string
+	timeout        time.Duration
+	hooks          CodeActHooks
+	agentOpts      []agent.Option
+	llm            llm.ChatModel
+	allowedImports []string
+}
+
+func defaultAgentOptions() agentOptions {
+	return agentOptions{
+		language: "python",
+		timeout:  30 * time.Second,
+	}
+}
+
+// WithExecutor sets the code executor for the agent.
+func WithExecutor(e CodeExecutor) AgentOption {
+	return func(o *agentOptions) {
+		o.executor = e
+	}
+}
+
+// WithLanguage sets the preferred programming language.
+func WithLanguage(lang string) AgentOption {
+	return func(o *agentOptions) {
+		o.language = lang
+	}
+}
+
+// WithExecTimeout sets the default timeout for code execution.
+func WithExecTimeout(d time.Duration) AgentOption {
+	return func(o *agentOptions) {
+		if d > 0 {
+			o.timeout = d
+		}
+	}
+}
+
+// WithCodeActHooks sets lifecycle hooks for code execution.
+func WithCodeActHooks(h CodeActHooks) AgentOption {
+	return func(o *agentOptions) {
+		o.hooks = h
+	}
+}
+
+// WithAgentLLM sets the LLM for the underlying agent.
+func WithAgentLLM(model llm.ChatModel) AgentOption {
+	return func(o *agentOptions) {
+		o.llm = model
+	}
+}
+
+// WithAgentOption passes through an option to the underlying BaseAgent.
+func WithAgentOption(opt agent.Option) AgentOption {
+	return func(o *agentOptions) {
+		o.agentOpts = append(o.agentOpts, opt)
+	}
+}
+
+// WithAllowedCodeImports sets allowed imports for the planner.
+func WithAllowedCodeImports(imports []string) AgentOption {
+	return func(o *agentOptions) {
+		o.allowedImports = imports
+	}
+}
+
+// NewCodeActAgent creates a new CodeActAgent with the given ID and options.
+func NewCodeActAgent(id string, opts ...AgentOption) *CodeActAgent {
+	o := defaultAgentOptions()
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	// Default to NoopExecutor if none provided
+	executor := o.executor
+	if executor == nil {
+		executor = NewNoopExecutor()
+	}
+
+	// Build planner options
+	var plannerOpts []PlannerOption
+	plannerOpts = append(plannerOpts, WithPlannerLanguage(o.language))
+	if len(o.allowedImports) > 0 {
+		plannerOpts = append(plannerOpts, WithAllowedImports(o.allowedImports))
+	}
+
+	// Build base agent options
+	baseOpts := make([]agent.Option, 0, len(o.agentOpts)+3)
+	if o.llm != nil {
+		planner := NewCodeActPlanner(o.llm, plannerOpts...)
+		baseOpts = append(baseOpts, agent.WithPlanner(planner))
+		baseOpts = append(baseOpts, agent.WithLLM(o.llm))
+	}
+	baseOpts = append(baseOpts, o.agentOpts...)
+
+	base := agent.New(id, baseOpts...)
+
+	return &CodeActAgent{
+		base:     base,
+		executor: executor,
+		language: o.language,
+		timeout:  o.timeout,
+		hooks:    o.hooks,
+	}
+}
+
+// ID returns the agent's unique identifier.
+func (a *CodeActAgent) ID() string { return a.base.ID() }
+
+// Persona returns the agent's persona.
+func (a *CodeActAgent) Persona() agent.Persona { return a.base.Persona() }
+
+// Tools returns the tools available to the agent.
+func (a *CodeActAgent) Tools() []tool.Tool { return a.base.Tools() }
+
+// Children returns child agents.
+func (a *CodeActAgent) Children() []agent.Agent { return a.base.Children() }
+
+// Invoke executes the agent synchronously and returns the final text result.
+func (a *CodeActAgent) Invoke(ctx context.Context, input string, opts ...agent.Option) (string, error) {
+	var result strings.Builder
+	var lastErr error
+
+	for event, err := range a.Stream(ctx, input, opts...) {
+		if err != nil {
+			lastErr = err
+			break
+		}
+		switch event.Type {
+		case agent.EventText, agent.EventDone:
+			result.WriteString(event.Text)
+		case agent.EventError:
+			lastErr = fmt.Errorf("agent error: %s", event.Text)
+		}
+	}
+
+	if lastErr != nil {
+		return result.String(), lastErr
+	}
+	return result.String(), nil
+}
+
+// Stream executes the agent and returns an iterator of events.
+// It intercepts ActionCode events from the base agent's stream, executes the
+// code via the CodeExecutor, and injects the results back.
+func (a *CodeActAgent) Stream(ctx context.Context, input string, opts ...agent.Option) iter.Seq2[agent.Event, error] {
+	return func(yield func(agent.Event, error) bool) {
+		for event, err := range a.base.Stream(ctx, input, opts...) {
+			if err != nil {
+				yield(event, err)
+				return
+			}
+
+			// Intercept tool result events that carry code execution metadata
+			// The executor in the base agent treats unknown action types by
+			// returning an error observation. We hook into BeforeAct via the
+			// agent hooks to intercept ActionCode.
+			if !yield(event, nil) {
+				return
+			}
+		}
+	}
+}
+
+// ExecuteCode runs a code action through the executor with hooks.
+func (a *CodeActAgent) ExecuteCode(ctx context.Context, action CodeAction) (CodeResult, error) {
+	if action.Language == "" {
+		action.Language = a.language
+	}
+	if action.Timeout == 0 {
+		action.Timeout = a.timeout
+	}
+
+	// BeforeExec hook
+	if a.hooks.BeforeExec != nil {
+		if err := a.hooks.BeforeExec(ctx, action); err != nil {
+			return CodeResult{}, err
+		}
+	}
+
+	result, err := a.executor.Execute(ctx, action)
+
+	// OnError hook
+	if err != nil && a.hooks.OnError != nil {
+		err = a.hooks.OnError(ctx, action, err)
+	}
+
+	if err != nil {
+		return result, err
+	}
+
+	// AfterExec hook
+	if a.hooks.AfterExec != nil {
+		if hookErr := a.hooks.AfterExec(ctx, action, result); hookErr != nil {
+			return result, hookErr
+		}
+	}
+
+	return result, nil
+}
+
+// codeResultToToolResult converts a CodeResult into a tool.Result for the
+// agent executor's observation flow.
+func codeResultToToolResult(result CodeResult) *tool.Result {
+	var text string
+	if result.Success() {
+		text = result.Output
+	} else {
+		text = fmt.Sprintf("Exit code: %d\nStdout: %s\nStderr: %s", result.ExitCode, result.Output, result.Error)
+	}
+	return &tool.Result{
+		Content: []schema.ContentPart{
+			schema.TextPart{Text: text},
+		},
+	}
+}

--- a/agent/codeact/agent.go
+++ b/agent/codeact/agent.go
@@ -23,11 +23,14 @@ const EventCodeResult agent.EventType = "code_result"
 // actions from the planner and routes them to the executor instead of the
 // standard tool execution path.
 type CodeActAgent struct {
-	base     *agent.BaseAgent
-	executor CodeExecutor
-	language string
-	timeout  time.Duration
-	hooks    CodeActHooks
+	base          *agent.BaseAgent
+	executor      CodeExecutor
+	language      string
+	timeout       time.Duration
+	hooks         CodeActHooks
+	planner       agent.Planner
+	llm           llm.ChatModel
+	maxIterations int
 }
 
 // Compile-time interface check.
@@ -44,12 +47,32 @@ type agentOptions struct {
 	agentOpts      []agent.Option
 	llm            llm.ChatModel
 	allowedImports []string
+	planner        agent.Planner
+	maxIterations  int
 }
 
 func defaultAgentOptions() agentOptions {
 	return agentOptions{
-		language: "python",
-		timeout:  30 * time.Second,
+		language:      "python",
+		timeout:       30 * time.Second,
+		maxIterations: 10,
+	}
+}
+
+// WithPlanner sets a custom planner for the CodeActAgent. If unset, a
+// CodeActPlanner is constructed from the configured LLM.
+func WithPlanner(p agent.Planner) AgentOption {
+	return func(o *agentOptions) {
+		o.planner = p
+	}
+}
+
+// WithMaxIterations sets the maximum number of plan-act-observe iterations.
+func WithMaxIterations(n int) AgentOption {
+	return func(o *agentOptions) {
+		if n > 0 {
+			o.maxIterations = n
+		}
 	}
 }
 
@@ -126,9 +149,14 @@ func NewCodeActAgent(id string, opts ...AgentOption) *CodeActAgent {
 
 	// Build base agent options
 	baseOpts := make([]agent.Option, 0, len(o.agentOpts)+3)
-	if o.llm != nil {
-		planner := NewCodeActPlanner(o.llm, plannerOpts...)
+	var planner agent.Planner = o.planner
+	if planner == nil && o.llm != nil {
+		planner = NewCodeActPlanner(o.llm, plannerOpts...)
+	}
+	if planner != nil {
 		baseOpts = append(baseOpts, agent.WithPlanner(planner))
+	}
+	if o.llm != nil {
 		baseOpts = append(baseOpts, agent.WithLLM(o.llm))
 	}
 	baseOpts = append(baseOpts, o.agentOpts...)
@@ -136,11 +164,14 @@ func NewCodeActAgent(id string, opts ...AgentOption) *CodeActAgent {
 	base := agent.New(id, baseOpts...)
 
 	return &CodeActAgent{
-		base:     base,
-		executor: executor,
-		language: o.language,
-		timeout:  o.timeout,
-		hooks:    o.hooks,
+		base:          base,
+		executor:      executor,
+		language:      o.language,
+		timeout:       o.timeout,
+		hooks:         o.hooks,
+		planner:       planner,
+		llm:           o.llm,
+		maxIterations: o.maxIterations,
 	}
 }
 
@@ -180,26 +211,149 @@ func (a *CodeActAgent) Invoke(ctx context.Context, input string, opts ...agent.O
 	return result.String(), nil
 }
 
-// Stream executes the agent and returns an iterator of events.
-// It intercepts ActionCode events from the base agent's stream, executes the
-// code via the CodeExecutor, and injects the results back.
+// Stream executes the agent and returns an iterator of events. It drives a
+// plan-act-observe loop directly: when the planner emits an ActionCode action,
+// the code block is executed via the configured CodeExecutor, a
+// code_exec/code_result event pair is emitted, and the observation is fed
+// back into the planner for the next iteration. All other action types are
+// delegated to the BaseAgent for backward compatibility.
 func (a *CodeActAgent) Stream(ctx context.Context, input string, opts ...agent.Option) iter.Seq2[agent.Event, error] {
 	return func(yield func(agent.Event, error) bool) {
-		for event, err := range a.base.Stream(ctx, input, opts...) {
+		// If we don't have a planner, fall back to the base agent behaviour.
+		if a.planner == nil {
+			for event, err := range a.base.Stream(ctx, input, opts...) {
+				if !yield(event, err) {
+					return
+				}
+				if err != nil {
+					return
+				}
+			}
+			return
+		}
+
+		// Build initial messages from persona + input.
+		var messages []schema.Message
+		if !a.base.Persona().IsEmpty() {
+			if sysMsg := a.base.Persona().ToSystemMessage(); sysMsg != nil {
+				messages = append(messages, sysMsg)
+			}
+		}
+		messages = append(messages, schema.NewHumanMessage(input))
+
+		state := agent.PlannerState{
+			Input:    input,
+			Messages: messages,
+			Tools:    a.base.Tools(),
+			Metadata: make(map[string]any),
+		}
+
+		for i := 0; i < a.maxIterations; i++ {
+			if err := ctx.Err(); err != nil {
+				yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
+				return
+			}
+			state.Iteration = i
+
+			var actions []agent.Action
+			var err error
+			if i == 0 {
+				actions, err = a.planner.Plan(ctx, state)
+			} else {
+				actions, err = a.planner.Replan(ctx, state)
+			}
 			if err != nil {
-				yield(event, err)
+				yield(agent.Event{Type: agent.EventError, AgentID: a.ID()}, err)
 				return
 			}
 
-			// Intercept tool result events that carry code execution metadata
-			// The executor in the base agent treats unknown action types by
-			// returning an error observation. We hook into BeforeAct via the
-			// agent hooks to intercept ActionCode.
-			if !yield(event, nil) {
-				return
+			done := false
+			for _, action := range actions {
+				if action.Type == ActionCode {
+					obs, stop := a.handleCodeAction(ctx, action, yield)
+					state.Observations = append(state.Observations, obs)
+					if stop {
+						return
+					}
+					continue
+				}
+
+				switch action.Type {
+				case agent.ActionFinish, agent.ActionRespond:
+					if action.Message != "" {
+						if !yield(agent.Event{Type: agent.EventText, AgentID: a.ID(), Text: action.Message}, nil) {
+							return
+						}
+					}
+					if action.Type == agent.ActionFinish {
+						yield(agent.Event{Type: agent.EventDone, AgentID: a.ID(), Text: action.Message}, nil)
+						done = true
+					}
+				default:
+					// Unsupported action type in the codeact loop.
+					yield(agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: fmt.Sprintf("unsupported action type: %s", action.Type)}, fmt.Errorf("unsupported action type: %s", action.Type))
+					return
+				}
+				if done {
+					return
+				}
 			}
 		}
+
+		yield(agent.Event{Type: agent.EventError, AgentID: a.ID(), Text: "maximum iterations exceeded"}, fmt.Errorf("codeact agent: reached maximum iterations (%d)", a.maxIterations))
 	}
+}
+
+// handleCodeAction executes a code action via the CodeExecutor and emits the
+// code_exec and code_result events. It returns an Observation to be fed back
+// into the planner and a boolean indicating whether the caller should stop
+// iterating (e.g., because the consumer stopped the stream).
+func (a *CodeActAgent) handleCodeAction(ctx context.Context, action agent.Action, yield func(agent.Event, error) bool) (agent.Observation, bool) {
+	code, _ := action.Metadata["code"].(string)
+	lang, _ := action.Metadata["language"].(string)
+	if lang == "" {
+		lang = a.language
+	}
+
+	if !yield(agent.Event{
+		Type:    EventCodeExec,
+		AgentID: a.ID(),
+		Text:    code,
+		Metadata: map[string]any{
+			"language": lang,
+		},
+	}, nil) {
+		return agent.Observation{Action: action}, true
+	}
+
+	start := time.Now()
+	result, execErr := a.ExecuteCode(ctx, CodeAction{
+		Language: lang,
+		Code:     code,
+		Timeout:  a.timeout,
+	})
+	latency := time.Since(start)
+
+	toolResult := codeResultToToolResult(result)
+
+	if !yield(agent.Event{
+		Type:       EventCodeResult,
+		AgentID:    a.ID(),
+		ToolResult: toolResult,
+		Metadata: map[string]any{
+			"exit_code": result.ExitCode,
+			"duration":  result.Duration,
+		},
+	}, nil) {
+		return agent.Observation{Action: action, Result: toolResult, Error: execErr, Latency: latency}, true
+	}
+
+	return agent.Observation{
+		Action:  action,
+		Result:  toolResult,
+		Error:   execErr,
+		Latency: latency,
+	}, false
 }
 
 // ExecuteCode runs a code action through the executor with hooks.

--- a/agent/codeact/codeact_test.go
+++ b/agent/codeact/codeact_test.go
@@ -1,0 +1,642 @@
+package codeact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// --- ExtractCodeBlocks tests ---
+
+func TestExtractCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []CodeBlock
+	}{
+		{
+			name:  "no code blocks",
+			input: "Just plain text with no code.",
+			want:  nil,
+		},
+		{
+			name:  "single python block",
+			input: "Here is some code:\n```python\nprint('hello')\n```\nDone.",
+			want:  []CodeBlock{{Language: "python", Code: "print('hello')"}},
+		},
+		{
+			name:  "multiple blocks",
+			input: "```python\nx = 1\n```\nThen:\n```javascript\nconsole.log('hi')\n```",
+			want: []CodeBlock{
+				{Language: "python", Code: "x = 1"},
+				{Language: "javascript", Code: "console.log('hi')"},
+			},
+		},
+		{
+			name:  "block without language tag",
+			input: "```\necho hello\n```",
+			want:  []CodeBlock{{Language: "", Code: "echo hello"}},
+		},
+		{
+			name:  "multiline code",
+			input: "```python\nimport math\nresult = math.sqrt(16)\nprint(result)\n```",
+			want:  []CodeBlock{{Language: "python", Code: "import math\nresult = math.sqrt(16)\nprint(result)"}},
+		},
+		{
+			name:  "empty code block",
+			input: "```python\n\n```",
+			want:  []CodeBlock{{Language: "python", Code: ""}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractCodeBlocks(tt.input)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d blocks, want %d", len(got), len(tt.want))
+			}
+			for i, block := range got {
+				if block.Language != tt.want[i].Language {
+					t.Errorf("block[%d].Language = %q, want %q", i, block.Language, tt.want[i].Language)
+				}
+				if block.Code != tt.want[i].Code {
+					t.Errorf("block[%d].Code = %q, want %q", i, block.Code, tt.want[i].Code)
+				}
+			}
+		})
+	}
+}
+
+// --- NoopExecutor tests ---
+
+func TestNoopExecutor(t *testing.T) {
+	exec := NewNoopExecutor()
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		action CodeAction
+		want   CodeResult
+	}{
+		{
+			name:   "returns code as output",
+			action: CodeAction{Language: "python", Code: "print('hello')"},
+			want:   CodeResult{Output: "print('hello')", ExitCode: 0},
+		},
+		{
+			name:   "empty code",
+			action: CodeAction{Language: "go", Code: ""},
+			want:   CodeResult{Output: "", ExitCode: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := exec.Execute(ctx, tt.action)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Output != tt.want.Output {
+				t.Errorf("Output = %q, want %q", got.Output, tt.want.Output)
+			}
+			if got.ExitCode != tt.want.ExitCode {
+				t.Errorf("ExitCode = %d, want %d", got.ExitCode, tt.want.ExitCode)
+			}
+		})
+	}
+}
+
+// --- ProcessExecutor tests ---
+
+func TestProcessExecutor_UnsupportedLanguage(t *testing.T) {
+	exec := NewProcessExecutor()
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, CodeAction{Language: "cobol", Code: "DISPLAY 'HELLO'"})
+	if err == nil {
+		t.Fatal("expected error for unsupported language")
+	}
+	if !containsString(err.Error(), "unsupported language") {
+		t.Errorf("error = %q, want to contain 'unsupported language'", err.Error())
+	}
+}
+
+func TestProcessExecutor_EmptyCode(t *testing.T) {
+	exec := NewProcessExecutor()
+	ctx := context.Background()
+
+	_, err := exec.Execute(ctx, CodeAction{Language: "python", Code: ""})
+	if err == nil {
+		t.Fatal("expected error for empty code")
+	}
+	if !containsString(err.Error(), "empty code") {
+		t.Errorf("error = %q, want to contain 'empty code'", err.Error())
+	}
+}
+
+func TestProcessExecutor_WithInterpreter(t *testing.T) {
+	exec := NewProcessExecutor(
+		WithInterpreter("bash", "bash"),
+		WithDefaultTimeout(10*time.Second),
+	)
+	if exec.interpreters["bash"] != "bash" {
+		t.Error("expected bash interpreter to be registered")
+	}
+	if exec.defaultTimeout != 10*time.Second {
+		t.Errorf("defaultTimeout = %v, want 10s", exec.defaultTimeout)
+	}
+}
+
+// --- CodeResult tests ---
+
+func TestCodeResult_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		result CodeResult
+		want   bool
+	}{
+		{
+			name:   "success",
+			result: CodeResult{Output: "ok", ExitCode: 0},
+			want:   true,
+		},
+		{
+			name:   "non-zero exit",
+			result: CodeResult{Output: "", ExitCode: 1},
+			want:   false,
+		},
+		{
+			name:   "has error text",
+			result: CodeResult{Output: "ok", Error: "warning", ExitCode: 0},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.Success(); got != tt.want {
+				t.Errorf("Success() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ExecutionState tests ---
+
+func TestExecutionState_Variables(t *testing.T) {
+	s := NewExecutionState()
+
+	// Get missing variable
+	_, ok := s.GetVariable("x")
+	if ok {
+		t.Error("expected missing variable")
+	}
+
+	// Set and get
+	s.SetVariable("x", "42")
+	v, ok := s.GetVariable("x")
+	if !ok || v != "42" {
+		t.Errorf("got (%q, %v), want (\"42\", true)", v, ok)
+	}
+
+	// Variables copy
+	vars := s.Variables()
+	if len(vars) != 1 || vars["x"] != "42" {
+		t.Errorf("Variables() = %v, want map[x:42]", vars)
+	}
+
+	// Verify copy isolation
+	vars["y"] = "99"
+	_, ok = s.GetVariable("y")
+	if ok {
+		t.Error("Variables() should return a copy, not a reference")
+	}
+}
+
+func TestExecutionState_Outputs(t *testing.T) {
+	s := NewExecutionState()
+
+	if s.StepCount() != 0 {
+		t.Errorf("StepCount() = %d, want 0", s.StepCount())
+	}
+	if s.LastOutput() != nil {
+		t.Error("LastOutput() should be nil for empty state")
+	}
+
+	s.AddOutput(StepOutput{Language: "python", Code: "print(1)", Output: "1", ExitCode: 0})
+	s.AddOutput(StepOutput{Language: "python", Code: "print(2)", Output: "2", ExitCode: 0})
+
+	if s.StepCount() != 2 {
+		t.Errorf("StepCount() = %d, want 2", s.StepCount())
+	}
+
+	last := s.LastOutput()
+	if last == nil || last.Output != "2" {
+		t.Errorf("LastOutput().Output = %v, want \"2\"", last)
+	}
+
+	// Copy isolation
+	outputs := s.Outputs()
+	if len(outputs) != 2 {
+		t.Fatalf("Outputs() len = %d, want 2", len(outputs))
+	}
+}
+
+func TestGetOrCreateState(t *testing.T) {
+	meta := make(map[string]any)
+
+	// Creates new state
+	s1 := GetOrCreateState(meta)
+	if s1 == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	// Returns existing state
+	s1.SetVariable("x", "1")
+	s2 := GetOrCreateState(meta)
+	v, _ := s2.GetVariable("x")
+	if v != "1" {
+		t.Error("expected to get same state instance")
+	}
+
+	// Handles non-ExecutionState in metadata
+	meta[stateKey] = "invalid"
+	s3 := GetOrCreateState(meta)
+	if s3 == nil {
+		t.Fatal("expected new state when metadata has wrong type")
+	}
+	if _, ok := s3.GetVariable("x"); ok {
+		t.Error("expected fresh state")
+	}
+}
+
+// --- CodeActPlanner tests ---
+
+func TestCodeActPlanner_ParsesCodeBlocks(t *testing.T) {
+	planner := NewCodeActPlanner(nil, WithPlannerLanguage("python"))
+
+	resp := &schema.AIMessage{
+		Parts: []schema.ContentPart{
+			schema.TextPart{Text: "Here is the solution:\n```python\nprint(42)\n```"},
+		},
+	}
+
+	actions := planner.parseResponse(resp)
+	if len(actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions))
+	}
+	if actions[0].Type != ActionCode {
+		t.Errorf("action type = %q, want %q", actions[0].Type, ActionCode)
+	}
+	if actions[0].Metadata["code"] != "print(42)" {
+		t.Errorf("code = %q, want \"print(42)\"", actions[0].Metadata["code"])
+	}
+	if actions[0].Metadata["language"] != "python" {
+		t.Errorf("language = %q, want \"python\"", actions[0].Metadata["language"])
+	}
+}
+
+func TestCodeActPlanner_NoCodeBlockFinishes(t *testing.T) {
+	planner := NewCodeActPlanner(nil)
+
+	resp := &schema.AIMessage{
+		Parts: []schema.ContentPart{
+			schema.TextPart{Text: "The answer is 42."},
+		},
+	}
+
+	actions := planner.parseResponse(resp)
+	if len(actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions))
+	}
+	if actions[0].Type != agent.ActionFinish {
+		t.Errorf("action type = %q, want %q", actions[0].Type, agent.ActionFinish)
+	}
+	if actions[0].Message != "The answer is 42." {
+		t.Errorf("message = %q, want \"The answer is 42.\"", actions[0].Message)
+	}
+}
+
+func TestCodeActPlanner_DefaultsLanguageFromPlanner(t *testing.T) {
+	planner := NewCodeActPlanner(nil, WithPlannerLanguage("go"))
+
+	resp := &schema.AIMessage{
+		Parts: []schema.ContentPart{
+			schema.TextPart{Text: "```\nfmt.Println(42)\n```"},
+		},
+	}
+
+	actions := planner.parseResponse(resp)
+	if len(actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions))
+	}
+	if actions[0].Metadata["language"] != "go" {
+		t.Errorf("language = %q, want \"go\"", actions[0].Metadata["language"])
+	}
+}
+
+func TestCodeActPlanner_MultipleCodeBlocks(t *testing.T) {
+	planner := NewCodeActPlanner(nil, WithPlannerLanguage("python"))
+
+	resp := &schema.AIMessage{
+		Parts: []schema.ContentPart{
+			schema.TextPart{Text: "Step 1:\n```python\nx = 1\n```\nStep 2:\n```python\nprint(x)\n```"},
+		},
+	}
+
+	actions := planner.parseResponse(resp)
+	if len(actions) != 2 {
+		t.Fatalf("got %d actions, want 2", len(actions))
+	}
+	if actions[0].Metadata["code"] != "x = 1" {
+		t.Errorf("actions[0].code = %q, want \"x = 1\"", actions[0].Metadata["code"])
+	}
+	if actions[1].Metadata["code"] != "print(x)" {
+		t.Errorf("actions[1].code = %q, want \"print(x)\"", actions[1].Metadata["code"])
+	}
+}
+
+// --- CodeActHooks tests ---
+
+func TestComposeCodeActHooks(t *testing.T) {
+	var callOrder []string
+
+	h1 := CodeActHooks{
+		BeforeExec: func(_ context.Context, _ CodeAction) error {
+			callOrder = append(callOrder, "h1-before")
+			return nil
+		},
+		AfterExec: func(_ context.Context, _ CodeAction, _ CodeResult) error {
+			callOrder = append(callOrder, "h1-after")
+			return nil
+		},
+	}
+	h2 := CodeActHooks{
+		BeforeExec: func(_ context.Context, _ CodeAction) error {
+			callOrder = append(callOrder, "h2-before")
+			return nil
+		},
+		AfterExec: func(_ context.Context, _ CodeAction, _ CodeResult) error {
+			callOrder = append(callOrder, "h2-after")
+			return nil
+		},
+	}
+
+	composed := ComposeCodeActHooks(h1, h2)
+	ctx := context.Background()
+	action := CodeAction{Language: "python", Code: "pass"}
+
+	if err := composed.BeforeExec(ctx, action); err != nil {
+		t.Fatalf("BeforeExec error: %v", err)
+	}
+	if err := composed.AfterExec(ctx, action, CodeResult{}); err != nil {
+		t.Fatalf("AfterExec error: %v", err)
+	}
+
+	expected := []string{"h1-before", "h2-before", "h1-after", "h2-after"}
+	if len(callOrder) != len(expected) {
+		t.Fatalf("call order = %v, want %v", callOrder, expected)
+	}
+	for i, v := range callOrder {
+		if v != expected[i] {
+			t.Errorf("callOrder[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestComposeCodeActHooks_ErrorShortCircuits(t *testing.T) {
+	errStop := errors.New("stop")
+
+	h1 := CodeActHooks{
+		BeforeExec: func(_ context.Context, _ CodeAction) error {
+			return errStop
+		},
+	}
+	h2 := CodeActHooks{
+		BeforeExec: func(_ context.Context, _ CodeAction) error {
+			t.Fatal("h2.BeforeExec should not be called")
+			return nil
+		},
+	}
+
+	composed := ComposeCodeActHooks(h1, h2)
+	err := composed.BeforeExec(context.Background(), CodeAction{})
+	if !errors.Is(err, errStop) {
+		t.Errorf("error = %v, want %v", err, errStop)
+	}
+}
+
+// --- CodeActAgent tests ---
+
+func TestCodeActAgent_ExecuteCode(t *testing.T) {
+	var hookCalls []string
+
+	a := NewCodeActAgent("test-agent",
+		WithLanguage("python"),
+		WithExecutor(NewNoopExecutor()),
+		WithExecTimeout(10*time.Second),
+		WithCodeActHooks(CodeActHooks{
+			BeforeExec: func(_ context.Context, action CodeAction) error {
+				hookCalls = append(hookCalls, fmt.Sprintf("before:%s", action.Language))
+				return nil
+			},
+			AfterExec: func(_ context.Context, _ CodeAction, result CodeResult) error {
+				hookCalls = append(hookCalls, fmt.Sprintf("after:%s", result.Output))
+				return nil
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	result, err := a.ExecuteCode(ctx, CodeAction{Code: "print('hello')"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output != "print('hello')" {
+		t.Errorf("Output = %q, want \"print('hello')\"", result.Output)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+
+	if len(hookCalls) != 2 {
+		t.Fatalf("hookCalls = %v, want 2 entries", hookCalls)
+	}
+	if hookCalls[0] != "before:python" {
+		t.Errorf("hookCalls[0] = %q, want \"before:python\"", hookCalls[0])
+	}
+	if hookCalls[1] != "after:print('hello')" {
+		t.Errorf("hookCalls[1] = %q, want \"after:print('hello')\"", hookCalls[1])
+	}
+}
+
+func TestCodeActAgent_ExecuteCode_DefaultsLanguage(t *testing.T) {
+	a := NewCodeActAgent("test",
+		WithLanguage("go"),
+		WithExecutor(NewNoopExecutor()),
+	)
+
+	ctx := context.Background()
+	// Action with no language should default to agent's language
+	result, err := a.ExecuteCode(ctx, CodeAction{Code: "fmt.Println(1)"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output != "fmt.Println(1)" {
+		t.Errorf("Output = %q, want code echoed back", result.Output)
+	}
+}
+
+func TestCodeActAgent_ExecuteCode_BeforeHookCancels(t *testing.T) {
+	errDenied := errors.New("denied")
+
+	a := NewCodeActAgent("test",
+		WithExecutor(NewNoopExecutor()),
+		WithCodeActHooks(CodeActHooks{
+			BeforeExec: func(_ context.Context, _ CodeAction) error {
+				return errDenied
+			},
+		}),
+	)
+
+	ctx := context.Background()
+	_, err := a.ExecuteCode(ctx, CodeAction{Language: "python", Code: "pass"})
+	if !errors.Is(err, errDenied) {
+		t.Errorf("error = %v, want %v", err, errDenied)
+	}
+}
+
+func TestCodeActAgent_ID(t *testing.T) {
+	a := NewCodeActAgent("my-agent")
+	if a.ID() != "my-agent" {
+		t.Errorf("ID() = %q, want \"my-agent\"", a.ID())
+	}
+}
+
+// --- Planner registry test ---
+
+func TestCodeActPlannerRegistered(t *testing.T) {
+	planners := agent.ListPlanners()
+	found := false
+	for _, name := range planners {
+		if name == "codeact" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("codeact planner not registered, available: %v", planners)
+	}
+}
+
+// --- System prompt tests ---
+
+func TestCodeActPlanner_SystemPrompt(t *testing.T) {
+	p := NewCodeActPlanner(nil, WithPlannerLanguage("javascript"), WithAllowedImports([]string{"fs", "path"}))
+	prompt := p.systemPrompt()
+
+	if !containsString(prompt, "javascript") {
+		t.Error("system prompt should mention the language")
+	}
+	if !containsString(prompt, "fs, path") {
+		t.Error("system prompt should mention allowed imports")
+	}
+}
+
+func TestCodeActPlanner_SystemPrompt_NoImports(t *testing.T) {
+	p := NewCodeActPlanner(nil)
+	prompt := p.systemPrompt()
+	if containsString(prompt, "Only use these imports") {
+		t.Error("system prompt should not mention imports when none are set")
+	}
+}
+
+// --- codeResultToToolResult test ---
+
+func TestCodeResultToToolResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result CodeResult
+		want   string
+	}{
+		{
+			name:   "success",
+			result: CodeResult{Output: "42", ExitCode: 0},
+			want:   "42",
+		},
+		{
+			name:   "failure",
+			result: CodeResult{Output: "", Error: "NameError", ExitCode: 1},
+			want:   "Exit code: 1\nStdout: \nStderr: NameError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := codeResultToToolResult(tt.result)
+			if len(tr.Content) != 1 {
+				t.Fatalf("content len = %d, want 1", len(tr.Content))
+			}
+			tp, ok := tr.Content[0].(schema.TextPart)
+			if !ok {
+				t.Fatal("content[0] is not TextPart")
+			}
+			if tp.Text != tt.want {
+				t.Errorf("text = %q, want %q", tp.Text, tt.want)
+			}
+		})
+	}
+}
+
+// --- optsFromExtra tests ---
+
+func TestOptsFromExtra_Nil(t *testing.T) {
+	opts := optsFromExtra(nil)
+	if len(opts) != 0 {
+		t.Errorf("expected no opts from nil extra, got %d", len(opts))
+	}
+}
+
+func TestOptsFromExtra_WithValues(t *testing.T) {
+	extra := map[string]any{
+		"language":        "go",
+		"allowed_imports": []string{"fmt", "os"},
+	}
+	opts := optsFromExtra(extra)
+	if len(opts) != 2 {
+		t.Errorf("expected 2 opts, got %d", len(opts))
+	}
+
+	// Apply opts and verify
+	p := &CodeActPlanner{language: "python"}
+	for _, opt := range opts {
+		opt(p)
+	}
+	if p.language != "go" {
+		t.Errorf("language = %q, want \"go\"", p.language)
+	}
+	if len(p.allowedImports) != 2 {
+		t.Errorf("allowedImports len = %d, want 2", len(p.allowedImports))
+	}
+}
+
+// helper
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/codeact/codeact_test.go
+++ b/agent/codeact/codeact_test.go
@@ -56,22 +56,26 @@ func TestExtractCodeBlocks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractCodeBlocks(tt.input)
-			if len(got) == 0 && len(tt.want) == 0 {
-				return
-			}
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %d blocks, want %d", len(got), len(tt.want))
-			}
-			for i, block := range got {
-				if block.Language != tt.want[i].Language {
-					t.Errorf("block[%d].Language = %q, want %q", i, block.Language, tt.want[i].Language)
-				}
-				if block.Code != tt.want[i].Code {
-					t.Errorf("block[%d].Code = %q, want %q", i, block.Code, tt.want[i].Code)
-				}
-			}
+			assertCodeBlocksEqual(t, ExtractCodeBlocks(tt.input), tt.want)
 		})
+	}
+}
+
+func assertCodeBlocksEqual(t *testing.T, got, want []CodeBlock) {
+	t.Helper()
+	if len(got) == 0 && len(want) == 0 {
+		return
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d blocks, want %d", len(got), len(want))
+	}
+	for i, block := range got {
+		if block.Language != want[i].Language {
+			t.Errorf("block[%d].Language = %q, want %q", i, block.Language, want[i].Language)
+		}
+		if block.Code != want[i].Code {
+			t.Errorf("block[%d].Code = %q, want %q", i, block.Code, want[i].Code)
+		}
 	}
 }
 
@@ -553,46 +557,54 @@ func TestCodeActAgent_Stream_ExecutesCodeAction(t *testing.T) {
 		WithMaxIterations(5),
 	)
 
-	var (
-		sawExec, sawResult, sawDone bool
-		finalText                   string
-	)
+	obs := collectStreamObservations(t, a)
+
+	if !obs.sawExec {
+		t.Error("expected EventCodeExec event")
+	}
+	if !obs.sawResult {
+		t.Error("expected EventCodeResult event")
+	}
+	if !obs.sawDone {
+		t.Error("expected EventDone event")
+	}
+	if obs.finalText != "final-answer" {
+		t.Errorf("finalText = %q, want final-answer", obs.finalText)
+	}
+	if planner.calls < 2 {
+		t.Errorf("planner.calls = %d, want >= 2 (code observation fed back)", planner.calls)
+	}
+}
+
+type streamObs struct {
+	sawExec, sawResult, sawDone bool
+	finalText                   string
+}
+
+func collectStreamObservations(t *testing.T, a *CodeActAgent) streamObs {
+	t.Helper()
+	var obs streamObs
 	for event, err := range a.Stream(context.Background(), "hello") {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		switch event.Type {
 		case EventCodeExec:
-			sawExec = true
+			obs.sawExec = true
 			if event.Text != "print('hi')" {
 				t.Errorf("EventCodeExec Text = %q, want print('hi')", event.Text)
 			}
 		case EventCodeResult:
-			sawResult = true
+			obs.sawResult = true
 			if event.ToolResult == nil {
 				t.Error("EventCodeResult ToolResult is nil")
 			}
 		case agent.EventDone:
-			sawDone = true
-			finalText = event.Text
+			obs.sawDone = true
+			obs.finalText = event.Text
 		}
 	}
-
-	if !sawExec {
-		t.Error("expected EventCodeExec event")
-	}
-	if !sawResult {
-		t.Error("expected EventCodeResult event")
-	}
-	if !sawDone {
-		t.Error("expected EventDone event")
-	}
-	if finalText != "final-answer" {
-		t.Errorf("finalText = %q, want final-answer", finalText)
-	}
-	if planner.calls < 2 {
-		t.Errorf("planner.calls = %d, want >= 2 (code observation fed back)", planner.calls)
-	}
+	return obs
 }
 
 func TestCodeActAgent_ID(t *testing.T) {

--- a/agent/codeact/codeact_test.go
+++ b/agent/codeact/codeact_test.go
@@ -174,9 +174,10 @@ func TestCodeResult_Success(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "has error text",
+			// Stderr output alone must not imply failure (POSIX exit-code semantics).
+			name:   "stderr with zero exit is success",
 			result: CodeResult{Output: "ok", Error: "warning", ExitCode: 0},
-			want:   false,
+			want:   true,
 		},
 	}
 	for _, tt := range tests {
@@ -510,6 +511,87 @@ func TestCodeActAgent_ExecuteCode_BeforeHookCancels(t *testing.T) {
 	_, err := a.ExecuteCode(ctx, CodeAction{Language: "python", Code: "pass"})
 	if !errors.Is(err, errDenied) {
 		t.Errorf("error = %v, want %v", err, errDenied)
+	}
+}
+
+// stubPlanner returns a canned sequence of action lists across iterations.
+type stubPlanner struct {
+	iterations [][]agent.Action
+	calls      int
+}
+
+func (p *stubPlanner) Plan(_ context.Context, _ agent.PlannerState) ([]agent.Action, error) {
+	if p.calls >= len(p.iterations) {
+		return []agent.Action{{Type: agent.ActionFinish, Message: "done"}}, nil
+	}
+	actions := p.iterations[p.calls]
+	p.calls++
+	return actions, nil
+}
+
+func (p *stubPlanner) Replan(ctx context.Context, state agent.PlannerState) ([]agent.Action, error) {
+	return p.Plan(ctx, state)
+}
+
+func TestCodeActAgent_Stream_ExecutesCodeAction(t *testing.T) {
+	planner := &stubPlanner{
+		iterations: [][]agent.Action{
+			{{
+				Type: ActionCode,
+				Metadata: map[string]any{
+					"language": "python",
+					"code":     "print('hi')",
+				},
+			}},
+			{{Type: agent.ActionFinish, Message: "final-answer"}},
+		},
+	}
+
+	a := NewCodeActAgent("codeact-test",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+		WithMaxIterations(5),
+	)
+
+	var (
+		sawExec, sawResult, sawDone bool
+		finalText                   string
+	)
+	for event, err := range a.Stream(context.Background(), "hello") {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		switch event.Type {
+		case EventCodeExec:
+			sawExec = true
+			if event.Text != "print('hi')" {
+				t.Errorf("EventCodeExec Text = %q, want print('hi')", event.Text)
+			}
+		case EventCodeResult:
+			sawResult = true
+			if event.ToolResult == nil {
+				t.Error("EventCodeResult ToolResult is nil")
+			}
+		case agent.EventDone:
+			sawDone = true
+			finalText = event.Text
+		}
+	}
+
+	if !sawExec {
+		t.Error("expected EventCodeExec event")
+	}
+	if !sawResult {
+		t.Error("expected EventCodeResult event")
+	}
+	if !sawDone {
+		t.Error("expected EventDone event")
+	}
+	if finalText != "final-answer" {
+		t.Errorf("finalText = %q, want final-answer", finalText)
+	}
+	if planner.calls < 2 {
+		t.Errorf("planner.calls = %d, want >= 2 (code observation fed back)", planner.calls)
 	}
 }
 

--- a/agent/codeact/coverage_test.go
+++ b/agent/codeact/coverage_test.go
@@ -1,0 +1,378 @@
+package codeact
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
+)
+
+// stubChatModel is a minimal llm.ChatModel used to exercise the CodeActPlanner
+// end-to-end without pulling a real provider.
+type stubChatModel struct {
+	resp *schema.AIMessage
+	err  error
+}
+
+func (m *stubChatModel) Generate(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) (*schema.AIMessage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.resp, nil
+}
+
+func (m *stubChatModel) Stream(_ context.Context, _ []schema.Message, _ ...llm.GenerateOption) iter.Seq2[schema.StreamChunk, error] {
+	return func(_ func(schema.StreamChunk, error) bool) {}
+}
+
+func (m *stubChatModel) BindTools(_ []schema.ToolDefinition) llm.ChatModel { return m }
+func (m *stubChatModel) ModelID() string                                   { return "stub" }
+
+var _ llm.ChatModel = (*stubChatModel)(nil)
+
+// --- Agent accessor coverage ---
+
+func TestCodeActAgent_Accessors(t *testing.T) {
+	a := NewCodeActAgent("acc",
+		WithLanguage("python"),
+		WithExecutor(NewNoopExecutor()),
+	)
+
+	if a.ID() != "acc" {
+		t.Errorf("ID = %q, want acc", a.ID())
+	}
+	// Persona/Tools/Children should be safe passthroughs on a freshly built agent.
+	_ = a.Persona()
+	if tools := a.Tools(); tools == nil && len(tools) != 0 {
+		t.Errorf("Tools() returned nil-with-length, unexpected")
+	}
+	_ = a.Children()
+}
+
+// WithAgentLLM / WithAllowedCodeImports / WithAgentOption coverage.
+func TestCodeActAgent_OptionsCoverage(t *testing.T) {
+	llmStub := &stubChatModel{
+		resp: &schema.AIMessage{
+			Parts: []schema.ContentPart{schema.TextPart{Text: "final answer"}},
+		},
+	}
+
+	a := NewCodeActAgent("opts",
+		WithAgentLLM(llmStub),
+		WithAllowedCodeImports([]string{"math"}),
+		WithAgentOption(agent.WithMaxIterations(2)),
+		WithExecutor(NewNoopExecutor()),
+	)
+	if a == nil {
+		t.Fatal("expected non-nil agent")
+	}
+	if a.llm != llmStub {
+		t.Error("WithAgentLLM did not install the stub model")
+	}
+}
+
+// --- Invoke coverage ---
+
+func TestCodeActAgent_Invoke(t *testing.T) {
+	planner := &stubPlanner{
+		iterations: [][]agent.Action{
+			{{Type: agent.ActionFinish, Message: "hello"}},
+		},
+	}
+	a := NewCodeActAgent("inv",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+		WithMaxIterations(3),
+	)
+
+	out, err := a.Invoke(context.Background(), "ping")
+	if err != nil {
+		t.Fatalf("Invoke error: %v", err)
+	}
+	if out == "" {
+		t.Error("Invoke returned empty string")
+	}
+}
+
+func TestCodeActAgent_Invoke_PlannerError(t *testing.T) {
+	errBoom := errors.New("boom")
+	planner := &errPlanner{err: errBoom}
+
+	a := NewCodeActAgent("inv-err",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+	)
+
+	_, err := a.Invoke(context.Background(), "ping")
+	if err == nil {
+		t.Fatal("expected error from planner")
+	}
+}
+
+type errPlanner struct {
+	err error
+}
+
+func (p *errPlanner) Plan(_ context.Context, _ agent.PlannerState) ([]agent.Action, error) {
+	return nil, p.err
+}
+func (p *errPlanner) Replan(_ context.Context, _ agent.PlannerState) ([]agent.Action, error) {
+	return nil, p.err
+}
+
+// --- Stream: no planner fallback path ---
+
+func TestCodeActAgent_Stream_NoPlannerFallback(t *testing.T) {
+	// No planner configured, no llm -> falls back to base agent's Stream.
+	a := NewCodeActAgent("nop",
+		WithExecutor(NewNoopExecutor()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the base agent's stream terminates cleanly.
+	cancel()
+	count := 0
+	for _, err := range a.Stream(ctx, "hi") {
+		count++
+		_ = err
+		if count > 10 {
+			break
+		}
+	}
+}
+
+// --- Stream: context-cancelled inside loop ---
+
+func TestCodeActAgent_Stream_ContextCanceled(t *testing.T) {
+	planner := &stubPlanner{
+		iterations: [][]agent.Action{
+			{{Type: agent.ActionFinish, Message: "done"}},
+		},
+	}
+	a := NewCodeActAgent("cancel",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sawError := false
+	for event, err := range a.Stream(ctx, "q") {
+		if err != nil {
+			sawError = true
+			break
+		}
+		_ = event
+	}
+	if !sawError {
+		t.Error("expected context cancellation to surface as error event")
+	}
+}
+
+// --- Stream: unsupported action ---
+
+func TestCodeActAgent_Stream_UnsupportedAction(t *testing.T) {
+	planner := &stubPlanner{
+		iterations: [][]agent.Action{
+			{{Type: agent.ActionType("custom"), Message: "x"}},
+		},
+	}
+	a := NewCodeActAgent("bad",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+	)
+	sawError := false
+	for _, err := range a.Stream(context.Background(), "q") {
+		if err != nil {
+			sawError = true
+			break
+		}
+	}
+	if !sawError {
+		t.Error("expected error for unsupported action type")
+	}
+}
+
+// --- Stream: max iterations exhausted ---
+
+func TestCodeActAgent_Stream_MaxIterationsExceeded(t *testing.T) {
+	// Planner that never finishes: always issues a code action so the loop
+	// can iterate.
+	planner := &loopPlanner{}
+	a := NewCodeActAgent("loop",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+		WithMaxIterations(2),
+	)
+	sawError := false
+	for _, err := range a.Stream(context.Background(), "q") {
+		if err != nil {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Error("expected max-iterations error")
+	}
+}
+
+type loopPlanner struct{}
+
+func (loopPlanner) Plan(_ context.Context, _ agent.PlannerState) ([]agent.Action, error) {
+	return []agent.Action{{
+		Type:     ActionCode,
+		Metadata: map[string]any{"code": "x", "language": "python"},
+	}}, nil
+}
+func (l loopPlanner) Replan(ctx context.Context, s agent.PlannerState) ([]agent.Action, error) {
+	return l.Plan(ctx, s)
+}
+
+// --- Stream: Respond action (no Finish) ---
+
+func TestCodeActAgent_Stream_Respond(t *testing.T) {
+	planner := &stubPlanner{
+		iterations: [][]agent.Action{
+			{{Type: agent.ActionRespond, Message: "hello-respond"}},
+			{{Type: agent.ActionFinish, Message: "bye"}},
+		},
+	}
+	a := NewCodeActAgent("resp",
+		WithPlanner(planner),
+		WithExecutor(NewNoopExecutor()),
+		WithMaxIterations(3),
+	)
+	var sawRespondText bool
+	for event, err := range a.Stream(context.Background(), "q") {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.Type == agent.EventText && event.Text == "hello-respond" {
+			sawRespondText = true
+		}
+	}
+	if !sawRespondText {
+		t.Error("expected to see the Respond action text as an EventText")
+	}
+}
+
+// --- ExecuteCode: AfterExec hook error ---
+
+func TestCodeActAgent_ExecuteCode_AfterHookError(t *testing.T) {
+	errAfter := errors.New("after-denied")
+	a := NewCodeActAgent("after",
+		WithExecutor(NewNoopExecutor()),
+		WithCodeActHooks(CodeActHooks{
+			AfterExec: func(_ context.Context, _ CodeAction, _ CodeResult) error {
+				return errAfter
+			},
+		}),
+	)
+	_, err := a.ExecuteCode(context.Background(), CodeAction{Language: "python", Code: "pass"})
+	if !errors.Is(err, errAfter) {
+		t.Errorf("error = %v, want %v", err, errAfter)
+	}
+}
+
+// --- Planner Generate / buildMessages / observationToMessage / extractResultText ---
+
+func TestCodeActPlanner_Plan_And_Replan(t *testing.T) {
+	model := &stubChatModel{
+		resp: &schema.AIMessage{
+			Parts: []schema.ContentPart{schema.TextPart{Text: "Here:\n```python\nprint(1)\n```"}},
+		},
+	}
+	p := NewCodeActPlanner(model, WithPlannerLanguage("python"))
+
+	// Plan (initial).
+	actions, err := p.Plan(context.Background(), agent.PlannerState{
+		Input:    "hello",
+		Messages: []schema.Message{schema.NewHumanMessage("hello")},
+	})
+	if err != nil {
+		t.Fatalf("Plan error: %v", err)
+	}
+	if len(actions) != 1 || actions[0].Type != ActionCode {
+		t.Fatalf("actions = %+v, want single ActionCode", actions)
+	}
+
+	// Replan with an observation fed back in to exercise observationToMessage.
+	obs := agent.Observation{
+		Action: agent.Action{
+			Type: ActionCode,
+			Metadata: map[string]any{
+				"code":     "print(1)",
+				"language": "python",
+			},
+		},
+		Result: &tool.Result{Content: []schema.ContentPart{schema.TextPart{Text: "1"}}},
+	}
+	state := agent.PlannerState{
+		Input:        "hello",
+		Messages:     []schema.Message{schema.NewSystemMessage("sys"), schema.NewHumanMessage("hello")},
+		Observations: []agent.Observation{obs},
+	}
+	actions2, err := p.Replan(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Replan error: %v", err)
+	}
+	if len(actions2) == 0 {
+		t.Error("Replan returned no actions")
+	}
+}
+
+func TestCodeActPlanner_Plan_LLMError(t *testing.T) {
+	model := &stubChatModel{err: errors.New("llm-down")}
+	p := NewCodeActPlanner(model)
+	_, err := p.Plan(context.Background(), agent.PlannerState{})
+	if err == nil {
+		t.Error("expected error from failing LLM")
+	}
+}
+
+func TestObservationToMessage_WithExecError(t *testing.T) {
+	obs := agent.Observation{
+		Action: agent.Action{
+			Type: ActionCode,
+			Metadata: map[string]any{
+				"code":     "boom",
+				"language": "python",
+			},
+		},
+		Error: errors.New("runtime error"),
+	}
+	msg := observationToMessage(obs)
+	if msg == nil {
+		t.Fatal("observationToMessage returned nil")
+	}
+}
+
+func TestExtractResultText(t *testing.T) {
+	if got := extractResultText(nil); got != "" {
+		t.Errorf("nil result should yield empty string, got %q", got)
+	}
+	if got := extractResultText(&tool.Result{}); got != "" {
+		t.Errorf("empty result should yield empty string, got %q", got)
+	}
+	r := &tool.Result{Content: []schema.ContentPart{schema.TextPart{Text: "hello"}}}
+	if got := extractResultText(r); got != "hello" {
+		t.Errorf("extractResultText = %q, want hello", got)
+	}
+}
+
+// --- executor.go: Execute error paths via NewProcessExecutor ---
+
+func TestProcessExecutor_ExecuteRuns(t *testing.T) {
+	// Use a shell built-in that exists virtually everywhere: /bin/echo.
+	exec := NewProcessExecutor(WithInterpreter("echoer", "/bin/echo"))
+	res, err := exec.Execute(context.Background(), CodeAction{Language: "echoer", Code: "ignored-stdin"})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	// /bin/echo ignores stdin and prints its own args; we only care that it ran.
+	if res.Duration <= 0 {
+		t.Error("expected non-zero duration")
+	}
+}

--- a/agent/codeact/doc.go
+++ b/agent/codeact/doc.go
@@ -1,0 +1,37 @@
+// Package codeact implements the Code-as-Action (CodeAct) agent pattern.
+//
+// In the CodeAct pattern, the LLM generates executable code blocks instead of
+// tool calls. The agent parses code from the LLM response, executes it via a
+// pluggable [CodeExecutor], and feeds the result back as an observation for the
+// next reasoning step.
+//
+// # Architecture
+//
+// The package provides three main components:
+//
+//   - [CodeExecutor] interface for executing code (with built-in Noop and Process
+//     implementations).
+//   - [CodeActPlanner] implementing agent.Planner, registered as "codeact" in the
+//     planner registry. Instructs the LLM to emit fenced code blocks and parses
+//     them into ActionCode actions.
+//   - [CodeActAgent] wrapping agent.BaseAgent with a CodeExecutor, intercepting
+//     ActionCode actions and routing them to the executor.
+//
+// # Usage
+//
+//	import "github.com/lookatitude/beluga-ai/agent/codeact"
+//
+//	a := codeact.NewCodeActAgent("solver",
+//	    codeact.WithAgentLLM(model),
+//	    codeact.WithLanguage("python"),
+//	    codeact.WithExecutor(codeact.NewNoopExecutor()),
+//	    codeact.WithExecTimeout(30 * time.Second),
+//	)
+//
+//	result, err := a.Invoke(ctx, "Calculate the fibonacci sequence up to 100")
+//
+// # Execution State
+//
+// [ExecutionState] tracks variables and outputs across code steps within a
+// session, stored in PlannerState.Metadata under the key "codeact_state".
+package codeact

--- a/agent/codeact/executor.go
+++ b/agent/codeact/executor.go
@@ -10,6 +10,9 @@ import (
 	"github.com/lookatitude/beluga-ai/core"
 )
 
+// opExecute is the operation name used in error codes emitted by code executors.
+const opExecute = "codeact.execute"
+
 // CodeExecutor executes code actions and returns results. Implementations
 // must respect context cancellation and enforce timeouts.
 type CodeExecutor interface {
@@ -94,7 +97,7 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 	interpreter, ok := e.interpreters[action.Language]
 	if !ok {
 		return CodeResult{}, core.NewError(
-			"codeact.execute",
+			opExecute,
 			core.ErrInvalidInput,
 			fmt.Sprintf("unsupported language %q (supported: %v)", action.Language, e.supportedLanguages()),
 			nil,
@@ -103,7 +106,7 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 
 	if action.Code == "" {
 		return CodeResult{}, core.NewError(
-			"codeact.execute",
+			opExecute,
 			core.ErrInvalidInput,
 			"empty code",
 			nil,
@@ -147,7 +150,7 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 		// context error, so we must branch on ctx state before the type check.
 		if execCtx.Err() != nil {
 			return result, core.NewError(
-				"codeact.execute",
+				opExecute,
 				core.ErrTimeout,
 				fmt.Sprintf("code execution timed out after %v", timeout),
 				execCtx.Err(),
@@ -158,7 +161,7 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 			return result, nil
 		}
 		return result, core.NewError(
-			"codeact.execute",
+			opExecute,
 			core.ErrToolFailed,
 			"code execution failed",
 			err,

--- a/agent/codeact/executor.go
+++ b/agent/codeact/executor.go
@@ -73,7 +73,7 @@ func WithDefaultTimeout(d time.Duration) ProcessExecutorOption {
 }
 
 // NewProcessExecutor creates a new ProcessExecutor with the given options.
-// Default interpreters: python -> python3, javascript -> node, go -> go run.
+// Default interpreters: python -> python3, javascript -> node.
 func NewProcessExecutor(opts ...ProcessExecutorOption) *ProcessExecutor {
 	e := &ProcessExecutor{
 		interpreters: map[string]string{
@@ -140,10 +140,9 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 	}
 
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			result.ExitCode = exitErr.ExitCode()
-			return result, nil
-		}
+		// Check context first: when exec.CommandContext kills a process due
+		// to a deadline, cmd.Run() returns *exec.ExitError rather than the
+		// context error, so we must branch on ctx state before the type check.
 		if execCtx.Err() != nil {
 			return result, core.NewError(
 				"codeact.execute",
@@ -151,6 +150,10 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 				fmt.Sprintf("code execution timed out after %v", timeout),
 				execCtx.Err(),
 			)
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
 		}
 		return result, core.NewError(
 			"codeact.execute",

--- a/agent/codeact/executor.go
+++ b/agent/codeact/executor.go
@@ -75,17 +75,6 @@ func WithDefaultTimeout(d time.Duration) ProcessExecutorOption {
 // NewProcessExecutor creates a new ProcessExecutor with the given options.
 // Default interpreters: python -> python3, javascript -> node.
 func NewProcessExecutor(opts ...ProcessExecutorOption) *ProcessExecutor {
-	e := &ProcessExecutor{
-		interpreters: map[string]string{
-			"python":     "python3",
-			"javascript": "node",
-		},
-		defaultTimeout: 30 * time.Second,
-	}
-	for _, opt := range opts {
-		opt(e)
-	}
-	return e
 }
 
 // Execute runs code by writing it to stdin of the appropriate interpreter.

--- a/agent/codeact/executor.go
+++ b/agent/codeact/executor.go
@@ -1,0 +1,173 @@
+package codeact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/core"
+)
+
+// CodeExecutor executes code actions and returns results. Implementations
+// must respect context cancellation and enforce timeouts.
+type CodeExecutor interface {
+	// Execute runs the given code action and returns the result.
+	Execute(ctx context.Context, action CodeAction) (CodeResult, error)
+}
+
+// Compile-time interface checks.
+var (
+	_ CodeExecutor = (*NoopExecutor)(nil)
+	_ CodeExecutor = (*ProcessExecutor)(nil)
+)
+
+// NoopExecutor returns the code itself as output without executing it.
+// Useful for testing and dry-run scenarios.
+type NoopExecutor struct{}
+
+// NewNoopExecutor creates a new NoopExecutor.
+func NewNoopExecutor() *NoopExecutor {
+	return &NoopExecutor{}
+}
+
+// Execute returns the code as the output without running it.
+func (e *NoopExecutor) Execute(_ context.Context, action CodeAction) (CodeResult, error) {
+	return CodeResult{
+		Output:   action.Code,
+		ExitCode: 0,
+		Duration: 0,
+	}, nil
+}
+
+// ProcessExecutor runs code via os/exec with timeout and resource limits.
+// It maps language names to interpreter commands.
+//
+// Security note: ProcessExecutor should only be used in sandboxed environments.
+// Never pass untrusted user input directly as code without proper sandboxing.
+type ProcessExecutor struct {
+	// interpreters maps language name to command (e.g., "python" -> "python3").
+	interpreters map[string]string
+	// defaultTimeout is the fallback timeout when CodeAction.Timeout is zero.
+	defaultTimeout time.Duration
+}
+
+// ProcessExecutorOption configures a ProcessExecutor.
+type ProcessExecutorOption func(*ProcessExecutor)
+
+// WithInterpreter registers a command for a language name.
+func WithInterpreter(language, command string) ProcessExecutorOption {
+	return func(e *ProcessExecutor) {
+		e.interpreters[language] = command
+	}
+}
+
+// WithDefaultTimeout sets the default execution timeout.
+func WithDefaultTimeout(d time.Duration) ProcessExecutorOption {
+	return func(e *ProcessExecutor) {
+		if d > 0 {
+			e.defaultTimeout = d
+		}
+	}
+}
+
+// NewProcessExecutor creates a new ProcessExecutor with the given options.
+// Default interpreters: python -> python3, javascript -> node, go -> go run.
+func NewProcessExecutor(opts ...ProcessExecutorOption) *ProcessExecutor {
+	e := &ProcessExecutor{
+		interpreters: map[string]string{
+			"python":     "python3",
+			"javascript": "node",
+		},
+		defaultTimeout: 30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Execute runs code by writing it to stdin of the appropriate interpreter.
+// It enforces timeouts via context and returns stdout/stderr.
+func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeResult, error) {
+	interpreter, ok := e.interpreters[action.Language]
+	if !ok {
+		return CodeResult{}, core.NewError(
+			"codeact.execute",
+			core.ErrInvalidInput,
+			fmt.Sprintf("unsupported language %q (supported: %v)", action.Language, e.supportedLanguages()),
+			nil,
+		)
+	}
+
+	if action.Code == "" {
+		return CodeResult{}, core.NewError(
+			"codeact.execute",
+			core.ErrInvalidInput,
+			"empty code",
+			nil,
+		)
+	}
+
+	timeout := action.Timeout
+	if timeout == 0 {
+		timeout = e.defaultTimeout
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+
+	// Run through interpreter with code on stdin.
+	// Security: code comes from the LLM, not directly from user input.
+	// The ProcessExecutor should only be used in sandboxed environments.
+	cmd := exec.CommandContext(execCtx, interpreter) //nolint:gosec // sandboxed execution
+	cmd.Stdin = bytes.NewReader([]byte(action.Code))
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	result := CodeResult{
+		Output:   stdout.String(),
+		Error:    stderr.String(),
+		Duration: duration,
+	}
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
+		}
+		if execCtx.Err() != nil {
+			return result, core.NewError(
+				"codeact.execute",
+				core.ErrTimeout,
+				fmt.Sprintf("code execution timed out after %v", timeout),
+				execCtx.Err(),
+			)
+		}
+		return result, core.NewError(
+			"codeact.execute",
+			core.ErrToolFailed,
+			"code execution failed",
+			err,
+		)
+	}
+
+	return result, nil
+}
+
+// supportedLanguages returns a sorted list of registered language names.
+func (e *ProcessExecutor) supportedLanguages() []string {
+	langs := make([]string, 0, len(e.interpreters))
+	for lang := range e.interpreters {
+		langs = append(langs, lang)
+	}
+	return langs
+}

--- a/agent/codeact/executor.go
+++ b/agent/codeact/executor.go
@@ -75,6 +75,17 @@ func WithDefaultTimeout(d time.Duration) ProcessExecutorOption {
 // NewProcessExecutor creates a new ProcessExecutor with the given options.
 // Default interpreters: python -> python3, javascript -> node.
 func NewProcessExecutor(opts ...ProcessExecutorOption) *ProcessExecutor {
+	e := &ProcessExecutor{
+		interpreters: map[string]string{
+			"python":     "python3",
+			"javascript": "node",
+		},
+		defaultTimeout: 30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // Execute runs code by writing it to stdin of the appropriate interpreter.
@@ -112,6 +123,8 @@ func (e *ProcessExecutor) Execute(ctx context.Context, action CodeAction) (CodeR
 	// Run through interpreter with code on stdin.
 	// Security: code comes from the LLM, not directly from user input.
 	// The ProcessExecutor should only be used in sandboxed environments.
+	// #nosec G204 -- interpreter is from a whitelisted map controlled by the
+	// application, not user input. ProcessExecutor is meant for sandboxed use.
 	cmd := exec.CommandContext(execCtx, interpreter) //nolint:gosec // sandboxed execution
 	cmd.Stdin = bytes.NewReader([]byte(action.Code))
 

--- a/agent/codeact/planner.go
+++ b/agent/codeact/planner.go
@@ -1,0 +1,221 @@
+package codeact
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/agent"
+	"github.com/lookatitude/beluga-ai/llm"
+	"github.com/lookatitude/beluga-ai/schema"
+)
+
+// ActionCode is the action type for code execution actions.
+const ActionCode agent.ActionType = "code"
+
+func init() {
+	agent.RegisterPlanner("codeact", func(cfg agent.PlannerConfig) (agent.Planner, error) {
+		if cfg.LLM == nil {
+			return nil, fmt.Errorf("codeact planner requires an LLM")
+		}
+		opts := optsFromExtra(cfg.Extra)
+		return NewCodeActPlanner(cfg.LLM, opts...), nil
+	})
+}
+
+// optsFromExtra extracts CodeActPlanner options from PlannerConfig.Extra.
+func optsFromExtra(extra map[string]any) []PlannerOption {
+	var opts []PlannerOption
+	if extra == nil {
+		return opts
+	}
+	if lang, ok := extra["language"].(string); ok && lang != "" {
+		opts = append(opts, WithPlannerLanguage(lang))
+	}
+	if imports, ok := extra["allowed_imports"].([]string); ok {
+		opts = append(opts, WithAllowedImports(imports))
+	}
+	return opts
+}
+
+// codeBlockPattern matches fenced code blocks: ```lang\ncode\n```
+var codeBlockPattern = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)\\n```")
+
+// CodeActPlanner implements agent.Planner using the CodeAct pattern.
+// It instructs the LLM to emit code blocks and parses them into ActionCode actions.
+type CodeActPlanner struct {
+	llm            llm.ChatModel
+	language       string
+	allowedImports []string
+}
+
+// Compile-time interface check.
+var _ agent.Planner = (*CodeActPlanner)(nil)
+
+// PlannerOption configures a CodeActPlanner.
+type PlannerOption func(*CodeActPlanner)
+
+// WithPlannerLanguage sets the preferred programming language.
+func WithPlannerLanguage(lang string) PlannerOption {
+	return func(p *CodeActPlanner) {
+		p.language = lang
+	}
+}
+
+// WithAllowedImports sets the list of allowed imports/modules.
+func WithAllowedImports(imports []string) PlannerOption {
+	return func(p *CodeActPlanner) {
+		p.allowedImports = imports
+	}
+}
+
+// NewCodeActPlanner creates a new CodeActPlanner with the given LLM and options.
+func NewCodeActPlanner(model llm.ChatModel, opts ...PlannerOption) *CodeActPlanner {
+	p := &CodeActPlanner{
+		llm:      model,
+		language: "python",
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Plan generates actions from the initial state by querying the LLM.
+func (p *CodeActPlanner) Plan(ctx context.Context, state agent.PlannerState) ([]agent.Action, error) {
+	return p.generate(ctx, state)
+}
+
+// Replan generates updated actions based on new observations.
+func (p *CodeActPlanner) Replan(ctx context.Context, state agent.PlannerState) ([]agent.Action, error) {
+	return p.generate(ctx, state)
+}
+
+// generate queries the LLM and parses the response into actions.
+func (p *CodeActPlanner) generate(ctx context.Context, state agent.PlannerState) ([]agent.Action, error) {
+	messages := p.buildMessages(state)
+
+	resp, err := p.llm.Generate(ctx, messages)
+	if err != nil {
+		return nil, fmt.Errorf("codeact planner: generate failed: %w", err)
+	}
+
+	return p.parseResponse(resp), nil
+}
+
+// buildMessages constructs the message list, injecting the CodeAct system prompt.
+func (p *CodeActPlanner) buildMessages(state agent.PlannerState) []schema.Message {
+	msgs := make([]schema.Message, 0, len(state.Messages)+2)
+
+	// Inject CodeAct system instruction
+	sysPrompt := p.systemPrompt()
+	msgs = append(msgs, schema.NewSystemMessage(sysPrompt))
+
+	// Add conversation history, skipping any existing system messages to avoid conflicts.
+	for _, m := range state.Messages {
+		if _, ok := m.(*schema.SystemMessage); ok {
+			continue
+		}
+		msgs = append(msgs, m)
+	}
+
+	// Add observation results from previous code executions
+	for _, obs := range state.Observations {
+		if obs.Action.Type == ActionCode {
+			code, _ := obs.Action.Metadata["code"].(string)
+			lang, _ := obs.Action.Metadata["language"].(string)
+
+			var resultText string
+			if obs.Result != nil {
+				for _, part := range obs.Result.Content {
+					if tp, ok := part.(schema.TextPart); ok {
+						resultText = tp.Text
+						break
+					}
+				}
+			}
+			if obs.Error != nil && resultText == "" {
+				resultText = obs.Error.Error()
+			}
+
+			obsMsg := fmt.Sprintf("Code executed (%s):\n```%s\n%s\n```\n\nResult:\n%s", lang, lang, code, resultText)
+			msgs = append(msgs, schema.NewHumanMessage(obsMsg))
+		}
+	}
+
+	return msgs
+}
+
+// systemPrompt returns the system message instructing the LLM to use CodeAct.
+func (p *CodeActPlanner) systemPrompt() string {
+	var sb strings.Builder
+	sb.WriteString("You are a code-executing assistant. To solve tasks, write executable code in fenced code blocks.\n\n")
+	sb.WriteString("Rules:\n")
+	sb.WriteString(fmt.Sprintf("- Use %s as the programming language.\n", p.language))
+	sb.WriteString("- Wrap all code in fenced code blocks with the language tag: ```" + p.language + "\n")
+	sb.WriteString("- Print results to stdout so they can be captured.\n")
+	sb.WriteString("- If you need multiple steps, write one code block at a time and wait for the result.\n")
+	sb.WriteString("- When you have the final answer, respond with plain text (no code block).\n")
+
+	if len(p.allowedImports) > 0 {
+		sb.WriteString(fmt.Sprintf("- Only use these imports/modules: %s\n", strings.Join(p.allowedImports, ", ")))
+	}
+
+	return sb.String()
+}
+
+// parseResponse extracts code blocks from the LLM response and creates actions.
+// If no code blocks are found, the response text is treated as a final answer.
+func (p *CodeActPlanner) parseResponse(resp *schema.AIMessage) []agent.Action {
+	text := resp.Text()
+	blocks := ExtractCodeBlocks(text)
+
+	if len(blocks) == 0 {
+		return []agent.Action{{
+			Type:    agent.ActionFinish,
+			Message: text,
+		}}
+	}
+
+	actions := make([]agent.Action, 0, len(blocks))
+	for _, block := range blocks {
+		lang := block.Language
+		if lang == "" {
+			lang = p.language
+		}
+		actions = append(actions, agent.Action{
+			Type:    ActionCode,
+			Message: block.Code,
+			Metadata: map[string]any{
+				"language": lang,
+				"code":     block.Code,
+			},
+		})
+	}
+	return actions
+}
+
+// CodeBlock represents a parsed fenced code block.
+type CodeBlock struct {
+	// Language is the language tag from the code fence (may be empty).
+	Language string
+	// Code is the source code content.
+	Code string
+}
+
+// ExtractCodeBlocks parses fenced code blocks from text.
+// Returns all matched blocks in order.
+func ExtractCodeBlocks(text string) []CodeBlock {
+	matches := codeBlockPattern.FindAllStringSubmatch(text, -1)
+	blocks := make([]CodeBlock, 0, len(matches))
+	for _, match := range matches {
+		if len(match) >= 3 {
+			blocks = append(blocks, CodeBlock{
+				Language: match[1],
+				Code:     match[2],
+			})
+		}
+	}
+	return blocks
+}

--- a/agent/codeact/planner.go
+++ b/agent/codeact/planner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lookatitude/beluga-ai/agent"
 	"github.com/lookatitude/beluga-ai/llm"
 	"github.com/lookatitude/beluga-ai/schema"
+	"github.com/lookatitude/beluga-ai/tool"
 )
 
 // ActionCode is the action type for code execution actions.
@@ -109,8 +110,7 @@ func (p *CodeActPlanner) buildMessages(state agent.PlannerState) []schema.Messag
 	msgs := make([]schema.Message, 0, len(state.Messages)+2)
 
 	// Inject CodeAct system instruction
-	sysPrompt := p.systemPrompt()
-	msgs = append(msgs, schema.NewSystemMessage(sysPrompt))
+	msgs = append(msgs, schema.NewSystemMessage(p.systemPrompt()))
 
 	// Add conversation history, skipping any existing system messages to avoid conflicts.
 	for _, m := range state.Messages {
@@ -120,31 +120,43 @@ func (p *CodeActPlanner) buildMessages(state agent.PlannerState) []schema.Messag
 		msgs = append(msgs, m)
 	}
 
-	// Add observation results from previous code executions
+	// Add observation results from previous code executions.
 	for _, obs := range state.Observations {
-		if obs.Action.Type == ActionCode {
-			code, _ := obs.Action.Metadata["code"].(string)
-			lang, _ := obs.Action.Metadata["language"].(string)
-
-			var resultText string
-			if obs.Result != nil {
-				for _, part := range obs.Result.Content {
-					if tp, ok := part.(schema.TextPart); ok {
-						resultText = tp.Text
-						break
-					}
-				}
-			}
-			if obs.Error != nil && resultText == "" {
-				resultText = obs.Error.Error()
-			}
-
-			obsMsg := fmt.Sprintf("Code executed (%s):\n```%s\n%s\n```\n\nResult:\n%s", lang, lang, code, resultText)
-			msgs = append(msgs, schema.NewHumanMessage(obsMsg))
+		if obs.Action.Type != ActionCode {
+			continue
 		}
+		msgs = append(msgs, observationToMessage(obs))
 	}
 
 	return msgs
+}
+
+// observationToMessage renders a code-execution observation as a human message
+// so the LLM can see the executed code and its result on the next planner turn.
+func observationToMessage(obs agent.Observation) schema.Message {
+	code, _ := obs.Action.Metadata["code"].(string)
+	lang, _ := obs.Action.Metadata["language"].(string)
+
+	resultText := extractResultText(obs.Result)
+	if resultText == "" && obs.Error != nil {
+		resultText = obs.Error.Error()
+	}
+
+	obsMsg := fmt.Sprintf("Code executed (%s):\n```%s\n%s\n```\n\nResult:\n%s", lang, lang, code, resultText)
+	return schema.NewHumanMessage(obsMsg)
+}
+
+// extractResultText returns the first text part from a tool result, or "".
+func extractResultText(result *tool.Result) string {
+	if result == nil {
+		return ""
+	}
+	for _, part := range result.Content {
+		if tp, ok := part.(schema.TextPart); ok {
+			return tp.Text
+		}
+	}
+	return ""
 }
 
 // systemPrompt returns the system message instructing the LLM to use CodeAct.

--- a/agent/codeact/state.go
+++ b/agent/codeact/state.go
@@ -1,0 +1,113 @@
+package codeact
+
+import (
+	"sync"
+)
+
+// stateKey is the metadata key for storing ExecutionState in PlannerState.Metadata.
+const stateKey = "codeact_state"
+
+// ExecutionState tracks variables and outputs across code execution steps
+// within a session. It is stored in PlannerState.Metadata under stateKey.
+type ExecutionState struct {
+	mu sync.RWMutex
+	// Variables holds named values persisted across code steps.
+	variables map[string]string
+	// Outputs records the output of each code execution in order.
+	outputs []StepOutput
+}
+
+// StepOutput records the code and result of a single execution step.
+type StepOutput struct {
+	// Language is the programming language used.
+	Language string
+	// Code is the source code that was executed.
+	Code string
+	// Output is the stdout from execution.
+	Output string
+	// Error is the stderr or error from execution.
+	Error string
+	// ExitCode is the process exit code.
+	ExitCode int
+}
+
+// NewExecutionState creates a new empty ExecutionState.
+func NewExecutionState() *ExecutionState {
+	return &ExecutionState{
+		variables: make(map[string]string),
+	}
+}
+
+// SetVariable stores a named value in the execution state.
+func (s *ExecutionState) SetVariable(name, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.variables[name] = value
+}
+
+// GetVariable retrieves a named value from the execution state.
+// Returns the value and whether it was found.
+func (s *ExecutionState) GetVariable(name string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.variables[name]
+	return v, ok
+}
+
+// Variables returns a copy of all stored variables.
+func (s *ExecutionState) Variables() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := make(map[string]string, len(s.variables))
+	for k, v := range s.variables {
+		cp[k] = v
+	}
+	return cp
+}
+
+// AddOutput appends a step output to the execution history.
+func (s *ExecutionState) AddOutput(output StepOutput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outputs = append(s.outputs, output)
+}
+
+// Outputs returns a copy of all step outputs.
+func (s *ExecutionState) Outputs() []StepOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := make([]StepOutput, len(s.outputs))
+	copy(cp, s.outputs)
+	return cp
+}
+
+// StepCount returns the number of code execution steps recorded.
+func (s *ExecutionState) StepCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.outputs)
+}
+
+// LastOutput returns the most recent step output, or nil if none.
+func (s *ExecutionState) LastOutput() *StepOutput {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.outputs) == 0 {
+		return nil
+	}
+	out := s.outputs[len(s.outputs)-1]
+	return &out
+}
+
+// GetOrCreateState retrieves the ExecutionState from metadata, or creates
+// and stores a new one if not present.
+func GetOrCreateState(metadata map[string]any) *ExecutionState {
+	if v, ok := metadata[stateKey]; ok {
+		if s, ok := v.(*ExecutionState); ok {
+			return s
+		}
+	}
+	s := NewExecutionState()
+	metadata[stateKey] = s
+	return s
+}

--- a/agent/codeact/types.go
+++ b/agent/codeact/types.go
@@ -1,0 +1,82 @@
+package codeact
+
+import (
+	"context"
+	"time"
+)
+
+// CodeAction describes a code block to be executed.
+type CodeAction struct {
+	// Language is the programming language of the code (e.g., "python", "go", "javascript").
+	Language string
+	// Code is the source code to execute.
+	Code string
+	// Timeout is the maximum duration allowed for execution. Zero means use default.
+	Timeout time.Duration
+}
+
+// CodeResult holds the outcome of executing a CodeAction.
+type CodeResult struct {
+	// Output is the stdout content from execution.
+	Output string
+	// Error is the stderr content or error message from execution, if any.
+	Error string
+	// ExitCode is the process exit code. Zero indicates success.
+	ExitCode int
+	// Duration is how long the execution took.
+	Duration time.Duration
+}
+
+// Success reports whether the code executed without errors.
+func (r CodeResult) Success() bool {
+	return r.ExitCode == 0 && r.Error == ""
+}
+
+// CodeActHooks provides optional callback functions for code execution lifecycle.
+// All fields are optional; nil hooks are skipped.
+type CodeActHooks struct {
+	// BeforeExec is called before code is executed. Returning an error cancels execution.
+	BeforeExec func(ctx context.Context, action CodeAction) error
+	// AfterExec is called after code execution completes.
+	AfterExec func(ctx context.Context, action CodeAction, result CodeResult) error
+	// OnError is called when code execution fails. The returned error replaces the original.
+	OnError func(ctx context.Context, action CodeAction, err error) error
+}
+
+// ComposeCodeActHooks merges multiple CodeActHooks into a single value.
+// Callbacks are called in the order provided. The first error short-circuits.
+func ComposeCodeActHooks(hooks ...CodeActHooks) CodeActHooks {
+	return CodeActHooks{
+		BeforeExec: func(ctx context.Context, action CodeAction) error {
+			for _, h := range hooks {
+				if h.BeforeExec != nil {
+					if err := h.BeforeExec(ctx, action); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+		AfterExec: func(ctx context.Context, action CodeAction, result CodeResult) error {
+			for _, h := range hooks {
+				if h.AfterExec != nil {
+					if err := h.AfterExec(ctx, action, result); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+		OnError: func(ctx context.Context, action CodeAction, err error) error {
+			for _, h := range hooks {
+				if h.OnError != nil {
+					err = h.OnError(ctx, action, err)
+					if err == nil {
+						return nil
+					}
+				}
+			}
+			return err
+		},
+	}
+}

--- a/agent/codeact/types.go
+++ b/agent/codeact/types.go
@@ -50,36 +50,51 @@ type CodeActHooks struct {
 // Callbacks are called in the order provided. The first error short-circuits.
 func ComposeCodeActHooks(hooks ...CodeActHooks) CodeActHooks {
 	return CodeActHooks{
-		BeforeExec: func(ctx context.Context, action CodeAction) error {
-			for _, h := range hooks {
-				if h.BeforeExec != nil {
-					if err := h.BeforeExec(ctx, action); err != nil {
-						return err
-					}
-				}
+		BeforeExec: composeBeforeExec(hooks),
+		AfterExec:  composeAfterExec(hooks),
+		OnError:    composeOnError(hooks),
+	}
+}
+
+func composeBeforeExec(hooks []CodeActHooks) func(context.Context, CodeAction) error {
+	return func(ctx context.Context, action CodeAction) error {
+		for _, h := range hooks {
+			if h.BeforeExec == nil {
+				continue
 			}
-			return nil
-		},
-		AfterExec: func(ctx context.Context, action CodeAction, result CodeResult) error {
-			for _, h := range hooks {
-				if h.AfterExec != nil {
-					if err := h.AfterExec(ctx, action, result); err != nil {
-						return err
-					}
-				}
+			if err := h.BeforeExec(ctx, action); err != nil {
+				return err
 			}
-			return nil
-		},
-		OnError: func(ctx context.Context, action CodeAction, err error) error {
-			for _, h := range hooks {
-				if h.OnError != nil {
-					err = h.OnError(ctx, action, err)
-					if err == nil {
-						return nil
-					}
-				}
+		}
+		return nil
+	}
+}
+
+func composeAfterExec(hooks []CodeActHooks) func(context.Context, CodeAction, CodeResult) error {
+	return func(ctx context.Context, action CodeAction, result CodeResult) error {
+		for _, h := range hooks {
+			if h.AfterExec == nil {
+				continue
 			}
-			return err
-		},
+			if err := h.AfterExec(ctx, action, result); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func composeOnError(hooks []CodeActHooks) func(context.Context, CodeAction, error) error {
+	return func(ctx context.Context, action CodeAction, err error) error {
+		for _, h := range hooks {
+			if h.OnError == nil {
+				continue
+			}
+			err = h.OnError(ctx, action, err)
+			if err == nil {
+				return nil
+			}
+		}
+		return err
 	}
 }

--- a/agent/codeact/types.go
+++ b/agent/codeact/types.go
@@ -27,9 +27,12 @@ type CodeResult struct {
 	Duration time.Duration
 }
 
-// Success reports whether the code executed without errors.
+// Success reports whether the code executed successfully, defined by the
+// POSIX convention of a zero exit code. Stderr output is ignored because
+// well-behaved programs (including Python deprecation warnings) routinely
+// write to stderr while exiting with code 0.
 func (r CodeResult) Success() bool {
-	return r.ExitCode == 0 && r.Error == ""
+	return r.ExitCode == 0
 }
 
 // CodeActHooks provides optional callback functions for code execution lifecycle.


### PR DESCRIPTION
## Summary
- agent/codeact package, CodeAction, ProcessExecutor, CodeActPlanner (registered as 'codeact'), CodeActAgent

## Linear
- LOO-54: https://linear.app/lookatitude/issue/LOO-54

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (with -race where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)