### PR TITLE
chore(rules): enforce pre-commit security gate and branch-PR discipline

### DIFF
--- a/.claude/rules/go-packages.md
+++ b/.claude/rules/go-packages.md
@@ -17,6 +17,38 @@ alwaysApply: false
 - [ ] OTel span at every exported method
 - [ ] Errors wrapped with `core.Error` + `ErrorCode`
 
+## Pre-commit verification gate (MANDATORY)
+
+Before ANY `git commit` on a Go change, run and pass:
+
+```bash
+go build ./...                    # compile
+go vet ./...                      # stdlib static analysis
+go test -race ./...               # tests with race detector
+go mod tidy && git diff --exit-code go.mod go.sum
+gofmt -l . | grep -v ".claude/worktrees"
+golangci-lint run ./...           # primary linter
+gosec -quiet ./...                # security scanner
+govulncheck ./...                 # known-CVE scanner
+```
+
+CI runs all of these on every PR (see `.github/workflows/_ci-checks.yml`
+and `_security-checks.yml`). Catching issues locally is faster than
+pushing and waiting for CI to fail.
+
+**gosec focus areas** (these are the most commonly flagged in this repo):
+- `G107` — avoid HTTP requests with tainted variables (sanitize URLs)
+- `G112` — always set `http.Server.ReadHeaderTimeout`
+- `G115` — integer overflow on type conversion (use range checks)
+- `G201/G202` — SQL string formatting → use parameterised queries or
+  validate the table/column name against an allowlist before interpolating
+- `G304` — file inclusion via variable (call `filepath.Clean` and check
+  the result is inside an allowed prefix before `os.ReadFile`)
+- `G404` — use `crypto/rand` not `math/rand` for anything security-sensitive
+- `errcheck` unhandled errors — use `_ = fn()` when intentional,
+  otherwise propagate with `core.Errorf(code, "...: %w", err)`
+- `G601` — context cancellation function must be called (always `defer cancel()`)
+
 ## Anti-rationalization
 
 | Excuse | Counter |

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -33,10 +33,31 @@ alwaysApply: true
 
 ## Quality Gates
 
-### Before Security Review (Developer must verify)
-- `go build ./...` passes
-- `go vet ./...` passes
-- `go test ./...` passes
+### Branch discipline (MANDATORY, every change)
+- Every code change starts with `git checkout -b <branch>` — **never commit to `main`**
+- Every branch ends with `gh pr create` — **never merge directly to `main`**
+- Verify `git branch --show-current` is not `main` before any `git commit`
+
+### Before commit (MANDATORY, every commit — not just before push)
+Run the full suite locally BEFORE `git commit`. Only commit when all pass:
+
+```bash
+go build ./...
+go vet ./...
+go test -race ./...
+go mod tidy && git diff --exit-code go.mod go.sum
+gofmt -l . | grep -v ".claude/worktrees"
+golangci-lint run ./...
+gosec -quiet ./...
+govulncheck ./...
+```
+
+Pre-existing findings in files you did NOT change do not block your commit, but
+MUST be documented in the commit message so reviewers know to ignore or fix
+separately. New findings in files you DID change MUST be fixed before commit.
+
+### Before Security Review (additional, for full-workflow tasks)
+- All of the "Before commit" checks above pass
 - No `TODO` or `FIXME` without associated tracking
 
 ### Security Review (2 clean passes required)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,31 @@ Go-native agentic AI framework. `github.com/lookatitude/beluga-ai`. Go 1.23+. St
 9. Interfaces have ≤4 methods. `context.Context` is the first parameter of every public function.
 10. Zero external deps in `core/` and `schema/` beyond stdlib + otel. No circular imports.
 
+## Branch + PR discipline (MANDATORY)
+
+1. **Never commit to `main`.** Every change — code, docs, tests — starts with `git checkout -b <type>/<short-desc>` where `<type>` is `fix`, `feat`, `refactor`, `docs`, or `chore`.
+2. Every branch ends with `gh pr create`. CI runs gosec, golangci-lint, govulncheck, SonarCloud, Snyk, Trivy, CodeQL, unit + integration tests. Wait for green before merge.
+3. Verify `git branch --show-current` ≠ `main` before any `git commit`.
+
+## Pre-commit verification gate (MANDATORY)
+
+Before ANY `git commit` on a Go change, run and pass:
+
+```bash
+go build ./...
+go vet ./...
+go test -race ./...
+go mod tidy && git diff --exit-code go.mod go.sum
+gofmt -l . | grep -v ".claude/worktrees"
+golangci-lint run ./...
+gosec -quiet ./...
+govulncheck ./...
+```
+
+Pre-existing findings in files you did NOT change: document in the commit
+message, don't block on them. New findings in files you DID change: fix
+before commit. See `.claude/rules/go-packages.md` for gosec focus areas.
+
 ## Before writing code
 
 1. File-scoped rules in `.claude/rules/` auto-load for the files you touch.


### PR DESCRIPTION
## Summary

- Adds mandatory **pre-commit verification gate** to `CLAUDE.md`, `.claude/rules/workflow.md`, and `.claude/rules/go-packages.md`
- Adds mandatory **branch + PR discipline** (never commit to `main`)
- Encodes the rules at the repo level so every dispatched subagent inherits them automatically

## Context

PR #248 (`arch-validate-sweep`) was pushed without local security/lint checks. CI caught 36 gosec alerts (20 errors + 16 warnings) on the top-level gosec check — many pre-existing findings surfaced because the sweep touched adjacent files. SonarCloud Code Analysis also failed. User asked that every code change verify tests + linters + security checks **before** committing, not just before push, and that all changes go through branch + PR (never directly on `main`).

## What changed

### `CLAUDE.md` (auto-loaded every session)

Two new top-level sections:

1. **Branch + PR discipline** — every change starts with `git checkout -b <type>/<desc>`, ends with `gh pr create`, verify `git branch --show-current` ≠ `main` before any commit.
2. **Pre-commit verification gate** — run `go build / vet / test -race / mod tidy / gofmt / golangci-lint / gosec / govulncheck` BEFORE `git commit`. Pre-existing findings in untouched files are documented, not blocking. New findings in touched files are blocking.

### `.claude/rules/workflow.md` (developer/QA quality gate)

Matches the CLAUDE.md additions in the Quality Gates section so the developer agent sees the same gate even without loading the root file.

### `.claude/rules/go-packages.md` (auto-loaded when editing `*.go`)

Adds a full "Pre-commit verification gate" section plus a **gosec focus areas** reference listing the rules that commonly trip this repo: G107, G112, G115, G201/G202, G304, G404, errcheck, G601. This gives subagents editing Go files the common pitfalls as part of their automatic context.

## Why repo-level rules not just user memory

The user's memory covers their personal workflow. Task-tool subagents inherit `CLAUDE.md` and `.claude/rules/*` but NOT user memory. Encoding the gate at repo level ensures every subagent — including parallel waves of 5+ — follows the same discipline without the dispatching agent having to replicate the full mandate in each prompt.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] CI: golangci-lint
- [ ] CI: gosec
- [ ] CI: SonarCloud
- [ ] CI: govulncheck
- [ ] CI: Snyk

🤖 Generated with [Claude Code](https://claude.com/claude-code)