### PR TITLE
docs(arch): expand DOC-05/06 with cognitive architectures and missing strategies

### DIFF
--- a/docs/architecture/05-agent-anatomy.md
+++ b/docs/architecture/05-agent-anatomy.md
@@ -27,7 +27,7 @@ graph TD
 ### Required
 
 - **Persona** — role, goal, backstory, optional traits. Maps to the system prompt.
-- **Planner** — decides the next action. 7 strategies ship, a `RegisterPlanner()` hook lets you add more. See [DOC-06](./06-reasoning-strategies.md).
+- **Planner** — decides the next action. 8 strategies ship, a `RegisterPlanner()` hook lets you add more. See [DOC-06](./06-reasoning-strategies.md).
 - **Executor** — runs the Plan → Act → Observe → Replan loop. See [DOC-04](./04-data-flow.md).
 
 ### Optional
@@ -174,16 +174,143 @@ Because agents implement `Runnable`, they participate in:
 
 Agents are values, not special-cased framework types. That's the whole point of the design.
 
+## Advanced Agent Architectures [experimental]
+
+The sub-packages below extend the base agent model with specialised runtime behaviours. They are shipped in the same module but isolated in their own packages so you can import only what you need. All are production-usable but their APIs may evolve between minor versions.
+
+### agent/cognitive — Dual-Process Routing
+
+`agent/cognitive` implements dual-process theory (Kahneman's System 1 / System 2). A `DualProcessAgent` wraps two ordinary `agent.Agent` instances and routes each request to the faster S1 agent or the more deliberate S2 agent based on a `ComplexityScorer`.
+
+**Key interface** (`agent/cognitive/types.go:57-60`):
+
+```go
+type ComplexityScorer interface {
+    Score(ctx context.Context, input string) (ComplexityScore, error)
+}
+```
+
+`ComplexityScore` carries a `ComplexityLevel` (`Simple`, `Moderate`, `Complex`) and a `Confidence` float in `[0.0, 1.0]`. The built-in `HeuristicScorer` registers itself under `"heuristic"` via `RegisterScorer`. Supply your own with `WithScorer(s)`.
+
+**Invoke vs Stream behaviour** (`agent/cognitive/agent.go:124-190` and `194-254`): `Invoke` uses a *cascading* strategy — S1 runs first, and if the score is `Moderate` with confidence below the threshold (default 0.7), execution escalates to S2. `Stream` pre-classifies before streaming so it never buffers a full S1 response before deciding. Both paths are symmetric: `Complex` inputs always route directly to S2.
+
+**Hook into BaseAgent:** `DualProcessAgent` implements `agent.Agent` directly (compile-time check at `agent/cognitive/agent.go:31`). Attach it to a `Runner` exactly like any other agent. Use `Hooks` (`agent/cognitive/types.go:65-76`) to observe `OnRouted`, `OnEscalated`, and `OnCompleted` events, and `RoutingMetrics` (`agent/cognitive/metrics.go:11`) to track aggregate S1/S2 counts and escalation rates.
+
+**When to use:** you have a cheap, fast agent (e.g., small local model) that handles the majority of queries, and an expensive, accurate agent for the minority that require deeper reasoning. Cognitive routing reduces cost proportionally to your S1 hit rate.
+
+```go
+import (
+    "context"
+    "github.com/lookatitude/beluga-ai/agent/cognitive"
+)
+
+a, err := cognitive.New("router", fastAgent, deepAgent,
+    cognitive.WithThreshold(0.75),
+    cognitive.WithCognitiveHooks(cognitive.Hooks{
+        OnRouted: func(ctx context.Context, input string, level cognitive.ComplexityLevel, target string) {
+            // observe routing decisions
+        },
+    }),
+)
+if err != nil {
+    return err
+}
+```
+
+### agent/metacognitive — Cross-Session Learning
+
+`agent/metacognitive` enables an agent to build a persistent self-model from execution experience. After each turn, a `Plugin` extracts heuristics from success and failure signals, updates per-task-type `CapabilityScore` values using an exponential moving average, and persists everything via a `SelfModelStore`. Before the next turn, relevant heuristics are retrieved and injected into the user message as context.
+
+**Key interface** (`agent/metacognitive/store.go:13-24`):
+
+```go
+type SelfModelStore interface {
+    Load(ctx context.Context, agentID string) (*SelfModel, error)
+    Save(ctx context.Context, model *SelfModel) error
+    SearchHeuristics(ctx context.Context, agentID, query string, k int) ([]Heuristic, error)
+}
+```
+
+**Component breakdown:**
+
+- `Monitor` (`agent/metacognitive/monitor.go:15`) — attaches to `agent.Hooks` (`OnStart`, `AfterAct`, `OnEnd`, `OnError`, `OnToolCall`, `OnToolResult`) to collect `MonitoringSignals` per turn.
+- `HeuristicExtractor` (`agent/metacognitive/extractor.go:15`) — derives `Heuristic` records from signals. `SimpleExtractor` uses rule-based patterns; replace with an LLM-backed extractor for richer heuristics.
+- `Plugin` (`agent/metacognitive/plugin.go:31`) — implements `runtime.Plugin`. Its `BeforeTurn` loads and injects heuristics; its `AfterTurn` extracts and saves new ones.
+- `InMemoryStore` (`agent/metacognitive/store.go:31`) — thread-safe in-process store for development. Implement `SelfModelStore` to persist across restarts.
+
+**Hook into BaseAgent:** attach `plugin.Monitor().Hooks()` to the agent, then register the `Plugin` with the `Runner` via `runner.AddPlugin(plugin)`. The runner calls `BeforeTurn`/`AfterTurn` around each session turn automatically.
+
+**When to use:** the agent handles recurring task types and you want it to improve without human intervention — for example, a customer-support agent that learns which tool sequences resolve certain query categories most efficiently.
+
+### agent/evolving — Self-Improvement Loop
+
+`agent/evolving` wraps any `agent.Agent` with a background learning loop. After every N interactions (`WithLearnEveryN`, default 10), a goroutine runs the `ExperienceDistiller` over buffered interactions, then passes the resulting `Experience` records to a `MetaOptimizer` for improvement suggestions.
+
+**Key interfaces** (`agent/evolving/evolving.go:17-27`):
+
+```go
+type MetaOptimizer interface {
+    Optimize(ctx context.Context, experiences []Experience) ([]Suggestion, error)
+}
+
+type ExperienceDistiller interface {
+    Distill(ctx context.Context, interactions []Interaction) ([]Experience, error)
+}
+```
+
+Built-in implementations — `SimpleDistiller` (success rate and average latency) and `FrequencyOptimizer` (frequency-based suggestions) — provide a working baseline. The `Suggestion` type carries a `Type` (`"prompt_update"`, `"tool_addition"`, etc.), `Priority`, and `Confidence` that your application can consume to drive offline improvements.
+
+**Hook into BaseAgent:** `EvolvingAgent` implements `agent.Agent` (compile-time check at `agent/evolving/evolving.go:134`). Wrap your agent with `evolving.New(inner, opts...)`. The `Experiences()` and `Suggestions()` methods surface the latest analysis. Learning goroutines run with `context.WithoutCancel(ctx)` so they outlive the triggering request but still carry trace and tenant values.
+
+**When to use:** long-running production agents where you want automated detection of reliability or performance regressions. Couple with an alerting system that reads `Suggestions()` and pages on high-priority items.
+
+### agent/speculative — Speculative Execution
+
+`agent/speculative` runs a cheap `Predictor` and the ground-truth `agent.Agent` in parallel. If the predictor finishes first with sufficient confidence and passes validation, the predicted result is returned immediately — similar to speculative execution in CPU pipelines. The ground-truth result is used otherwise.
+
+**Key interfaces** (`agent/speculative/predictor.go:13-15` and `agent/speculative/validator.go:10-13`):
+
+```go
+type Predictor interface {
+    Predict(ctx context.Context, input string) (prediction string, confidence float64, err error)
+}
+
+type Validator interface {
+    Validate(ctx context.Context, prediction, groundTruth string) (valid bool, err error)
+}
+```
+
+`LightModelPredictor` uses any `llm.ChatModel` as a cheap drafting model; confidence is estimated from response length. `ExactValidator` checks case-normalised string equality; `SemanticValidator` uses cosine similarity of term-frequency vectors with a configurable threshold.
+
+**Hook into BaseAgent:** `SpeculativeExecutor` implements `agent.Agent` (compile-time check at `agent/speculative/executor.go:14`). Construct with `speculative.NewSpeculativeExecutor(groundTruthAgent, opts...)` and use it anywhere a normal agent is expected. For streaming, supply `WithFastAgent` — when predictor confidence is high, the fast agent's stream is used directly.
+
+**When to use:** your ground-truth agent is expensive (e.g., LATS or MoA) and many inputs have predictable answers that a lighter model can supply. Measure the hit rate via `SpeculativeExecutor.Metrics()` before relying on this in production.
+
+### agent/plancache — Plan-Level Caching
+
+`agent/plancache` caches successful action sequences at the planner level. When the same (or similar) input recurs, `CachedPlanner` returns the cached plan without calling the inner planner. Plans that require frequent replanning are evicted automatically.
+
+See [DOC-06 — Reasoning Strategies: Plan-Level Caching](./06-reasoning-strategies.md#agentplancache--plan-level-caching-experimental) for full integration details. The key types are:
+
+- `Store` (`agent/plancache/store.go:7`) — persistence interface: `Save`, `Get`, `List`, `Delete`.
+- `Matcher` (`agent/plancache/matcher.go:8`) — similarity scoring interface.
+- `Template` (`agent/plancache/template.go:12`) — a cached plan with `SuccessCount`, `DeviationCount`, and `DeviationRatio()`.
+- `CachedPlanner` (`agent/plancache/cached_planner.go:16`) — wraps any `agent.Planner`.
+
+**When to use:** agents that solve recurring, structurally similar tasks — ticket routing, document classification, data extraction — where re-running the planner on every input is wasteful.
+
 ## Common mistakes
 
 - **Forgetting to embed `BaseAgent`.** Your custom agent needs to satisfy the full `Agent` interface. Embedding `BaseAgent` is the shortcut.
 - **Hand-rolling handoffs with direct calls.** Don't. Use the `Handoffs` field and let Beluga generate the `transfer_to_*` tool.
 - **Treating the planner and the LLM as the same thing.** The planner *decides*; the LLM *generates*. One planner can call the LLM zero or many times per iteration.
 - **Storing state in agent fields instead of session/memory.** Agents should be stateless — state lives in the session. Otherwise two concurrent requests share state and race.
+- **Sharing a metacognitive store across unrelated agents.** `SelfModelStore` uses `agentID` as the namespace key. Two agents with the same ID share heuristics — use distinct IDs.
+- **Using speculative execution without measuring hit rate.** A low hit rate means you're paying for two agents and getting one. Set a baseline with `Metrics().HitRate()` before deploying.
 
 ## Related reading
 
-- [06 — Reasoning Strategies](./06-reasoning-strategies.md) — how `Planner.Plan` actually works.
+- [06 — Reasoning Strategies](./06-reasoning-strategies.md) — how `Planner.Plan` actually works, and how `plancache` and `speculative` optimize it.
 - [07 — Orchestration Patterns](./07-orchestration-patterns.md) — how teams coordinate.
 - [08 — Runner and Lifecycle](./08-runner-and-lifecycle.md) — how agents get hosted.
 - [09 — Memory Architecture](./09-memory-architecture.md) — how memory threads through agents.

--- a/docs/architecture/06-reasoning-strategies.md
+++ b/docs/architecture/06-reasoning-strategies.md
@@ -6,17 +6,16 @@
 
 ## Overview
 
-A planner decides *what an agent does next*. Beluga ships seven reasoning strategies that trade off cost against quality. Pick the cheapest one that gives acceptable results for your task — upgrading is a one-line change because every planner implements the same `Planner` interface.
+A planner decides *what an agent does next*. Beluga ships eight reasoning strategies that trade off cost against quality. Pick the cheapest one that gives acceptable results for your task — upgrading is a one-line change because every planner implements the same `Planner` interface. Run `agent.ListPlanners()` at runtime to see what is registered in your build.
 
-**Status note:** some of the advanced strategies below (LATS, MoA) are on the roadmap but may not be fully implemented yet. Check `agent/planners/` for the current list and use `planner.List()` at runtime to see what's registered.
-
-## The seven strategies, cheapest to most expensive
+## The eight strategies, cheapest to most expensive
 
 ```mermaid
 graph LR
   ReAct[ReAct · cheap] --> Reflexion[Reflexion]
   Reflexion --> SD[Self-Discover]
-  SD --> ToT[Tree-of-Thought]
+  SD --> MM[MindMap]
+  MM --> ToT[Tree-of-Thought]
   ToT --> GoT[Graph-of-Thought]
   GoT --> LATS[LATS]
   LATS --> MoA[Mixture-of-Agents · expensive]
@@ -27,6 +26,7 @@ graph LR
 | ReAct | 1 | Simple tool use, general tasks |
 | Reflexion | 2-3 | Quality-sensitive, iterative improvement |
 | Self-Discover | 2 | Cost-sensitive planning, reusable plans |
+| MindMap | 2-4 | Structured reasoning with contradiction detection |
 | Tree-of-Thought | 5-20 | Combinatorial search, puzzles |
 | Graph-of-Thought | 5-20 | Reasoning with cycles and merging |
 | LATS | 20-100 | Deep reasoning, math proofs, code synthesis |
@@ -60,6 +60,27 @@ Three roles, all played by the same LLM with different prompts. The actor produc
 ### Self-Discover
 
 The model first composes a task-specific reasoning plan ("decompose → find evidence → synthesise"), then executes it. The plan is cached and reused for similar inputs. Cheaper than full Tree-of-Thought, more structured than ReAct.
+
+### MindMap — Structured Reasoning Graph
+
+`MindMapPlanner` constructs a typed reasoning graph — claims, evidence, questions, and conclusions connected by support, contradiction, derivation, and refinement edges — before synthesising actions. At each iteration it adds nodes from the LLM's structured output, then runs coherence checking. When the coherence score falls below the configured threshold, the planner asks the LLM to resolve contradictions before synthesising.
+
+```mermaid
+graph TD
+  Input --> Populate[Populate graph: claims, evidence, questions]
+  Populate --> Check[Coherence check]
+  Check -->|score >= threshold| Synthesize[Synthesize actions]
+  Check -->|score < threshold| Resolve[Resolve contradictions]
+  Resolve --> Synthesize
+  Synthesize -->|new observations| AddEvidence[Add evidence nodes]
+  AddEvidence --> Populate
+```
+
+**Source:** `agent/mindmap.go:55-130` — `MindMapPlanner` struct, `Plan`, and `Replan`.
+
+The graph is reset on each `Plan` call and updated incrementally on each `Replan` call. `PlannerState.Metadata` is not used for graph persistence — the graph lives in the planner struct across the Plan/Replan lifecycle of one agent loop. This means `MindMapPlanner` is stateful within a single agent turn but stateless across sessions.
+
+`WithMaxNodes(n)` caps total nodes per iteration (default 20). `WithCoherenceThreshold(t)` sets the minimum acceptable coherence score (default 0.5). The planner auto-registers as `"mindmap"` in `init()` (`agent/mindmap.go:17`).
 
 ### Tree-of-Thought
 
@@ -168,6 +189,7 @@ graph TD
   Start --> Simple[Simple tool use or Q&A]
   Start --> Quality[Quality-sensitive, iterative]
   Start --> Plan[Plans repeatable]
+  Start --> Structured[Structured reasoning with contradictions]
   Start --> Combinatorial[Combinatorial search]
   Start --> Deep[Deep reasoning, math/code]
   Start --> Ensemble[Need diverse perspectives]
@@ -175,12 +197,107 @@ graph TD
   Simple --> R1[ReAct]
   Quality --> R2[Reflexion]
   Plan --> R3[Self-Discover]
-  Combinatorial --> R4[Tree-of-Thought]
-  Deep --> R5[LATS]
-  Ensemble --> R6[MoA]
+  Structured --> R4[MindMap]
+  Combinatorial --> R5[Tree-of-Thought]
+  Deep --> R6[LATS]
+  Ensemble --> R7[MoA]
 ```
 
-Start with ReAct. Upgrade only when you have a measurable quality gap and a budget for more tokens. Never pick LATS for a use case that ReAct handles — the cost difference is 20-100×.
+Start with ReAct. Upgrade only when you have a measurable quality gap and a budget for more tokens. Never pick LATS for a use case that ReAct handles — the cost difference is 20-100x.
+
+## agent/plancache — Plan-Level Caching [experimental]
+
+`agent/plancache` is a strategy-agnostic optimisation layer that caches the action sequences produced by any planner. It wraps the planner; callers see the same `agent.Planner` interface.
+
+```mermaid
+graph LR
+  Input --> Matcher[Matcher.Score vs templates]
+  Matcher -->|score >= minScore| CacheHit[Return cached actions]
+  Matcher -->|cache miss| Inner[Inner planner.Plan]
+  Inner --> Extract[ExtractTemplate / Store.Save]
+  Replan --> Inner2[Inner planner.Replan]
+  Replan --> Track[Track deviation count]
+  Track -->|ratio > evictionThreshold| Evict[Store.Delete]
+```
+
+**Key interfaces:**
+
+- `Store` (`agent/plancache/store.go:7-23`) — `Save`, `Get`, `List`, `Delete`. `InMemoryStore` ships for testing; implement `Store` for Redis- or Postgres-backed persistence.
+- `Matcher` (`agent/plancache/matcher.go:8-12`) — returns a `[0.0, 1.0]` similarity score for `(input, template)` pairs. The default keyword matcher registers as `"keyword"`.
+- `Template` (`agent/plancache/template.go:12-43`) — captures the input, keyword fingerprint, action sequence, success/deviation counts, and a `DeviationRatio()` method used for eviction.
+
+**Wiring a cached planner** (simplest path via `plancache.WrapPlanner`, `agent/plancache/integration.go:17`):
+
+```go
+import (
+    "context"
+    "github.com/lookatitude/beluga-ai/agent/plancache"
+)
+
+cached, err := plancache.WrapPlanner(myPlanner,
+    plancache.WithMinScore(0.7),
+    plancache.WithMaxTemplates(50),
+    plancache.WithEvictionThreshold(0.4),
+    plancache.WithHooks(plancache.Hooks{
+        OnCacheHit: func(ctx context.Context, tmpl *plancache.Template, score float64) {
+            // observe cache hits
+        },
+        OnTemplateEvicted: func(ctx context.Context, tmpl *plancache.Template) {
+            // observe evictions
+        },
+    }),
+)
+if err != nil {
+    return err
+}
+```
+
+**Eviction:** every `Replan` call increments `Template.DeviationCount`. When `DeviationRatio()` exceeds `evictionThreshold` (default 0.5), the template is deleted. Plans that required frequent replanning are not served from cache.
+
+**Namespace isolation:** `CachedPlanner` derives the agent namespace from `state.Metadata["agent_id"]` (`agent/plancache/cached_planner.go:224`). If this key is absent, all planners fall into the `"default"` namespace and may share templates. Set `state.Metadata["agent_id"]` explicitly when multiple planners share a store.
+
+**When to use:** tasks that recur structurally — ticket triage, document routing, data extraction pipelines — where the same tool sequence applies to most inputs. `plancache` is transparent to the planner it wraps and compatible with every strategy.
+
+## agent/speculative — Speculative Execution [experimental]
+
+`agent/speculative` runs a cheap `Predictor` and the full ground-truth agent in parallel. If the predictor's result is validated before the ground-truth finishes, it is returned with a measurable latency speedup — similar to speculative execution in CPU pipelines.
+
+```mermaid
+graph TD
+  Input --> PredGo[Predictor.Predict goroutine]
+  Input --> GTGo[GroundTruth.Invoke goroutine]
+  PredGo --> PredDone[prediction + confidence]
+  PredDone -->|confidence < threshold| WaitGT[Wait for ground truth]
+  PredDone -->|confidence >= threshold| Validate[Validator.Validate]
+  Validate -->|valid| ReturnPred[Return prediction]
+  Validate -->|invalid| ReturnGT[Return ground truth]
+  GTGo --> WaitGT
+  WaitGT --> ReturnGT
+```
+
+**Key interfaces** (`agent/speculative/predictor.go:13-15`, `agent/speculative/validator.go:10-13`):
+
+```go
+type Predictor interface {
+    Predict(ctx context.Context, input string) (prediction string, confidence float64, err error)
+}
+
+type Validator interface {
+    Validate(ctx context.Context, prediction, groundTruth string) (valid bool, err error)
+}
+```
+
+Built-in implementations:
+
+- `LightModelPredictor` (`agent/speculative/predictor.go:21`) — uses any `llm.ChatModel`. Confidence is estimated from response length (shorter = higher confidence, per heuristic at `agent/speculative/predictor.go:54`).
+- `ExactValidator` — case-normalised exact match.
+- `SemanticValidator` — cosine similarity of TF vectors with a configurable threshold.
+
+**Metrics** (`agent/speculative/metrics.go`) track `HitRate()`, total speedup, and wasted tokens from mispredictions. Instrument these before setting the confidence threshold in production.
+
+**Streaming path:** when `WithFastAgent` is configured and predictor confidence exceeds the threshold, the fast agent's stream is used directly (`agent/speculative/executor.go:253-316`). Without `WithFastAgent`, streaming always falls back to the ground-truth agent.
+
+**When to use:** the ground-truth agent is expensive (e.g., LATS or MoA) and a large fraction of inputs have predictable answers a lighter model can supply. A hit rate below roughly 40% typically means the speedup is outweighed by the wasted predictor tokens.
 
 ## Common mistakes
 
@@ -188,9 +305,12 @@ Start with ReAct. Upgrade only when you have a measurable quality gap and a budg
 - **Forgetting that planners use the same LLM.** If your LLM is rate-limited, switching to LATS makes the problem worse, not better.
 - **Using MoA with identical agents.** The point of ensemble is *diversity*. Running the same agent 5 times gets you no new information.
 - **Mutating `PlannerState.Metadata` in the executor.** That's the planner's private storage. The executor round-trips it untouched.
+- **Using `plancache` without setting `state.Metadata["agent_id"]`.** Missing agent IDs put all planners in the same `"default"` namespace and templates bleed across unrelated agents.
+- **Deploying speculative execution without measuring hit rate.** A low hit rate means every request pays predictor cost with no benefit. Always baseline `Metrics().HitRate()` in a shadow-run before routing real traffic.
+- **Treating MindMap as a drop-in for Tree-of-Thought.** MindMap builds a typed knowledge graph and is better for reasoning problems with known contradictions. ToT explores a search tree and is better for combinatorial problems with a reachable goal state.
 
 ## Related reading
 
 - [04 — Data Flow](./04-data-flow.md) — how the executor calls the planner.
-- [05 — Agent Anatomy](./05-agent-anatomy.md) — where the planner lives inside an agent.
+- [05 — Agent Anatomy](./05-agent-anatomy.md) — where the planner lives inside an agent, and the experimental agent architectures.
 - [Custom Planner guide](../guides/custom-planner.md) — end-to-end example of implementing one.


### PR DESCRIPTION
## Summary

- **DOC-05** (\`docs/architecture/05-agent-anatomy.md\`): adds a new \`## Advanced Agent Architectures [experimental]\` section covering all five sub-packages with key interface citations, BaseAgent integration notes, and when-to-use guidance.
- **DOC-06** (\`docs/architecture/06-reasoning-strategies.md\`): documents MindMap as the 8th shipped strategy (was undocumented), adds dedicated sections for \`agent/plancache\` and \`agent/speculative\`, removes the stale status note, and expands the strategy selection diagram and common mistakes.

## Sub-packages documented

| Sub-package | What was added |
|---|---|
| \`agent/cognitive\` | \`DualProcessAgent\`, \`ComplexityScorer\`, \`RoutingMetrics\`, cascade vs stream routing |
| \`agent/metacognitive\` | \`Plugin\`, \`Monitor\`, \`HeuristicExtractor\`, \`SelfModelStore\`, \`InMemoryStore\`, EMA capability scoring |
| \`agent/evolving\` | \`EvolvingAgent\`, \`MetaOptimizer\`, \`ExperienceDistiller\`, background learning loop |
| \`agent/speculative\` | \`SpeculativeExecutor\`, \`Predictor\`, \`Validator\`, parallel prediction + validation |
| \`agent/plancache\` | \`CachedPlanner\`, \`Store\`, \`Matcher\`, \`Template\`, eviction logic, namespace isolation |

## Retrieval protocol followed

1. Read \`.wiki/index.md\` routing table.
2. Ran \`.claude/hooks/wiki-query.sh agent\` — returned corrections C-006 through C-009 and otel pattern pointer.
3. Read \`.wiki/architecture/package-map.md\` for agent package context.
4. Read \`.wiki/corrections.md\` for common mistakes to source.
5. Read all Go source files in each sub-package before writing.

## No Go code written — test evidence

This PR modifies only two Markdown files. No Go source was changed. The following builds and test runs were performed against the documented packages:

- \`go build ./agent/cognitive/... ./agent/metacognitive/... ./agent/evolving/... ./agent/speculative/... ./agent/plancache/...\` — **PASS**
- \`go test -race ./agent/cognitive/...\` — **PASS**
- \`go test -race ./agent/evolving/...\` — **PASS**
- \`go test -race ./agent/speculative/...\` — **PASS**
- \`go test -race ./agent/plancache/...\` — **PASS**
- \`go test -race ./agent/metacognitive/...\` — **FAIL** (pre-existing race at \`agent/metacognitive/store.go:149\` in \`TestInMemoryStore_ConcurrentAccess\`; this file was not modified in this PR and the race exists on \`origin/main\` HEAD)

## Test plan

- [ ] Verify all file:line citations in the diff exist in the codebase (\`agent/cognitive/types.go:57\`, \`agent/cognitive/agent.go:31\`, \`agent/metacognitive/store.go:13\`, \`agent/metacognitive/plugin.go:31\`, \`agent/evolving/evolving.go:17\`, \`agent/speculative/executor.go:14\`, \`agent/plancache/store.go:7\`, \`agent/mindmap.go:55\`, \`agent/mindmap.go:17\`).
- [ ] Confirm no broken cross-references in the new sections.
- [ ] Confirm Go code snippets compile (no framework types are invented; all use real package paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)