### PR TITLE
feat(claude): A1+A2 integration — /develop Linear-aware + /consult specialist escape hatch

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -76,6 +76,21 @@ Scan the target package for violations of `.wiki/architecture/invariants.md`. Re
 
 See `.wiki/architecture/invariants.md`. The 10 invariants are the core contract.
 
+## When to invoke /consult
+
+If during planning you hit a question outside your core architectural expertise, use `/consult <specialist-name> <question>` to bounce it to a workspace specialist. Specialists:
+
+- `ai-ml-expert` — planner design, LLM routing, eval metrics, prompt compilation
+- `rag-expert` — retrieval strategies, embedding selection, vectorstore picks
+- `security-architect` — threat models, OWASP ASI mapping, audit design, compliance
+- `systems-architect` — layer placement, interface composition, ADR writing
+- `devops-expert` — deployment modes, sandbox backends, CI/CD
+- `observability-expert` — OTel span design, metric shape, cost tracking schemas
+
+The specialist produces a consultation file at `docs/consultations/<date>-<slug>-<specialist>.md`. Cite it in your implementation plan — reviewer agents will check for it when they see a question that crossed specialist boundaries.
+
+**When not to consult:** if the question is answerable by reading `framework/.wiki/` or the existing codebase. Reach for the wiki first; consultations cost time.
+
 ## Anti-rationalization
 
 | Excuse | Counter |

--- a/.claude/agents/developer-go.md
+++ b/.claude/agents/developer-go.md
@@ -63,6 +63,18 @@ go test -race -count=1 ./<package>/...
 
 All three must pass.
 
+## When to invoke /consult
+
+During implementation, if you encounter a design question that wasn't resolved in the architect's plan and isn't trivially answerable from the codebase/wiki, use `/consult <specialist-name> <question>`. Typical cases:
+
+- "The span naming here isn't obvious from gen_ai.* conventions" → `/consult observability-expert`
+- "This tool input pattern might be susceptible to prompt injection" → `/consult security-architect`
+- "Not sure whether this helper belongs in core or in a higher layer" → `/consult systems-architect`
+
+The consultation file is produced at `docs/consultations/<date>-<slug>-<specialist>.md` — cite it in your implementation commit message so reviewers can trace the reasoning.
+
+Prefer consulting over guessing; prefer reading the wiki over consulting.
+
 ## Anti-rationalization
 
 | Excuse | Counter |

--- a/.claude/commands/consult.md
+++ b/.claude/commands/consult.md
@@ -1,6 +1,6 @@
 ---
 name: consult
-description: Escape hatch for framework agents (or humans) to bounce a design question to a workspace specialist mid-implementation. Produces a citable consultation artifact in framework/docs/consultations/.
+description: Escape hatch for framework agents (or humans) to bounce a design question to a workspace specialist mid-implementation. Produces a citable consultation artifact in docs/consultations/ (framework-relative).
 ---
 
 Consult: $ARGUMENTS
@@ -35,14 +35,14 @@ The specialist agents live in the workspace repo at `../.claude/agents/<name>.md
 
 - The question from $ARGUMENTS
 - The context gathered in step 2
-- The instruction: "Produce a consultation response at framework/docs/consultations/<YYYY-MM-DD>-<feature-slug>-<specialist>.md. Use your standard output format (Question / Analysis / Recommendation / Tradeoffs / Risks / Sources)."
+- The instruction: "Produce a consultation response at `docs/consultations/<YYYY-MM-DD>-<feature-slug>-<specialist>.md` (relative to the framework repo root — this command runs with framework/ as cwd). Use your standard output format (Question / Analysis / Recommendation / Tradeoffs / Risks / Sources)."
 
-The specialist's normal output path is `research/briefs/<slug>/specialist-<name>.md`; consultations use a different path (`framework/docs/consultations/`) so they coexist with specialist design-time inputs without overwriting.
+The specialist's normal output path is `research/briefs/<slug>/specialist-<name>.md`; consultations use a different path (framework-relative `docs/consultations/`) so they coexist with specialist design-time inputs without overwriting.
 
 ### 4. Verify the file was produced
 
 ```bash
-ls framework/docs/consultations/<YYYY-MM-DD>-*-<specialist>.md
+ls docs/consultations/<YYYY-MM-DD>-*-<specialist>.md
 ```
 
 If not produced: report the specialist failed and include their output for manual capture.
@@ -50,7 +50,7 @@ If not produced: report the specialist failed and include their output for manua
 ### 5. Print the path + one-sentence summary
 
 ```
-Consulted <specialist-name>. Response at framework/docs/consultations/<YYYY-MM-DD>-<slug>-<specialist>.md.
+Consulted <specialist-name>. Response at docs/consultations/<YYYY-MM-DD>-<slug>-<specialist>.md (framework-relative).
 Summary: <first line of the Recommendation section>
 
 Cite this in your PR description or commit message so reviewers can find it.
@@ -71,4 +71,4 @@ Cite this in your PR description or commit message so reviewers can find it.
 
 ## On consultation cleanup
 
-Consultations persist in `framework/docs/consultations/`. They're citable history — do not clean them up after a feature ships. If the directory grows unwieldy later, a policy can be defined then.
+Consultations persist in `docs/consultations/` (framework-relative). They're citable history — do not clean them up after a feature ships. If the directory grows unwieldy later, a policy can be defined then.

--- a/.claude/commands/consult.md
+++ b/.claude/commands/consult.md
@@ -1,0 +1,74 @@
+---
+name: consult
+description: Escape hatch for framework agents (or humans) to bounce a design question to a workspace specialist mid-implementation. Produces a citable consultation artifact in framework/docs/consultations/.
+---
+
+Consult: $ARGUMENTS
+
+$ARGUMENTS must be: `<specialist-name> <question>` where `<specialist-name>` is one of: `ai-ml-expert`, `rag-expert`, `security-architect`, `systems-architect`, `devops-expert`, `observability-expert`. Anything after the first token is the question.
+
+Example:
+
+```
+/consult observability-expert How should harness.Invoke emit spans to match gen_ai.* conventions when approval gates interpose between agent and LLM?
+```
+
+## Steps
+
+### 1. Parse arguments
+
+Split $ARGUMENTS on whitespace. First token = specialist name. Remainder = question. Reject (with a clear error) if:
+- First token is not one of the six valid specialist names
+- Question is empty or under 10 characters (likely missing)
+
+### 2. Gather current context
+
+Collect:
+- Current git branch + most recent commit (via `git log -1 --oneline`)
+- Current feature's Linear parent (if detectable — look at the branch name for `loo-NN` and fetch via Linear MCP if a sub-issue with that prefix is currently open)
+- Current brief (if the Linear parent references one at `../research/briefs/<slug>.md`)
+- File tree snapshot of the package being worked on (`git diff --name-only main...HEAD`)
+
+### 3. Invoke the workspace specialist
+
+The specialist agents live in the workspace repo at `../.claude/agents/<name>.md`. Invoke via subagent with a prompt that includes:
+
+- The question from $ARGUMENTS
+- The context gathered in step 2
+- The instruction: "Produce a consultation response at framework/docs/consultations/<YYYY-MM-DD>-<feature-slug>-<specialist>.md. Use your standard output format (Question / Analysis / Recommendation / Tradeoffs / Risks / Sources)."
+
+The specialist's normal output path is `research/briefs/<slug>/specialist-<name>.md`; consultations use a different path (`framework/docs/consultations/`) so they coexist with specialist design-time inputs without overwriting.
+
+### 4. Verify the file was produced
+
+```bash
+ls framework/docs/consultations/<YYYY-MM-DD>-*-<specialist>.md
+```
+
+If not produced: report the specialist failed and include their output for manual capture.
+
+### 5. Print the path + one-sentence summary
+
+```
+Consulted <specialist-name>. Response at framework/docs/consultations/<YYYY-MM-DD>-<slug>-<specialist>.md.
+Summary: <first line of the Recommendation section>
+
+Cite this in your PR description or commit message so reviewers can find it.
+```
+
+## Purpose and boundaries
+
+`/consult` is an escape hatch for the framework team — architect, developer-go, security-reviewer, QA — when a question falls outside their core expertise and waiting for a full design round is overkill.
+
+**Good uses:**
+- Architect hits a question about OTel span design mid-planning; one /consult call beats a whole design iteration.
+- Developer-go encounters a surprise layering tension during implementation; /consult systems-architect clarifies.
+- Security-reviewer needs a threat model review for a code change; /consult security-architect produces it.
+
+**Bad uses:**
+- Using /consult as a substitute for thinking. The reviewer-qa agent may flag "this consultation could have been decided locally" as feedback.
+- Bouncing every design question to consultation. If you're calling it more than twice per PR, the feature probably needs a full /design-feature (A3) round at the workspace instead.
+
+## On consultation cleanup
+
+Consultations persist in `framework/docs/consultations/`. They're citable history — do not clean them up after a feature ships. If the directory grows unwieldy later, a policy can be defined then.

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -42,8 +42,7 @@ From the sub-issue's labels, pick the branch prefix. Mapping (matches workspace 
 - `Feature` label → `feat/`
 - `Bug` label → `fix/`
 - `Improvement` label → `refactor/`
-- `documentation` label → `docs/`
-- Otherwise → `chore/`
+- Otherwise → `chore/` (workspace `/plan-feature` deliberately does NOT create a `documentation` type label for doc-only changes — they flow through untyped to `chore/`)
 
 Branch name: `<prefix>/loo-NN-<short-slug>` where `<short-slug>` is a 3-5 word kebab-case summary of the sub-issue title. Linear auto-links via the `loo-NN` portion regardless of prefix.
 

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -1,40 +1,121 @@
 ---
 name: develop
-description: Implement a planned task using Red/Green TDD, followed by QA review and fix loop.
+description: Implement a Linear sub-issue end-to-end via the framework agent chain (architect → developer-go → reviewer-security → reviewer-qa → PR).
 ---
 
-Implement task: $ARGUMENTS
+Develop: $ARGUMENTS
 
-## Workflow
+$ARGUMENTS should be a Linear sub-issue ID (e.g., `LOO-43`) created by `/plan-feature` in the workspace. For work not tracked in Linear (small fixes, exploration), pass a brief path instead: `/develop research/briefs/<slug>.md` — then most of the Linear-specific steps below are skipped and the agents work from the brief alone.
 
-### Step 1 — Context
-`@agent-developer-go` runs the retrieval protocol: reads `.wiki/index.md`, runs `.claude/hooks/wiki-query.sh <package>`, reads relevant patterns + corrections + existing code.
+## Pre-flight (Linear-integrated)
 
-### Step 2 — Red: failing tests
-`@agent-developer-go` writes tests that define expected behavior. Run and confirm RED.
+### 1. Fetch the sub-issue from Linear
 
-### Step 3 — Green: implement
-`@agent-developer-go` writes minimum code to pass. Run full suite. Confirm GREEN.
+If $ARGUMENTS matches `LOO-\d+`:
 
-### Step 4 — Refactor
-Clean up while keeping tests green.
+```
+mcp__claude_ai_Linear__get_issue(id="$ARGUMENTS")
+```
 
-### Step 5 — QA review
-`@agent-reviewer-qa` validates against the Architect's acceptance criteria.
+Capture: title, description, labels, parentId.
 
-### Step 6 — Fix loop (max 3 iterations)
-If QA found issues:
-1. `@agent-developer-go` fixes each issue.
-2. `@agent-reviewer-qa` re-reviews.
-3. Loop until approved.
+Then fetch the parent:
 
-### Step 7 — Learning capture
-`@agent-coordinator`:
-- Checks for corrections made during fix loop.
-- Appends C-NNN entries to `.wiki/corrections.md`.
-- Updates `.wiki/patterns/*.md` if a canonical pattern was discovered.
-- Appends to `.wiki/log.md`.
+```
+mcp__claude_ai_Linear__get_issue(id="<parentId>")
+```
 
-## Prerequisites
+Capture: title, description, labels, any brief path referenced in the description.
 
-An Architect's plan with acceptance criteria. Run `/plan` first if none exists.
+### 2. Read the workspace brief
+
+The parent issue's description should reference a brief at `research/briefs/<slug>.md` in the workspace repo (relative path from the workspace root — `../research/briefs/<slug>.md` when cd'd into framework/).
+
+Read that brief fully. It is source of truth for Problem, Proposed solution, Success criteria, Framework tasks, Risks, and any open questions.
+
+If the brief is not findable: proceed with just Linear parent + sub-issue content. Flag to the user that the brief was not located.
+
+### 3. Derive the branch name
+
+From the sub-issue's labels, pick the branch prefix. Mapping (matches workspace `/plan-feature`):
+
+- `Feature` label → `feat/`
+- `Bug` label → `fix/`
+- `Improvement` label → `refactor/`
+- `documentation` label → `docs/`
+- Otherwise → `chore/`
+
+Branch name: `<prefix>/loo-NN-<short-slug>` where `<short-slug>` is a 3-5 word kebab-case summary of the sub-issue title. Linear auto-links via the `loo-NN` portion regardless of prefix.
+
+Example: sub-issue `LOO-43 "Implement cmd/beluga/ cobra scaffold with version + providers"` labeled `layer:framework, Feature, size:regular` → `feat/loo-43-beluga-cli-foundation`.
+
+If $ARGUMENTS is a brief path (no Linear ID), fall back to `feat/<brief-slug>` or let the architect/developer pick a branch during implementation.
+
+### 4. Create the branch
+
+```bash
+git checkout main
+git pull
+git checkout -b <branch-name>
+```
+
+## Agent chain
+
+With context loaded (sub-issue + parent + brief), proceed with the standard framework implementation chain per `framework/.claude/rules/workflow.md`:
+
+### Step 1 — Architect
+
+`@agent-architect` analyzes the brief's Framework tasks + Proposed solution, produces a research request if gaps exist, then (after any research) outputs an implementation plan with interface definitions (Go code), tasks in dependency order, and acceptance criteria per task.
+
+If the architect hits a design question outside their core expertise (OTel span naming, OWASP mapping, RAG strategy, etc.), they may invoke `/consult <specialist-name>` once A2 ships to bounce the question to a workspace specialist. In A1, the architect should stop and ask the user when hitting such questions.
+
+### Step 2 — Researcher (if requested by architect)
+
+`@agent-researcher` investigates each specific research question, returns structured findings with evidence. Architect refines the plan with findings.
+
+### Step 3 — Developer-go
+
+`@agent-developer-go` implements code AND tests per the plan using Red/Green TDD. Must pass `go build ./...`, `go vet ./...`, `go test -race ./...`, `go mod tidy`, `gofmt`, `golangci-lint`, `gosec -quiet`, `govulncheck` before submitting per `framework/.claude/rules/go-packages.md`.
+
+### Step 4 — Reviewer-security
+
+`@agent-reviewer-security` performs thorough review against security checklists. Requires 2 consecutive clean passes with zero issues. Any issue resets the counter.
+
+### Step 5 — Reviewer-qa
+
+`@agent-reviewer-qa` validates every acceptance criterion with evidence. Any failure returns to developer-go.
+
+## Open the PR
+
+### 1. Push the branch
+
+```bash
+git push -u origin <branch-name>
+```
+
+### 2. Create the PR
+
+```bash
+gh pr create --fill --title "<Conventional commit prefix>: <sub-issue title> (LOO-NN)" --body "<PR body referencing the brief, the sub-issue ID, and acceptance criteria>"
+```
+
+The PR title should include the `LOO-NN` ID so Linear auto-links the PR to the sub-issue (auto-link works on title/body/branch name). The PR body should link to the brief at `research/briefs/<slug>.md` in the workspace and summarize what was implemented against the acceptance criteria.
+
+### 3. Wait for CI + human review
+
+CI runs gosec, golangci-lint, govulncheck, SonarCloud, Snyk, Trivy, CodeQL, unit + integration tests. Human reviews and merges when CI is green. On merge, Linear auto-closes the sub-issue.
+
+## If Linear MCP fails during pre-flight
+
+Retry twice with ~3-second backoff. On persistent failure, proceed with whatever context was loaded. Print:
+
+```
+Linear MCP unavailable. Proceeding with:
+  - Brief: <path if found>
+  - Sub-issue: not fetched
+  - Branch name: guessed from brief slug
+
+Consider running `/feature-status <parent-id>` later to verify Linear state matches the PR.
+```
+
+Never silently skip the pre-flight. The user should know the context is incomplete.

--- a/.claude/rules/branch-discipline.md
+++ b/.claude/rules/branch-discipline.md
@@ -1,0 +1,33 @@
+# Branch Discipline
+
+Branch-and-PR discipline for the framework repo. This file mirrors the
+mandatory rules already stated in `CLAUDE.md` and `workflow.md`, and adds the
+Linear-integrated branch-naming convention introduced in A1.
+
+## Rules
+
+1. **Never commit directly to `main`.** Every change — code, docs, tests — starts with `git checkout -b <type>/<short-desc>` where `<type>` is `fix`, `feat`, `refactor`, `docs`, or `chore`.
+2. **Every branch ends with `gh pr create`.** Never merge directly to `main`. CI must be green before merge.
+3. **Verify `git branch --show-current` is not `main`** before any `git commit`.
+4. **Never skip hooks** (`--no-verify`, `--no-gpg-sign`, etc.) unless the user explicitly requests it. If a hook fails, investigate and fix the underlying issue.
+5. **Never force-push to `main`**, and never force-push without explicit user approval on any shared branch.
+6. **Never delete files, branches, or tags destructively** without explicit user approval. Measure twice, cut once.
+
+## Linear-integrated branch naming (A1)
+
+When work is tracked via a Linear sub-issue:
+
+- Branch name format: `<type>/loo-NN-<short-slug>` where:
+  - `<type>` is derived from Linear labels: `Feature` → `feat/`, `Bug` → `fix/`, `Improvement` → `refactor/`, `documentation` → `docs/`, otherwise `chore/`
+  - `loo-NN` is the Linear sub-issue ID (lowercase, matches auto-link behavior)
+  - `<short-slug>` is a 3-5 word kebab-case summary of the sub-issue title
+- Example: sub-issue `LOO-43 "Implement cmd/beluga/ cobra scaffold"` labeled `Feature, layer:framework` → `feat/loo-43-beluga-cli-foundation`
+- Linear's GitHub integration auto-links PRs and auto-closes sub-issues when the `loo-NN` token appears anywhere in the branch name, PR title, or PR body. The type prefix is workspace convention, not a Linear requirement.
+
+For work not tracked in Linear (small fixes, exploration), use the pre-A1 format: `<type>/<short-desc>`.
+
+## Why
+
+- CI (tests, linters, security scanners) is the last line of defense against regressions. Direct `main` pushes skip that line.
+- Every change becomes a reviewable, revertable unit with its own history.
+- Pre-existing findings in files you did NOT change do not block your commit, but MUST be documented in the commit message so reviewers know to ignore or fix them separately.

--- a/.claude/rules/branch-discipline.md
+++ b/.claude/rules/branch-discipline.md
@@ -18,7 +18,7 @@ Linear-integrated branch-naming convention introduced in A1.
 When work is tracked via a Linear sub-issue:
 
 - Branch name format: `<type>/loo-NN-<short-slug>` where:
-  - `<type>` is derived from Linear labels: `Feature` → `feat/`, `Bug` → `fix/`, `Improvement` → `refactor/`, `documentation` → `docs/`, otherwise `chore/`
+  - `<type>` is derived from Linear labels: `Feature` → `feat/`, `Bug` → `fix/`, `Improvement` → `refactor/`, otherwise `chore/` (workspace `/plan-feature` does not apply a `documentation` label — doc-only changes flow through to `chore/`)
   - `loo-NN` is the Linear sub-issue ID (lowercase, matches auto-link behavior)
   - `<short-slug>` is a 3-5 word kebab-case summary of the sub-issue title
 - Example: sub-issue `LOO-43 "Implement cmd/beluga/ cobra scaffold"` labeled `Feature, layer:framework` → `feat/loo-43-beluga-cli-foundation`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ before commit. See `.claude/rules/go-packages.md` for gosec focus areas.
 |---|---|
 | `/plan $FEATURE` | Architect + Researcher design loop → implementation plan with acceptance criteria |
 | `/develop $TASK` | Developer-go Red/Green TDD → QA review → fix loop |
+| `/consult <specialist> <question>` | Bounce a design question to a workspace specialist mid-flow; produces citable consultation in `docs/consultations/`. |
 | `/security-review $PATH` | 2 consecutive clean passes required |
 | `/qa-review $PATH` | Standalone QA review |
 | `/doc-check $PATH` | Verify examples compile and docs match current API |


### PR DESCRIPTION
## Summary

Framework-side of the pipeline-tightening epic — combines A1 (tracking spine) and A2 (specialist rosters) into one PR since they touch the same files' context and don't conflict.

**A1 changes:**
- `/develop <LOO-NN>` — accepts a Linear sub-issue ID and performs a pre-flight MCP read (sub-issue → parent → workspace brief at `../research/briefs/<slug>.md`) before the framework agent chain runs. Derives branch name `<type>/loo-NN-<short-slug>` from Linear issue labels (Feature→feat/, Bug→fix/, Improvement→refactor/, else chore/). Falls back to brief-path for non-Linear work.
- `.claude/rules/branch-discipline.md` — new file consolidating the 6 baseline branch rules (mirroring the workspace rule file) + the Linear-integrated naming section.

**A2 changes:**
- `/consult <specialist> <question>` — new escape hatch for framework agents (architect, developer-go, reviewer-security, reviewer-qa) to bounce design questions to workspace specialists mid-flow. Produces citable artifacts at `docs/consultations/<YYYY-MM-DD>-<slug>-<specialist>.md`. Six valid specialists: ai-ml-expert, rag-expert, security-architect, systems-architect, devops-expert, observability-expert.
- `.claude/agents/architect.md` — "When to invoke /consult" section listing the six specialists with their domains (planning-time breadth).
- `.claude/agents/developer-go.md` — "When to invoke /consult" section with implementation-time examples.
- `CLAUDE.md` — `/consult` row added to the commands table.
- `docs/consultations/.gitkeep` — ensures directory ships with the repo.

## Review history

- Spec compliance review: passed with two acceptable overrides (branch-discipline.md created since it didn't previously exist; label mapping uses workspace-aligned capitalized labels).
- Code quality review: found 2 important issues (documentation label arm never fires; /consult paths had wrong cwd prefix).
- Fix round: 1 additional commit (7 total) resolving both.
- A1 + A2 plans updated in parallel (separate PR #4 on workspace) to prevent future runs from replicating the defects.

## Commits (7 total)

- `22347576` feat(claude): extend /develop with Linear MCP pre-flight and label-derived branch naming
- `fb979fbe` docs(claude): document Linear-integrated branch naming in branch-discipline
- `c52e12be` feat(claude): add /consult command for workspace specialist escape hatch (A2)
- `824df87b` docs(claude): architect can invoke /consult for specialist escape hatch (A2)
- `10151772` docs(claude): developer-go can invoke /consult for specialist escape hatch (A2)
- `54d0ba7d` docs: document /consult command in framework CLAUDE.md (A2)
- `1998d362` fix(claude): address framework review findings

## Test plan

- [ ] Invoke `/develop <LOO-NN>` against a test sub-issue; verify pre-flight reads succeed and branch name follows the convention
- [ ] Invoke `/develop ../research/briefs/<slug>.md` as fallback; verify chain still runs
- [ ] Invoke `/consult observability-expert "test question about span design"`; verify file lands at `docs/consultations/<date>-*-observability-expert.md`
- [ ] Invoke `/consult invalid-specialist "..."`; verify rejection with clear error
- [ ] Full pipeline exercise during first post-merge feature (DX-1 Slice 1 pilot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)