### PR TITLE
feat(ci): wire dispatch-examples into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,3 +293,25 @@ jobs:
               "tag": "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}",
               "sha": "${{ github.sha }}"
             }
+
+  # Notify beluga-examples so it can smoke-test all examples against the
+  # new release. Does not block the release — examples can be fixed after.
+  dispatch-examples:
+    name: Dispatch beluga-examples smoke test
+    needs: [release]
+    if: |
+      always() &&
+      needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to beluga-examples
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.EXAMPLES_DISPATCH_TOKEN }}
+          repository: lookatitude/beluga-examples
+          event-type: framework-release
+          client-payload: |
+            {
+              "tag": "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

Adds a `dispatch-examples` job to `release.yml` that notifies `beluga-examples` on every successful framework release. Same pattern as the existing `dispatch-website` job.

The new job:
- Depends on the `release` (goreleaser) job, not `docs-bundle` — examples need the published Go module, not the docs bundle
- Runs in parallel with `dispatch-website` and `docs-bundle` to avoid adding latency
- Uses `EXAMPLES_DISPATCH_TOKEN` (same fine-grained PAT pattern as `WEBSITE_DISPATCH_TOKEN`)
- Sends `framework-release` event type with `tag` and `sha` in client payload

### Action required before next release

Create `EXAMPLES_DISPATCH_TOKEN` in this repo's secrets:
- Fine-grained PAT
- Resource owner: `lookatitude`
- Repository access: Selected repositories → `beluga-examples`
- Permissions: `Contents: write`

## Test plan

- [x] Job YAML is structurally valid (same pattern as dispatch-website)
- [x] `needs: [release]` — only fires after goreleaser succeeds
- [x] Payload format matches what the examples CI workflow expects
- [ ] CI green on this branch
- [ ] End-to-end test on next real release (after PAT is created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)