### PR TITLE
docs: add production-readiness framing to docs hub pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,17 @@ New to Beluga? Read in this order:
 3. [Extensibility Patterns](./architecture/03-extensibility-patterns.md) — the 4 mechanisms every package uses.
 4. [Build Your First Agent](./guides/first-agent.md) — 5-minute quickstart.
 
+## Production readiness
+
+Beluga is designed for the production agent stack. Every package ships with
+OpenTelemetry GenAI spans ([DOC-14](architecture/14-observability.md)),
+circuit breakers and rate limits are middleware on the same interface as your
+LLM calls ([DOC-15](architecture/15-resilience.md)), and the `workflow/`
+package provides crash-durable execution ([DOC-16](architecture/16-durable-workflows.md)).
+Deployment targets — Docker, Kubernetes, Temporal, and embedded — are documented in
+[DOC-17](architecture/17-deployment-modes.md).
+See the [Production Checklist](production-checklist.md).
+
 ## Sections
 
 ### [Architecture](./architecture/README.md)

--- a/docs/architecture/01-overview.md
+++ b/docs/architecture/01-overview.md
@@ -195,7 +195,7 @@ graph TD
 
 See [DOC-07](./07-orchestration-patterns.md).
 
-## The three design principles
+## The four design principles
 
 ### 1. Streaming first
 
@@ -214,6 +214,12 @@ See [DOC-07](./07-orchestration-patterns.md).
 `core/` and `schema/` have **zero** external dependencies beyond the Go stdlib and OpenTelemetry. Providers live in `*/providers/` subdirectories and pull their own SDKs. You can import `core` and build a toy agent without touching a single cloud SDK.
 
 **Why:** keeps the critical path auditable, makes dependency updates targeted (a breaking change in the OpenAI SDK never destabilises `memory/`), and enables embedded/edge use cases.
+
+### 4. Production-ready by default
+
+Every extensible package ships with `WithTracing()` middleware that emits OTel GenAI spans at package boundaries ([DOC-14](./14-observability.md)). Circuit breakers, retry, and rate limiting are middleware on the same `func(T) T` signature as any other wrapper — no special infrastructure required ([DOC-15](./15-resilience.md)). The `workflow/` package provides crash-durable execution via a Temporal-compatible backend so agent runs survive process restarts without application-level checkpointing ([DOC-16](./16-durable-workflows.md)).
+
+**Why:** observability, resilience, and durability are default concerns for any agent running in a multi-tenant or long-running context. Requiring users to bolt these on after the fact produces inconsistent coverage. Shipping them as opt-in middleware on every interface keeps the path from prototype to production a configuration change, not an architectural one.
 
 ## The universal package shape
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,10 @@
 # Architecture
 
 The 18 documents in this directory explain the Beluga AI v2 architecture, layer by layer.
+The design targets production deployments: observability ([DOC-14](./14-observability.md)) and
+resilience ([DOC-15](./15-resilience.md)) are first-class concerns in Layer 2, not retrofit; durable
+workflow execution ([DOC-16](./16-durable-workflows.md)) and deployment topology ([DOC-17](./17-deployment-modes.md))
+are covered in the cross-cutting section.
 
 ## The 7-layer model
 


### PR DESCRIPTION
## Summary

- Add a **Production readiness** section to `docs/README.md` after "Start here", linking DOC-14 (Observability), DOC-15 (Resilience), DOC-16 (Durable Workflows), DOC-17 (Deployment Modes), and a `production-checklist.md` stub link.
- Add a two-sentence production-oriented framing at the top of `docs/architecture/README.md` pointing to the same four docs.
- Add a fourth design principle, **Production-ready by default**, to `docs/architecture/01-overview.md`, citing `WithTracing()` middleware, resilience middleware, and durable workflow execution — each with a link to the implementing doc.

All three edits are factual, link-backed, and free of forbidden words (tone sweep: `revolutionary`, `world-class`, `blazing`, `seamless`, `magical`, `best-in-class` — zero hits).

## Test plan

- [ ] Read `docs/README.md` — "Production readiness" section present after "Start here", before "Sections".
- [ ] Read `docs/architecture/README.md` — production framing in first paragraph, all four doc links resolve.
- [ ] Read `docs/architecture/01-overview.md` — "The four design principles" heading, fourth principle present with three link citations.
- [ ] Tone sweep passes: `grep -rnE "revolutionary|world-class|blazing|seamless|magical|best-in-class" docs/` returns no hits in authored docs.
- [ ] No marketing language in any added sentence — each claim cites a specific doc or package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)