### PR TITLE
docs(claude): link framework to workspace knowledge layer

### DIFF
--- a/.wiki/index.md
+++ b/.wiki/index.md
@@ -2,7 +2,7 @@
 
 **Last Scanned:** 2026-04-11
 
-This wiki documents canonical architectural patterns, package structure, and invariants across the Beluga AI v2 Go codebase.
+This wiki documents canonical architectural patterns, package structure, and invariants across the Beluga AI v2 Go codebase. **Scope: framework-local.** It only covers the framework's Go code and its design invariants — anything cross-repo (release flow fan-out, website content coordination, examples orchestration, shared ops incidents) lives in the workspace wiki at `../../.wiki/index.md`, which is visible when this repo is checked out inside the multi-repo Beluga workspace.
 
 ## Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 Go-native agentic AI framework. `github.com/lookatitude/beluga-ai`. Go 1.23+. Streaming via `iter.Seq2[T, error]`.
 
+## Project scope
+
+This repo owns the **engineering layer** of the Beluga project: code, tech docs, and releases. It does **not** own website content, marketing, blog posts, runnable example programs, or cross-repo strategy — those live in sibling repos (`beluga-website`, `beluga-examples`) and in the private workspace repo (`beluga.git`).
+
+When working on cross-repo concerns (release flow fan-out, website dispatch, shared incident learnings, feature-brief coordination), consult the **workspace wiki** at `../.wiki/index.md` and the workspace `CLAUDE.md` at `../CLAUDE.md` — they're only visible when this repo is checked out inside the multi-repo workspace. Anything code-grounded or framework-specific stays here, in this repo's `.wiki/` and `docs/`.
+
 ## Critical rules
 
 1. Streaming uses `iter.Seq2[T, error]` in public APIs — never channels. `Invoke()` = stream + collect.


### PR DESCRIPTION
## Summary

- Add a **Project scope** section to `CLAUDE.md` clarifying that this repo owns the engineering layer only — code, tech docs, releases. Website content, marketing, runnable examples, and cross-repo strategy live elsewhere.
- Add a cross-repo pointer in both `CLAUDE.md` and `.wiki/index.md` directing agents at the workspace wiki (`../.wiki/`) and workspace `CLAUDE.md` (`../CLAUDE.md`) for cross-repo concerns — release fan-out, website dispatch, shared ops incidents, feature-brief coordination.

This is **Phase 0 of a multi-repo knowledge migration** across the four-layer Beluga project (workspace / framework / website / examples). Future phases will evict website/marketing orphans from `framework/.claude/` (rule, agent, skill, commands left over from the pre-split era) into the website repo, and populate the workspace `.wiki/` with cross-cutting content (release flow, incident post-mortems, shared corrections). No code changes here; docs-only.

## Test plan

- [x] `CLAUDE.md` section renders cleanly and doesn't break the existing "Critical rules" numbering
- [x] `.wiki/index.md` change is a single-sentence scope clarification, no link rot
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)