### PR TITLE
fix(ci): handle merge commits in release filter + fix goreleaser checkout ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,10 @@ jobs:
             exit 0
           fi
 
-          CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}")
+          # Use first-parent diff instead of diff-tree. For merge commits,
+          # diff-tree combined diff omits files matching either parent, which
+          # causes releases to be silently skipped (see incident 2026-04-15).
+          CHANGED_FILES=$(git diff --name-only "${GITHUB_SHA}^" "${GITHUB_SHA}" 2>/dev/null || true)
 
           if [ -z "${CHANGED_FILES}" ]; then
             echo "No changed files detected in tagged commit; skipping release."
@@ -151,7 +154,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          # Use the tag (not the branch) as checkout ref — the tag is the
+          # release source of truth. inputs.ref defaults to main which can
+          # drift past the tag after CHANGELOG PRs merge (incident 2026-04-15).
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

Two fixes from the v2.8.5 release incident (2026-04-15). Both are documented in the workspace incident log at `beluga.git/.wiki/incidents/2026-04-15-v2.8.5.md`.

### Fix 1 — Changes filter for merge commits

**Problem:** `git diff-tree -r` uses combined diff semantics for merge commits, omitting files that match either parent. A merge commit adding only `CHANGELOG.md` (which already exists on the merge branch) shows zero changed files → `release_needed=false` → goreleaser skipped → release "succeeds" with no artifacts.

**Fix:** Replace `git diff-tree --no-commit-id --name-only -r ${GITHUB_SHA}` with `git diff --name-only ${GITHUB_SHA}^ ${GITHUB_SHA}`. This diffs against the first parent, which always shows what the commit brought in regardless of merge vs regular.

### Fix 2 — goreleaser checkout ref

**Problem:** On `workflow_dispatch`, the goreleaser job checks out `inputs.ref` (defaults to `main`). If `main` has advanced past the tag (e.g., after a CHANGELOG PR merges), goreleaser checks out the wrong commit and fails: "git tag vX.Y.Z was not made against commit ...".

**Fix:** Change checkout ref from `inputs.ref` to `inputs.tag`. The tag is the release source of truth. The `docs-bundle` job already does this correctly via `RELEASE_TAG`; this aligns goreleaser to the same pattern.

## Test plan

- [x] `git diff` against first parent works for regular commits (single parent = same as before)
- [x] `git diff` against first parent works for merge commits (shows what the merge brought in)
- [x] `2>/dev/null || true` handles the edge case of a root commit with no parent (exits cleanly with empty CHANGED_FILES → skips release, same as before)
- [x] goreleaser ref change: on tag push, `github.ref` still resolves correctly (no change from that trigger)
- [x] goreleaser ref change: on `workflow_dispatch`, `inputs.tag` is always a valid ref (the `create-tag` job ensures it exists before goreleaser runs)
- [ ] CI green on this branch
- [ ] Next release verifies end-to-end (cannot be tested without an actual tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)