### PR TITLE
fix(website): bump react-dom to 19.2.5 to match react

### DIFF
--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -30,7 +30,7 @@
     "mdast-util-to-hast": "13.2.1",
     "mermaid": "^11.12.3",
     "react": "^19.2.5",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.5",
     "satori": "^0.25.0",
     "sharp": "^0.34.5",
     "unist-util-visit": "^5.1.0",

--- a/docs/website/yarn.lock
+++ b/docs/website/yarn.lock
@@ -4648,10 +4648,10 @@ radix3@^1.1.2:
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.1.2.tgz#fd27d2af3896c6bf4bcdfab6427c69c2afc69ec0"
   integrity sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==
 
-react-dom@^19.2.4:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
+react-dom@^19.2.5:
+  version "19.2.5"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
+  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
   dependencies:
     scheduler "^0.27.0"
 


### PR DESCRIPTION
## Summary

- PR #194 bumped `react` from 19.2.4 → 19.2.5 but did not bump `react-dom`
- React refuses to run when these two packages have different versions, so the Astro build on main is failing with `Incompatible React versions` in `ensureCorrectIsomorphicReactVersion`
- This PR bumps `react-dom` to `^19.2.5` so the versions match again

## Test plan

- [x] Reproduced failure locally: https://github.com/lookatitude/beluga-ai/actions/runs/24271628123/job/70877790432
- [x] Bumped react-dom to ^19.2.5 in package.json
- [x] Regenerated yarn.lock with yarn@1.22.22 (matching CI's yarn classic setup)
- [x] `yarn install --frozen-lockfile` passes locally
- [x] `yarn build` succeeds locally — 468 pages built in ~120s
- [x] Lockfile diff is surgical (8 lines) — only the react-dom entry changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)