### PR TITLE
feat: DX-1 S4 — beluga eval CLI + scaffolded eval branch [LOO-154]

### DIFF
--- a/.github/workflows/eval-integration.yml
+++ b/.github/workflows/eval-integration.yml
@@ -1,0 +1,132 @@
+name: Eval Integration
+
+# Linux-only end-to-end smoke for `beluga eval`. The job scaffolds the
+# `basic` template into /tmp, points its go.mod at the in-tree
+# framework, then runs the scaffolded `make eval-ci` target against the
+# bundled 3-row mock-fixture dataset (.beluga/eval.smoke.json). The job
+# asserts: (1) exit 0, (2) eval-report.json written to the project root,
+# (3) the populated report has run_id + 3 samples + zero row errors,
+# (4) aggregate exact_match >= 0.999 so the pass-rate gate trips on any
+# regression in the mock-provider trajectory replay.
+#
+# Budget: under 90s cold cache (brief §specialist-devops-expert §Q1
+# names <30s as the scaffolded-project budget; the framework-side CI
+# adds a `go build` + scaffold + `go mod tidy` on top and still fits
+# comfortably inside 90s).
+#
+# OS coverage: Linux only. Eval runs in-process with no fsnotify, no
+# HTTP listener, and no subprocess lifecycle beyond the shared binary-
+# exec pattern — `filepath.Join` handles the only OS-specific risk
+# (path separator). See brief §specialist-devops-expert §Q5.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/beluga/**"
+      - "eval/**"
+      - "llm/providers/mock/**"
+      - ".github/workflows/eval-integration.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cmd/beluga/**"
+      - "eval/**"
+      - "llm/providers/mock/**"
+      - ".github/workflows/eval-integration.yml"
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: "1.25.7"
+  # Pin the toolchain to the setup-go version; prevents Go from fetching
+  # a newer toolchain mid-build and producing platform-dependent output.
+  GOTOOLCHAIN: local
+
+jobs:
+  eval-smoke:
+    name: beluga eval smoke (mock provider)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build beluga CLI
+        run: go build -o /tmp/beluga ./cmd/beluga
+
+      - name: Scaffold basic project
+        run: |
+          mkdir -p /tmp/eval-test
+          cd /tmp/eval-test
+          /tmp/beluga init --template basic testproject
+
+      - name: Point generated go.mod at in-tree framework
+        # Mirrors scaffold-integration.yml's replace-directive safety
+        # net: covers the future tagged-release case where the
+        # scaffolder emits `require v2.x.y` and go mod tidy would need
+        # network access to the module proxy.
+        run: |
+          cd /tmp/eval-test/testproject
+          go mod edit -replace github.com/lookatitude/beluga-ai/v2=${{ github.workspace }}
+
+      - name: go mod tidy
+        run: |
+          cd /tmp/eval-test/testproject
+          go mod tidy
+
+      - name: Run make eval-ci
+        # The scaffolded `make eval-ci` target pins the 5 canonical env
+        # vars (BELUGA_LLM_PROVIDER=mock, BELUGA_DETERMINISTIC=1,
+        # BELUGA_SEED=42, OTEL_SDK_DISABLED=true) and runs
+        # `go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval
+        # .beluga/eval.smoke.json`. Exit 0 is a precondition for the
+        # threshold assertions below.
+        run: |
+          set -euo pipefail
+          cd /tmp/eval-test/testproject
+          make eval-ci | tee /tmp/eval.out
+
+      - name: Assert eval-report.json smoke thresholds
+        # Structural + threshold checks on the populated report. The
+        # bundled fixture is 3 rows, all expected to score exact_match
+        # = 1.0 via the FixturesFromTurns-derived mock trajectory.
+        # Any regression (wiring change, mock drift, scaffolded main.go
+        # drift) trips one of the asserts below and fails the job.
+        run: |
+          set -euo pipefail
+          cd /tmp/eval-test/testproject
+          test -f eval-report.json || { echo "FAIL: eval-report.json missing"; exit 1; }
+          python3 - <<'PY'
+          import json, sys
+          with open("eval-report.json") as f:
+              rep = json.load(f)
+          run_id = rep.get("run_id") or ""
+          samples = rep.get("samples") or []
+          aggregate = rep.get("aggregate") or {}
+          errors = rep.get("errors") or []
+          exact_match = aggregate.get("exact_match")
+          print(f"run_id={run_id!r} samples={len(samples)} "
+                f"aggregate.exact_match={exact_match} errors={len(errors)}")
+          assert run_id, "FAIL: missing run_id"
+          assert len(samples) == 3, f"FAIL: expected 3 samples, got {len(samples)}"
+          assert len(errors) == 0, f"FAIL: {len(errors)} row error(s): {errors}"
+          assert exact_match is not None, "FAIL: aggregate.exact_match absent"
+          assert exact_match >= 0.999, f"FAIL: pass-rate {exact_match} below 0.999"
+          PY
+
+      - name: Upload eval-report.json artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report-smoke
+          path: /tmp/eval-test/testproject/eval-report.json
+          if-no-files-found: warn

--- a/.github/workflows/eval-integration.yml
+++ b/.github/workflows/eval-integration.yml
@@ -83,13 +83,30 @@ jobs:
           cd /tmp/eval-test/testproject
           go mod tidy
 
+      - name: Install in-tree beluga CLI on PATH
+        # The scaffolded `make eval-ci` target expects `beluga` on PATH
+        # (matches `beluga dev`/`beluga run`/`beluga test`) rather than
+        # `go run <modpath>` — the latter requires the scaffolded
+        # project's go.sum to carry transitive-dep entries for every
+        # package the full CLI imports (fsnotify, cobra, every provider),
+        # which a tidy'd user-project go.sum does not include.
+        # setup-go ensures $HOME/go/bin is on PATH; copy the already-
+        # built /tmp/beluga there so `make eval-ci` picks it up without
+        # re-resolving modules.
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/go/bin"
+          cp /tmp/beluga "$HOME/go/bin/beluga"
+          command -v beluga
+          beluga version || true
+
       - name: Run make eval-ci
         # The scaffolded `make eval-ci` target pins the 5 canonical env
         # vars (BELUGA_LLM_PROVIDER=mock, BELUGA_DETERMINISTIC=1,
         # BELUGA_SEED=42, OTEL_SDK_DISABLED=true) and runs
-        # `go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval
-        # .beluga/eval.smoke.json`. Exit 0 is a precondition for the
-        # threshold assertions below.
+        # `beluga eval .beluga/eval.smoke.json` against the PATH-
+        # resolved binary installed above. Exit 0 is a precondition
+        # for the threshold assertions below.
         run: |
           set -euo pipefail
           cd /tmp/eval-test/testproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Beluga AI are documented here.
 
+## [Unreleased]
+
+### Features
+
+- **cli**: `beluga eval` — dataset-driven agent evaluation with exec-once-per-row IPC, mock-mode smoke evals, and `eval-report.json` CI artefact (LOO-154, DX-1 S4)
+- **eval**: `EvalSample.Turns` + `EvalSample.ExpectedTools` backward-compatible schema extensions for multi-turn trajectories and tool-use evaluation (LOO-154)
+- **eval**: OTel GenAI `gen_ai.evaluation.*` span/event emission on `eval.run` + `eval.row` spans with `beluga.eval.metric.score` Histogram and `beluga.eval.run_id` resource attribute for cross-signal join (LOO-154)
+- **llm/providers/mock**: `FixturesFromTurns` helper derives a mock fixture queue from `eval.Turn` trajectories so scaffolded smoke evals replay deterministically without API keys (LOO-154)
+- **scaffold**: `.beluga/eval.yaml` + `.beluga/eval.smoke.json` templates, `make eval-ci` Makefile target, Tier-1 `eval-smoke` CI job + commented Tier-2 real-provider template in the scaffolded `ci.yml` (LOO-154)
+- **ci**: `eval-integration.yml` — Linux-only framework CI that scaffolds the `basic` template, runs `make eval-ci`, and asserts aggregate pass-rate thresholds on the populated `eval-report.json` (LOO-154)
+
+### Documentation
+
+- **guides**: `docs/guides/evaluation.md` — task-oriented "eval your first agent" walkthrough (LOO-154)
+- **reference**: `docs/reference/cli.md` — add `beluga eval` subcommand section covering flags, IPC contract, dataset schema, config file, reports, CI integration, and observability (LOO-154)
+
 ## [2.12.0] - 2026-04-21
 
 ### Features

--- a/cmd/beluga/devloop/env.go
+++ b/cmd/beluga/devloop/env.go
@@ -187,7 +187,17 @@ func stripInlineComment(raw string) string {
 // override earlier ones for duplicate keys. The returned slice is safe
 // to pass to exec.Cmd.Env.
 func MergeEnv(base, loaded, extras []string) []string {
-	order := make([]string, 0, len(base)+len(loaded)+len(extras))
+	// Clamp the cap hint via int64 + a conservative upper bound so the
+	// sum can never overflow a native int (CodeQL go/allocation-size-
+	// overflow). 1<<20 env entries is already five orders of magnitude
+	// beyond any real system; `append` will grow the slice past that
+	// clamp on the unreachable-in-practice hot path.
+	const mergeEnvCapLimit = 1 << 20
+	capHint := int64(len(base)) + int64(len(loaded)) + int64(len(extras))
+	if capHint > mergeEnvCapLimit {
+		capHint = mergeEnvCapLimit
+	}
+	order := make([]string, 0, int(capHint))
 	idx := make(map[string]int)
 	add := func(entry string) {
 		key, _, ok := strings.Cut(entry, "=")

--- a/cmd/beluga/eval.go
+++ b/cmd/beluga/eval.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	evalcmd "github.com/lookatitude/beluga-ai/v2/cmd/beluga/eval"
+)
+
+// evalRun is indirected so tests can substitute the runner. Production
+// code always dispatches to evalcmd.Run which owns the exec-once IPC
+// and framework-layer runner wire-up.
+var evalRun = evalcmd.Run
+
+// newEvalCmd returns the cobra subcommand for `beluga eval`. It loads
+// .beluga/eval.yaml (if present), merges flag overrides, runs the
+// evaluation against a JSON dataset, always writes eval-report.json to
+// the project root, and optionally emits <report>.junit.xml alongside
+// when --format junit is passed. Exit code follows the dataset's
+// aggregate pass signal: any per-row exec error → non-zero exit.
+func newEvalCmd() *cobra.Command {
+	var (
+		projectRoot  string
+		datasetFlag  string
+		configPath   string
+		metricsFlag  []string
+		evalProvider string
+		judgeModel   string
+		format       string
+		rowTimeout   time.Duration
+		maxRows      int
+		maxCost      float64
+		dryRun       bool
+		parallel     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "eval [dataset.json] [flags]",
+		Short: "Run evaluations against a dataset",
+		Long: "Evaluates the scaffolded project against a JSON dataset. Writes a " +
+			"machine-readable eval-report.json artefact on every run and, with " +
+			"--format junit, an additional <report>.junit.xml file consumable by " +
+			"dorny/test-reporter. Child binaries are dispatched once per row via " +
+			"BELUGA_ENV=eval + BELUGA_EVAL_SAMPLE_JSON.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dataset := datasetFlag
+			if dataset == "" && len(args) == 1 {
+				dataset = args[0]
+			}
+			return runEval(cmd.Context(), evalRunOptions{
+				projectRoot:  projectRoot,
+				dataset:      dataset,
+				configPath:   configPath,
+				metrics:      metricsFlag,
+				evalProvider: evalProvider,
+				judgeModel:   judgeModel,
+				format:       format,
+				rowTimeout:   rowTimeout,
+				maxRows:      maxRows,
+				maxCost:      maxCost,
+				dryRun:       dryRun,
+				parallel:     parallel,
+			}, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+
+	cmd.Flags().StringVar(&projectRoot, "project-root", ".",
+		"scaffolded project root (directory with go.mod + .beluga/project.yaml)")
+	cmd.Flags().StringVar(&datasetFlag, "dataset", "",
+		"path to dataset JSON (defaults to positional argument)")
+	cmd.Flags().StringVar(&configPath, "config", "",
+		"path to eval config file (default: <project-root>/.beluga/eval.yaml)")
+	cmd.Flags().StringSliceVar(&metricsFlag, "metric", nil,
+		"metric name (repeatable); overrides any metrics set in the config file")
+	cmd.Flags().StringVar(&evalProvider, "eval-provider", "",
+		"eval-provider name (braintrust, deepeval, ragas) — reserved for S4.5")
+	cmd.Flags().StringVar(&judgeModel, "judge-model", "",
+		"LLM model name for LLM-judge metrics — reserved for S4.5")
+	cmd.Flags().StringVar(&format, "format", "",
+		"additive output format alongside the default JSON report ('junit')")
+	cmd.Flags().DurationVar(&rowTimeout, "row-timeout", 0,
+		"per-row subprocess wall-clock cap (default 30s)")
+	cmd.Flags().IntVar(&maxRows, "max-rows", 0,
+		"cap the number of rows actually executed (0 = no cap)")
+	cmd.Flags().Float64Var(&maxCost, "max-cost", 0,
+		"cap the total USD cost across rows (0 = no cap) — reserved for S4.5")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"print the planned run (row count, row_timeout) without launching subprocesses")
+	cmd.Flags().IntVar(&parallel, "parallel", 0,
+		"worker-pool size for per-row subprocess dispatch (default 1)")
+
+	cmd.AddCommand(newEvalSchemaCmd())
+	return cmd
+}
+
+type evalRunOptions struct {
+	projectRoot  string
+	dataset      string
+	configPath   string
+	metrics      []string
+	evalProvider string
+	judgeModel   string
+	format       string
+	rowTimeout   time.Duration
+	maxRows      int
+	maxCost      float64
+	dryRun       bool
+	parallel     int
+}
+
+func runEval(ctx context.Context, opts evalRunOptions, stdout, stderr io.Writer) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	root, err := filepath.Abs(opts.projectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project-root: %w", err)
+	}
+
+	cfg, err := evalcmd.LoadConfig(root, opts.configPath)
+	if err != nil {
+		return err
+	}
+	applyEvalOverrides(cfg, opts)
+	if err := cfg.ApplyDefaults(); err != nil {
+		return err
+	}
+
+	report, err := evalRun(ctx, cfg, stdout, stderr)
+	if err != nil {
+		return err
+	}
+
+	if err := writeReports(cfg, report, stdout); err != nil {
+		return err
+	}
+	if err := evalcmd.RenderText(stdout, report); err != nil {
+		return err
+	}
+
+	if len(report.Errors) > 0 && !cfg.DryRun {
+		return &runExitError{code: 1, err: fmt.Errorf("eval: %d row error(s)", len(report.Errors))}
+	}
+	return nil
+}
+
+func applyEvalOverrides(cfg *evalcmd.CLIConfig, opts evalRunOptions) {
+	if opts.dataset != "" {
+		cfg.Dataset = opts.dataset
+	}
+	if len(opts.metrics) > 0 {
+		cfg.Metrics = opts.metrics
+	}
+	if opts.evalProvider != "" {
+		cfg.EvalProvider = opts.evalProvider
+	}
+	if opts.judgeModel != "" {
+		cfg.JudgeModel = opts.judgeModel
+	}
+	if opts.format != "" {
+		cfg.Format = opts.format
+	}
+	if opts.rowTimeout > 0 {
+		cfg.RowTimeout = opts.rowTimeout
+	}
+	if opts.maxRows > 0 {
+		cfg.MaxRows = opts.maxRows
+	}
+	if opts.maxCost > 0 {
+		cfg.MaxCost = opts.maxCost
+	}
+	if opts.dryRun {
+		cfg.DryRun = true
+	}
+	if opts.parallel > 0 {
+		cfg.Parallel = opts.parallel
+	}
+}
+
+func writeReports(cfg *evalcmd.CLIConfig, report *evalcmd.Report, stdout io.Writer) error {
+	jsonPath := cfg.ReportPath
+	if jsonPath == "" {
+		jsonPath = filepath.Join(cfg.ProjectRoot, evalcmd.DefaultReportFilename)
+	}
+	if err := writeReportJSON(jsonPath, report); err != nil {
+		return fmt.Errorf("write json report: %w", err)
+	}
+	fmt.Fprintf(stdout, "wrote %s\n", jsonPath)
+
+	if cfg.WantsJUnit() {
+		junitPath := cfg.JUnitReportPath()
+		if err := writeReportJUnit(junitPath, report); err != nil {
+			return fmt.Errorf("write junit report: %w", err)
+		}
+		fmt.Fprintf(stdout, "wrote %s\n", junitPath)
+	}
+	return nil
+}
+
+func writeReportJSON(path string, report *evalcmd.Report) error {
+	f, err := os.Create(filepath.Clean(path)) //nolint:gosec // G304: path is derived from cfg.ReportPath (flag/yaml/default); no remote input.
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return evalcmd.RenderJSON(f, report)
+}
+
+func writeReportJUnit(path string, report *evalcmd.Report) error {
+	f, err := os.Create(filepath.Clean(path)) //nolint:gosec // G304: path is derived from cfg.JUnitReportPath; no remote input.
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return evalcmd.RenderJUnit(f, report)
+}
+
+// newEvalSchemaCmd is the hidden `beluga eval schema` subcommand — it
+// prints the embedded JSON Schema for editor validation. Hidden because
+// users don't need to see it in --help; it is only invoked by tooling.
+func newEvalSchemaCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "schema",
+		Short:  "Print the embedded dataset JSON Schema",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := cmd.OutOrStdout().Write(evalcmd.DatasetSchema())
+			return err
+		},
+	}
+}

--- a/cmd/beluga/eval/config.go
+++ b/cmd/beluga/eval/config.go
@@ -1,0 +1,214 @@
+// Package eval is the Layer 7 CLI-adapter for `beluga eval`. It owns the
+// per-row exec-once IPC to the scaffolded user binary, dataset loading,
+// metric dispatch, and report rendering. The heavy lifting (eval.Runner,
+// metrics, OTel spans) lives in the framework-layer eval package; this
+// subpackage is the thin glue between cobra and that API.
+//
+// DX-1 S4 brief: research/briefs/2026-04-21-dx1-s4-eval.md.
+package eval
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultRowTimeout is the mandatory per-row subprocess timeout applied
+// when the user supplies none. The S4 brief pins this at 30s to satisfy
+// the "every external call must have a timeout" security rule while
+// keeping the mock-provider smoke eval well under the 30s cold-cache CI
+// budget (specialist-devops-expert §Q2).
+const DefaultRowTimeout = 30 * time.Second
+
+// DefaultProtocolProbeTimeout bounds how long the CLI waits for the
+// user binary to emit its first `{"beluga_eval_protocol":1}` line. The
+// brief names 5s as the user-facing migration hint ("please re-scaffold
+// or add the BELUGA_ENV=eval branch manually"); anything shorter makes
+// cold-start modules noisy on CI.
+const DefaultProtocolProbeTimeout = 5 * time.Second
+
+// DefaultReportFilename is where eval-report.json lands when no explicit
+// path is configured — always at the project root so CI artefact steps
+// can upload a well-known location.
+const DefaultReportFilename = "eval-report.json"
+
+// OutputFormatJSON is the always-on machine-readable renderer: every run
+// writes eval-report.json regardless of any --format flag. The CLI has
+// no --format=json toggle; it is unconditional.
+const OutputFormatJSON = "json"
+
+// OutputFormatJUnit is the optional additive renderer selected via
+// --format junit. It writes <report>.junit.xml alongside the JSON
+// artefact for consumption by dorny/test-reporter on GitHub Actions.
+const OutputFormatJUnit = "junit"
+
+// CLIConfig is the merged shape of .beluga/eval.yaml plus flag overrides.
+// Flag values beat YAML values; YAML beats built-in defaults. The zero
+// value is safe to [ApplyDefaults] and [Validate] against.
+type CLIConfig struct {
+	// Dataset is the path to the dataset JSON file — always flag- or
+	// positional-supplied, never read from YAML, so an eval.yaml cannot
+	// silently redirect a CI invocation to a different dataset.
+	Dataset string `yaml:"-"`
+	// Metrics lists the metric names to run. Defaults to
+	// ["exact_match", "latency"] when empty (specialist-ai-ml-expert §Q2).
+	Metrics []string `yaml:"metrics,omitempty"`
+	// EvalProvider, when set, names an eval.Metric provider whose
+	// Score-implementing types are used as scorers (braintrust /
+	// deepeval / ragas). Single dispatch per §Q5.
+	EvalProvider string `yaml:"eval_provider,omitempty"`
+	// JudgeModel is the LLM model name passed to LLM-judge metrics.
+	JudgeModel string `yaml:"judge_model,omitempty"`
+	// Format is the optional additive output format. "" → JSON only;
+	// "junit" → JSON + JUnit XML. No "json" toggle — JSON is always on.
+	Format string `yaml:"format,omitempty"`
+	// RowTimeout is the wall-clock cap on each row's subprocess
+	// invocation. Defaults to [DefaultRowTimeout] when unset.
+	RowTimeout time.Duration `yaml:"-"`
+	// RowTimeoutRaw is the YAML-facing string form ("30s") parsed
+	// into RowTimeout by [ApplyDefaults].
+	RowTimeoutRaw string `yaml:"row_timeout,omitempty"`
+	// MaxRows, when >0, caps the number of dataset rows actually
+	// executed; the rest are skipped with a "not run" marker.
+	MaxRows int `yaml:"max_rows,omitempty"`
+	// MaxCost, when >0, caps the total USD cost summed across rows.
+	// Rows whose projected cost would push the running total past
+	// MaxCost are skipped.
+	MaxCost float64 `yaml:"max_cost,omitempty"`
+	// DryRun prints the planned run (row count, estimated cost) and
+	// exits 0 without launching any subprocesses — the safe preview
+	// before a real-provider run (specialist-devops-expert §Q2).
+	DryRun bool `yaml:"dry_run,omitempty"`
+	// Parallel is the worker-pool size. Defaults to 1 to avoid mock
+	// fixture-queue cross-contamination (§Q4). Users can override to
+	// >1 for real-provider runs.
+	Parallel int `yaml:"parallel,omitempty"`
+	// ProjectRoot is the scaffolded-project directory (has go.mod +
+	// .beluga/project.yaml). Always absolute after [ApplyDefaults].
+	ProjectRoot string `yaml:"-"`
+	// ConfigPath records which eval.yaml was actually loaded (empty
+	// when no file existed and the caller used defaults).
+	ConfigPath string `yaml:"-"`
+	// ReportPath is where the JSON report lands. Defaults to
+	// <ProjectRoot>/eval-report.json.
+	ReportPath string `yaml:"report_path,omitempty"`
+}
+
+// LoadConfig reads .beluga/eval.yaml from projectRoot and returns a
+// populated [CLIConfig]. Missing eval.yaml when configPath is empty is
+// not an error — the caller gets a default config ready for flag
+// overrides. An explicit configPath that does not exist IS an error.
+func LoadConfig(projectRoot, configPath string) (*CLIConfig, error) {
+	cfg := &CLIConfig{ProjectRoot: projectRoot}
+
+	explicit := configPath != ""
+	path := configPath
+	if path == "" {
+		path = filepath.Join(projectRoot, ".beluga", "eval.yaml")
+	}
+	cleaned := filepath.Clean(path)
+	// #nosec G304 -- path is supplied by the developer via --config or
+	// derived from projectRoot (scanned to .beluga/eval.yaml). No
+	// remote input reaches this read.
+	data, err := os.ReadFile(cleaned)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && !explicit {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", cleaned, err)
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", cleaned, err)
+	}
+	cfg.ConfigPath = cleaned
+	return cfg, nil
+}
+
+// ApplyDefaults fills in mandatory defaults for any zero-valued fields.
+// It parses the YAML-facing RowTimeoutRaw string ("30s") into the
+// typed RowTimeout duration, enforces Parallel≥1, and defaults
+// ReportPath under ProjectRoot. Called after flag overrides have been
+// layered on so explicit zero overrides remain zero where the caller
+// intended (e.g., MaxRows=0 means "no cap").
+func (c *CLIConfig) ApplyDefaults() error {
+	if c.RowTimeoutRaw != "" && c.RowTimeout == 0 {
+		d, err := time.ParseDuration(c.RowTimeoutRaw)
+		if err != nil {
+			return fmt.Errorf("row_timeout %q: %w", c.RowTimeoutRaw, err)
+		}
+		c.RowTimeout = d
+	}
+	if c.RowTimeout <= 0 {
+		c.RowTimeout = DefaultRowTimeout
+	}
+	if c.Parallel <= 0 {
+		c.Parallel = 1
+	}
+	if len(c.Metrics) == 0 {
+		c.Metrics = []string{"exact_match", "latency"}
+	}
+	if c.ProjectRoot == "" {
+		c.ProjectRoot = "."
+	}
+	abs, err := filepath.Abs(c.ProjectRoot)
+	if err != nil {
+		return fmt.Errorf("resolve project-root: %w", err)
+	}
+	c.ProjectRoot = abs
+	if c.ReportPath == "" {
+		c.ReportPath = filepath.Join(abs, DefaultReportFilename)
+	}
+	return nil
+}
+
+// Validate reports configuration errors that the user can act on. It is
+// intentionally conservative: unknown metric names are deferred to
+// [ResolveMetrics] so the CLI can list valid names in the error
+// message, while shape-level problems (empty dataset path, bad format)
+// are caught here before any subprocess work begins.
+func (c *CLIConfig) Validate() error {
+	if c.Dataset == "" {
+		return errors.New("dataset path is required (positional arg or --dataset)")
+	}
+	switch c.Format {
+	case "", OutputFormatJUnit:
+	default:
+		return fmt.Errorf("unknown --format %q (valid: junit)", c.Format)
+	}
+	if c.RowTimeout <= 0 {
+		return fmt.Errorf("row_timeout must be >0, got %s", c.RowTimeout)
+	}
+	if c.Parallel < 1 {
+		return fmt.Errorf("parallel must be >=1, got %d", c.Parallel)
+	}
+	if c.MaxRows < 0 {
+		return fmt.Errorf("max_rows must be >=0, got %d", c.MaxRows)
+	}
+	if c.MaxCost < 0 {
+		return fmt.Errorf("max_cost must be >=0, got %v", c.MaxCost)
+	}
+	return nil
+}
+
+// WantsJUnit reports whether the JUnit renderer should run in addition
+// to the always-on JSON renderer.
+func (c *CLIConfig) WantsJUnit() bool {
+	return strings.EqualFold(c.Format, OutputFormatJUnit)
+}
+
+// JUnitReportPath derives the JUnit sibling path from ReportPath —
+// `<base>.junit.xml` next to the JSON report so CI artefact uploads
+// pick both up with a single wildcard.
+func (c *CLIConfig) JUnitReportPath() string {
+	if c.ReportPath == "" {
+		return ""
+	}
+	ext := filepath.Ext(c.ReportPath)
+	base := strings.TrimSuffix(c.ReportPath, ext)
+	return base + ".junit.xml"
+}

--- a/cmd/beluga/eval/config_test.go
+++ b/cmd/beluga/eval/config_test.go
@@ -1,0 +1,145 @@
+package eval_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	evalcmd "github.com/lookatitude/beluga-ai/v2/cmd/beluga/eval"
+)
+
+func TestLoadConfig_MissingFile_ReturnsDefaultsWhenImplicit(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := evalcmd.LoadConfig(dir, "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, dir, cfg.ProjectRoot)
+	assert.Empty(t, cfg.ConfigPath)
+	assert.Empty(t, cfg.Metrics, "defaults not applied until ApplyDefaults")
+}
+
+func TestLoadConfig_MissingFile_ErrorsWhenExplicit(t *testing.T) {
+	dir := t.TempDir()
+	_, err := evalcmd.LoadConfig(dir, filepath.Join(dir, "nope.yaml"))
+	require.Error(t, err, "explicit --config path must exist")
+}
+
+func TestLoadConfig_ParsesYAML(t *testing.T) {
+	dir := t.TempDir()
+	belugaDir := filepath.Join(dir, ".beluga")
+	require.NoError(t, os.MkdirAll(belugaDir, 0o755))
+	yamlBody := `
+metrics:
+  - exact_match
+  - latency
+row_timeout: 45s
+parallel: 2
+max_rows: 10
+max_cost: 1.5
+eval_provider: braintrust
+judge_model: gpt-4o
+`
+	require.NoError(t, os.WriteFile(filepath.Join(belugaDir, "eval.yaml"), []byte(yamlBody), 0o600))
+
+	cfg, err := evalcmd.LoadConfig(dir, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"exact_match", "latency"}, cfg.Metrics)
+	assert.Equal(t, "45s", cfg.RowTimeoutRaw)
+	assert.Equal(t, 2, cfg.Parallel)
+	assert.Equal(t, 10, cfg.MaxRows)
+	assert.InDelta(t, 1.5, cfg.MaxCost, 1e-9)
+	assert.Equal(t, "braintrust", cfg.EvalProvider)
+	assert.Equal(t, "gpt-4o", cfg.JudgeModel)
+	assert.NotEmpty(t, cfg.ConfigPath)
+}
+
+func TestApplyDefaults_FillsMandatoryFields(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	assert.Equal(t, evalcmd.DefaultRowTimeout, cfg.RowTimeout)
+	assert.Equal(t, 1, cfg.Parallel)
+	assert.Equal(t, []string{"exact_match", "latency"}, cfg.Metrics)
+	assert.True(t, filepath.IsAbs(cfg.ProjectRoot), "ProjectRoot must be absolute")
+	assert.True(t, filepath.IsAbs(cfg.ReportPath), "ReportPath must be absolute")
+	assert.Equal(t, evalcmd.DefaultReportFilename, filepath.Base(cfg.ReportPath))
+}
+
+func TestApplyDefaults_ParsesRowTimeoutRaw(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{RowTimeoutRaw: "45s"}
+	require.NoError(t, cfg.ApplyDefaults())
+	assert.Equal(t, 45*time.Second, cfg.RowTimeout)
+}
+
+func TestApplyDefaults_InvalidRowTimeoutRaw(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{RowTimeoutRaw: "nope"}
+	err := cfg.ApplyDefaults()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "row_timeout")
+}
+
+func TestApplyDefaults_FlagOverrideDoesNotReplaceExplicitRowTimeout(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{RowTimeout: 10 * time.Second}
+	require.NoError(t, cfg.ApplyDefaults())
+	assert.Equal(t, 10*time.Second, cfg.RowTimeout, "explicit flag value survives ApplyDefaults")
+}
+
+func TestValidate_RequiresDataset(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{}
+	require.NoError(t, cfg.ApplyDefaults())
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dataset")
+}
+
+func TestValidate_UnknownFormat(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{Dataset: "ds.json", Format: "sarif"}
+	require.NoError(t, cfg.ApplyDefaults())
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "format")
+}
+
+func TestValidate_JUnitAccepted(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{Dataset: "ds.json", Format: "junit"}
+	require.NoError(t, cfg.ApplyDefaults())
+	require.NoError(t, cfg.Validate())
+	assert.True(t, cfg.WantsJUnit())
+}
+
+func TestValidate_NegativeValues(t *testing.T) {
+	tests := map[string]func(*evalcmd.CLIConfig){
+		"negative max_rows": func(c *evalcmd.CLIConfig) { c.MaxRows = -1 },
+		"negative max_cost": func(c *evalcmd.CLIConfig) { c.MaxCost = -0.01 },
+		"zero parallel after apply": func(c *evalcmd.CLIConfig) {
+			c.Parallel = 0 // will be coerced to 1; Validate should not trip
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := &evalcmd.CLIConfig{Dataset: "ds.json"}
+			mutate(cfg)
+			require.NoError(t, cfg.ApplyDefaults())
+			err := cfg.Validate()
+			if name == "zero parallel after apply" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestJUnitReportPath_Siblings(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{ReportPath: "/tmp/eval-report.json"}
+	assert.Equal(t, "/tmp/eval-report.junit.xml", cfg.JUnitReportPath())
+}
+
+func TestJUnitReportPath_EmptyWhenNoReport(t *testing.T) {
+	cfg := &evalcmd.CLIConfig{}
+	assert.Empty(t, cfg.JUnitReportPath())
+}

--- a/cmd/beluga/eval/render.go
+++ b/cmd/beluga/eval/render.go
@@ -213,12 +213,13 @@ func junitTestcaseName(s SampleReport) string {
 }
 
 // isFailedByExactMatch returns true when exact_match is the only
-// correctness metric present and the sample scored 0. Other metrics
-// (latency, LLM-judge) are not treated as pass/fail here because their
-// thresholds are context-specific and surface via the JSON report.
+// metric recorded for the sample and it scored 0. Mixed-metric runs
+// (e.g., exact_match + latency, exact_match + LLM-judge) are not
+// treated as pass/fail here because their thresholds are context-
+// specific and surface via the JSON report.
 func isFailedByExactMatch(s SampleReport) bool {
 	v, ok := s.Scores["exact_match"]
-	return ok && v == 0
+	return ok && v == 0 && len(s.Scores) == 1
 }
 
 // scoresAsProperties renders metric scores in deterministic order for

--- a/cmd/beluga/eval/render.go
+++ b/cmd/beluga/eval/render.go
@@ -1,0 +1,274 @@
+package eval
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+)
+
+// RenderText writes a human-readable summary of the report to w: a
+// per-row table ordered by sample index and an aggregate footer. Used
+// for stdout in interactive and CI logs. Output is deterministic —
+// metric columns are emitted in alphabetical order so golden-file
+// tests round-trip cleanly.
+func RenderText(w io.Writer, rep *Report) error {
+	if rep == nil {
+		return fmt.Errorf("nil report")
+	}
+	if rep.DryRun {
+		_, err := fmt.Fprintf(w, "dry-run: %d skipped, %d samples queued (run_id=%s)\n",
+			rep.Skipped, len(rep.Samples), rep.RunID)
+		return err
+	}
+
+	metricNames := sortedMetricNames(rep)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	header := "IDX\tROW_ID\tINPUT\tOUTPUT\tEXPECTED"
+	for _, name := range metricNames {
+		header += "\t" + name
+	}
+	header += "\tERROR"
+	fmt.Fprintln(tw, header)
+
+	for _, s := range rep.Samples {
+		row := fmt.Sprintf("%d\t%s\t%s\t%s\t%s",
+			s.Index, s.RowID, truncate(s.Input, 40), truncate(s.Output, 40), truncate(s.Expected, 40))
+		for _, name := range metricNames {
+			if v, ok := s.Scores[name]; ok {
+				row += fmt.Sprintf("\t%.2f", v)
+			} else {
+				row += "\t-"
+			}
+		}
+		row += "\t" + truncate(s.Error, 60)
+		fmt.Fprintln(tw, row)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "run_id:  %s\n", rep.RunID)
+	fmt.Fprintf(w, "dataset: %s (%s)\n", rep.DatasetName, rep.DatasetPath)
+	fmt.Fprintf(w, "samples: %d", len(rep.Samples))
+	if rep.Skipped > 0 {
+		fmt.Fprintf(w, " (+%d skipped)", rep.Skipped)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "duration: %s\n", rep.Duration)
+
+	if len(metricNames) > 0 {
+		fmt.Fprintln(w, "aggregate:")
+		for _, name := range metricNames {
+			fmt.Fprintf(w, "  %s: %.4f\n", name, rep.Aggregate[name])
+		}
+	}
+	if len(rep.Errors) > 0 {
+		fmt.Fprintf(w, "errors: %d\n", len(rep.Errors))
+	}
+	return nil
+}
+
+// RenderJSON writes the report as indented JSON to w. This is the
+// always-on CI artefact: every `beluga eval` run writes eval-report.json
+// regardless of any --format toggle (brief §Q3, devops-expert §Q3).
+func RenderJSON(w io.Writer, rep *Report) error {
+	if rep == nil {
+		return fmt.Errorf("nil report")
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(rep)
+}
+
+// junitTestSuites is the dorny/test-reporter-compatible wire shape.
+// A single <testsuite> wraps every sample as a <testcase>; per-row
+// errors become <failure> children so PR annotations point at the
+// failing dataset row. Non-exact_match metrics show up as <properties>
+// on the testcase for UI hover-over consumption.
+type junitTestSuites struct {
+	XMLName  xml.Name `xml:"testsuites"`
+	Name     string   `xml:"name,attr"`
+	Tests    int      `xml:"tests,attr"`
+	Failures int      `xml:"failures,attr"`
+	Errors   int      `xml:"errors,attr"`
+	Time     float64  `xml:"time,attr"`
+	Suites   []junitTestSuite
+}
+
+type junitTestSuite struct {
+	XMLName   xml.Name `xml:"testsuite"`
+	Name      string   `xml:"name,attr"`
+	Tests     int      `xml:"tests,attr"`
+	Failures  int      `xml:"failures,attr"`
+	Errors    int      `xml:"errors,attr"`
+	Time      float64  `xml:"time,attr"`
+	Testcases []junitTestCase
+}
+
+type junitTestCase struct {
+	XMLName    xml.Name         `xml:"testcase"`
+	Classname  string           `xml:"classname,attr"`
+	Name       string           `xml:"name,attr"`
+	Time       float64          `xml:"time,attr"`
+	Failure    *junitFailure    `xml:"failure,omitempty"`
+	Properties *junitProperties `xml:"properties,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+type junitProperties struct {
+	Items []junitProperty `xml:"property"`
+}
+
+type junitProperty struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// RenderJUnit writes a JUnit XML report to w compatible with
+// dorny/test-reporter. It is called only when cfg.WantsJUnit() is
+// true. The MVP emits a single suite named after the dataset; per-row
+// failures are derived from cfg-less heuristics — a sample is "failed"
+// when it recorded an exec error OR exact_match=0 when exact_match is
+// the configured metric. Metric scores are attached as properties so
+// they survive the trip through dorny without custom UI work.
+func RenderJUnit(w io.Writer, rep *Report) error {
+	if rep == nil {
+		return fmt.Errorf("nil report")
+	}
+
+	suite := junitTestSuite{
+		Name:      rep.DatasetName,
+		Tests:     len(rep.Samples),
+		Time:      rep.Duration.Seconds(),
+		Testcases: make([]junitTestCase, 0, len(rep.Samples)),
+	}
+
+	for _, s := range rep.Samples {
+		tc := junitTestCase{
+			Classname: rep.DatasetName,
+			Name:      junitTestcaseName(s),
+		}
+		switch {
+		case s.Error != "":
+			tc.Failure = &junitFailure{
+				Message: s.Error,
+				Type:    "exec_error",
+				Body:    s.Error,
+			}
+			suite.Errors++
+		case isFailedByExactMatch(s):
+			tc.Failure = &junitFailure{
+				Message: fmt.Sprintf("exact_match=%.2f (expected=%q, got=%q)",
+					s.Scores["exact_match"], s.Expected, s.Output),
+				Type: "exact_match_fail",
+				Body: s.Output,
+			}
+			suite.Failures++
+		}
+		if len(s.Scores) > 0 {
+			tc.Properties = &junitProperties{Items: scoresAsProperties(s.Scores)}
+		}
+		suite.Testcases = append(suite.Testcases, tc)
+	}
+
+	suites := junitTestSuites{
+		Name:     rep.DatasetName,
+		Tests:    suite.Tests,
+		Failures: suite.Failures,
+		Errors:   suite.Errors,
+		Time:     suite.Time,
+		Suites:   []junitTestSuite{suite},
+	}
+
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(suites); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\n")
+	return err
+}
+
+// junitTestcaseName derives a stable per-row identifier. RowID is
+// preferred for join-with-JSON; Index is the fallback when RowID is
+// empty (e.g., a future path where samples lack row IDs).
+func junitTestcaseName(s SampleReport) string {
+	if s.RowID != "" {
+		return s.RowID
+	}
+	return fmt.Sprintf("sample_%04d", s.Index)
+}
+
+// isFailedByExactMatch returns true when exact_match is the only
+// correctness metric present and the sample scored 0. Other metrics
+// (latency, LLM-judge) are not treated as pass/fail here because their
+// thresholds are context-specific and surface via the JSON report.
+func isFailedByExactMatch(s SampleReport) bool {
+	v, ok := s.Scores["exact_match"]
+	return ok && v == 0
+}
+
+// scoresAsProperties renders metric scores in deterministic order for
+// golden-file stability.
+func scoresAsProperties(scores map[string]float64) []junitProperty {
+	names := make([]string, 0, len(scores))
+	for name := range scores {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]junitProperty, 0, len(names))
+	for _, name := range names {
+		out = append(out, junitProperty{
+			Name:  name,
+			Value: fmt.Sprintf("%.4f", scores[name]),
+		})
+	}
+	return out
+}
+
+// sortedMetricNames returns the union of metrics present in the
+// aggregate map (authoritative) plus any per-row scores, sorted
+// alphabetically for deterministic column ordering across runs.
+func sortedMetricNames(rep *Report) []string {
+	seen := make(map[string]struct{}, len(rep.Aggregate))
+	for name := range rep.Aggregate {
+		seen[name] = struct{}{}
+	}
+	for _, s := range rep.Samples {
+		for name := range s.Scores {
+			seen[name] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// truncate returns s unchanged when it fits, else a three-dot
+// truncated copy. Used for stdout-readable row rendering without
+// destroying alignment when a row happens to carry a long prompt.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/beluga/eval/render_test.go
+++ b/cmd/beluga/eval/render_test.go
@@ -1,0 +1,147 @@
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleReport(t *testing.T) *Report {
+	t.Helper()
+	return &Report{
+		RunID:       "run0123456789ab",
+		DatasetName: "smoke",
+		DatasetPath: "/tmp/smoke.json",
+		StartedAt:   time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
+		Duration:    1500 * time.Millisecond,
+		Samples: []SampleReport{
+			{
+				Index: 0, RowID: "run0123456789ab-0000",
+				Input: "capital of France?", Output: "Paris", Expected: "Paris",
+				Scores: map[string]float64{"exact_match": 1.0, "latency": 0.85},
+			},
+			{
+				Index: 1, RowID: "run0123456789ab-0001",
+				Input: "capital of Spain?", Output: "Lisbon", Expected: "Madrid",
+				Scores: map[string]float64{"exact_match": 0.0, "latency": 0.82},
+			},
+			{
+				Index: 2, RowID: "run0123456789ab-0002",
+				Input: "capital of Germany?", Output: "", Expected: "Berlin",
+				Scores: map[string]float64{},
+				Error:  "child exited: exit status 1",
+			},
+		},
+		Aggregate: map[string]float64{"exact_match": 0.333, "latency": 0.556},
+		Errors:    []string{"child exited: exit status 1"},
+	}
+}
+
+func TestRenderText_DeterministicOrdering(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RenderText(&buf, sampleReport(t)))
+	got := buf.String()
+
+	// Header columns appear alphabetically (exact_match before latency).
+	hdrIdx := strings.Index(got, "exact_match")
+	latIdx := strings.Index(got, "latency")
+	require.Positive(t, hdrIdx, "exact_match must be in header")
+	require.Positive(t, latIdx, "latency must be in header")
+	assert.Less(t, hdrIdx, latIdx, "exact_match column before latency")
+
+	// Aggregate footer lists each metric once, in alpha order.
+	assert.Contains(t, got, "aggregate:")
+	emIdx := strings.Index(got, "exact_match: 0.3330")
+	laIdx := strings.Index(got, "latency: 0.5560")
+	require.Positive(t, emIdx)
+	require.Positive(t, laIdx)
+	assert.Less(t, emIdx, laIdx)
+
+	assert.Contains(t, got, "run_id:  run0123456789ab")
+	assert.Contains(t, got, "samples: 3")
+	assert.Contains(t, got, "errors: 1")
+}
+
+func TestRenderText_DryRun(t *testing.T) {
+	rep := &Report{
+		RunID:   "dry1234567890ab",
+		DryRun:  true,
+		Skipped: 2,
+		Samples: []SampleReport{},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, RenderText(&buf, rep))
+	assert.Contains(t, buf.String(), "dry-run")
+	assert.Contains(t, buf.String(), "dry1234567890ab")
+}
+
+func TestRenderText_NilReport(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, RenderText(&buf, nil))
+}
+
+func TestRenderJSON_RoundTrips(t *testing.T) {
+	original := sampleReport(t)
+	var buf bytes.Buffer
+	require.NoError(t, RenderJSON(&buf, original))
+
+	var back Report
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &back))
+	assert.Equal(t, original.RunID, back.RunID)
+	assert.Equal(t, original.DatasetName, back.DatasetName)
+	assert.Len(t, back.Samples, len(original.Samples))
+	assert.Equal(t, original.Aggregate["exact_match"], back.Aggregate["exact_match"])
+}
+
+func TestRenderJSON_NilReport(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, RenderJSON(&buf, nil))
+}
+
+func TestRenderJUnit_StructureAndCounts(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, RenderJUnit(&buf, sampleReport(t)))
+	out := buf.String()
+
+	assert.True(t, strings.HasPrefix(out, xml.Header),
+		"JUnit output begins with XML declaration")
+	assert.Contains(t, out, `<testsuites name="smoke"`)
+	assert.Contains(t, out, `tests="3"`)
+	assert.Contains(t, out, `failures="1"`, "one exact_match=0 row → one <failure>")
+	assert.Contains(t, out, `errors="1"`, "one exec-error row → one <error>-classified testcase")
+	assert.Contains(t, out, `<testcase classname="smoke" name="run0123456789ab-0000"`)
+	assert.Contains(t, out, `type="exact_match_fail"`, "row 1 fails exact_match")
+	assert.Contains(t, out, `type="exec_error"`, "row 2 recorded an exec error")
+	assert.Contains(t, out, `<property name="exact_match" value="1.0000">`)
+	assert.Contains(t, out, `<property name="latency" value="0.8500">`)
+}
+
+func TestRenderJUnit_NilReport(t *testing.T) {
+	var buf bytes.Buffer
+	require.Error(t, RenderJUnit(&buf, nil))
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"under", "abc", 10, "abc"},
+		{"equal", "abcde", 5, "abcde"},
+		{"over", "abcdefghij", 6, "abc..."},
+		{"max3", "abcdef", 3, "abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, truncate(tt.in, tt.max))
+		})
+	}
+}

--- a/cmd/beluga/eval/render_test.go
+++ b/cmd/beluga/eval/render_test.go
@@ -27,9 +27,13 @@ func sampleReport(t *testing.T) *Report {
 				Scores: map[string]float64{"exact_match": 1.0, "latency": 0.85},
 			},
 			{
+				// Single-metric row: isFailedByExactMatch only fires
+				// when exact_match is the sole metric recorded (see
+				// render.go:isFailedByExactMatch). Mixed-metric rows
+				// defer to the JSON report for pass/fail judgement.
 				Index: 1, RowID: "run0123456789ab-0001",
 				Input: "capital of Spain?", Output: "Lisbon", Expected: "Madrid",
-				Scores: map[string]float64{"exact_match": 0.0, "latency": 0.82},
+				Scores: map[string]float64{"exact_match": 0.0},
 			},
 			{
 				Index: 2, RowID: "run0123456789ab-0002",

--- a/cmd/beluga/eval/runner.go
+++ b/cmd/beluga/eval/runner.go
@@ -159,8 +159,6 @@ func Run(ctx context.Context, cfg *CLIConfig, stdout, stderr io.Writer) (*Report
 			Skipped:     skipped,
 			DryRun:      true,
 		}
-		fmt.Fprintf(stdout, "dry-run: %d rows queued (capped from %d), row_timeout=%s\n",
-			len(samples), len(ds.Samples), cfg.RowTimeout)
 		report.Duration = time.Since(started)
 		return report, nil
 	}
@@ -284,21 +282,68 @@ func execOneRow(ctx context.Context, binary string, cfg *CLIConfig, sample eval.
 		sample eval.EvalSample
 		err    error
 	}
-	results := make(chan readOutcome, 1)
+	// The scanner is shared between the probe and payload phases — the
+	// scan cursor must advance past the probe line before payload reads
+	// kick off, and bufio.Scanner is not safe across goroutines, so both
+	// phases run in the same goroutine that signals completion via two
+	// channels. probeCh fires as soon as the first line is parsed (or
+	// errored) so the caller can bound it at DefaultProtocolProbeTimeout
+	// without penalising cold-start provider latency on the payload.
+	sc := bufio.NewScanner(stdoutPipe)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	probeCh := make(chan error, 1)
+	sampleCh := make(chan readOutcome, 1)
 	go func() {
-		out, err := readProtocolAndSample(stdoutPipe)
-		results <- readOutcome{out, err}
+		if err := readProtocolProbe(sc); err != nil {
+			probeCh <- err
+			return
+		}
+		probeCh <- nil
+		out, err := readPopulatedSample(sc)
+		sampleCh <- readOutcome{out, err}
 	}()
 
+	// Probe phase — bounded by DefaultProtocolProbeTimeout (S4 Risk 7:
+	// users on a pre-eval scaffold must see a fast, actionable error
+	// instead of waiting out the full row timeout).
+	probeTimer := time.NewTimer(DefaultProtocolProbeTimeout)
+	defer probeTimer.Stop()
+	select {
+	case err := <-probeCh:
+		if err != nil {
+			_ = stdoutPipe.Close()
+			_ = cmd.Wait()
+			return sample, err
+		}
+	case <-probeTimer.C:
+		// The child is alive but silent — closing stdout alone would
+		// leave cmd.Wait() blocked on the process until rowCtx fires.
+		// Kill the process explicitly so the probe timeout actually
+		// bounds wall-clock for pre-eval scaffolds (Risk 7).
+		_ = stdoutPipe.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		return sample, fmt.Errorf("no protocol probe within %s — re-scaffold with `beluga init` or add the BELUGA_ENV=eval branch manually", DefaultProtocolProbeTimeout)
+	case <-ctx.Done():
+		// exec.CommandContext kills the child on ctx.Done, so cmd.Wait()
+		// returns promptly without an explicit Kill.
+		_ = stdoutPipe.Close()
+		_ = cmd.Wait()
+		return sample, ctx.Err()
+	}
+
+	// Payload phase — bounded by the remaining row ctx.
 	var rr readOutcome
 	select {
-	case rr = <-results:
+	case rr = <-sampleCh:
 	case <-ctx.Done():
 		// Force the reader to unblock by closing the stdout pipe — any
 		// grandchild holding the fd will simply get EPIPE on its next
-		// write. cmd.WaitDelay below ensures Wait() still returns.
+		// write. cmd.WaitDelay above ensures Wait() still returns.
 		_ = stdoutPipe.Close()
-		rr = <-results
+		rr = <-sampleCh
 		if rr.err == nil {
 			rr.err = ctx.Err()
 		}
@@ -326,24 +371,45 @@ func execOneRow(ctx context.Context, binary string, cfg *CLIConfig, sample eval.
 
 // readProtocolAndSample consumes the child's stdout: first line MUST
 // be the protocol probe; the next non-empty line MUST be the populated
-// sample JSON. Any deviation is returned as a typed error so callers
-// can distinguish "project not scaffolded for eval" from "child
-// crashed mid-response".
+// sample JSON. It is the in-process helper used by table-driven unit
+// tests; the live exec path uses [readProtocolProbe] and
+// [readPopulatedSample] directly so each phase can be bounded by its
+// own timeout.
 func readProtocolAndSample(r io.Reader) (eval.EvalSample, error) {
-	var empty eval.EvalSample
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	if err := readProtocolProbe(sc); err != nil {
+		return eval.EvalSample{}, err
+	}
+	return readPopulatedSample(sc)
+}
+
+// readProtocolProbe consumes the first line of the scanner and checks
+// it against the expected {"beluga_eval_protocol":1} envelope. Any
+// deviation is returned as a typed error so callers can distinguish
+// "project not scaffolded for eval" from "child crashed mid-response".
+// The scanner must be buffered by the caller to survive realistic
+// populated-sample sizes.
+func readProtocolProbe(sc *bufio.Scanner) error {
 	if !sc.Scan() {
 		if err := sc.Err(); err != nil {
-			return empty, fmt.Errorf("read protocol probe: %w", err)
+			return fmt.Errorf("read protocol probe: %w", err)
 		}
-		return empty, fmt.Errorf("no output from child — project may not have the BELUGA_ENV=eval branch; re-scaffold or add manually")
+		return fmt.Errorf("no output from child — project may not have the BELUGA_ENV=eval branch; re-scaffold or add manually")
 	}
 	var probe protocolProbe
 	if err := json.Unmarshal(sc.Bytes(), &probe); err != nil || probe.BelugaEvalProtocol != ProtocolVersion {
-		return empty, fmt.Errorf("child did not emit eval protocol probe on first line (expected %q, got %q)",
+		return fmt.Errorf("child did not emit eval protocol probe on first line (expected %q, got %q)",
 			fmt.Sprintf(`{"beluga_eval_protocol":%d}`, ProtocolVersion), sc.Text())
 	}
+	return nil
+}
+
+// readPopulatedSample consumes the next non-empty line and decodes it
+// into an eval.EvalSample. It is meant to run after
+// [readProtocolProbe] has advanced the scanner past the probe line.
+func readPopulatedSample(sc *bufio.Scanner) (eval.EvalSample, error) {
+	var empty eval.EvalSample
 	var payload eval.EvalSample
 	for sc.Scan() {
 		line := sc.Bytes()

--- a/cmd/beluga/eval/runner.go
+++ b/cmd/beluga/eval/runner.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -223,7 +224,21 @@ func execAllRows(ctx context.Context, cfg *CLIConfig, binary string, samples []e
 			rowID := newRunID()
 			out, err := execOneRow(rowCtx, binary, cfg, samples[idx], runID, rowID, stderr)
 			if err != nil {
+				// Exec failed. Build a populated sample whose Metadata
+				// carries latency_ms=0 so the default latency metric
+				// scores cleanly instead of synthesizing a second error
+				// ("missing metadata key \"latency_ms\"") — that duplicate
+				// would inflate report.Errors and overwrite the per-sample
+				// exec error downstream. maps.Clone copies the caller's
+				// metadata so the dataset is not aliased; Clone returns
+				// nil for a nil map, so we always own a fresh one here.
 				populated[idx] = samples[idx]
+				cloned := maps.Clone(samples[idx].Metadata)
+				if cloned == nil {
+					cloned = map[string]any{}
+				}
+				cloned["latency_ms"] = 0.0
+				populated[idx].Metadata = cloned
 				errs[idx] = err.Error()
 				return
 			}

--- a/cmd/beluga/eval/runner.go
+++ b/cmd/beluga/eval/runner.go
@@ -1,0 +1,435 @@
+package eval
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/lookatitude/beluga-ai/v2/cmd/beluga/devloop"
+	"github.com/lookatitude/beluga-ai/v2/eval"
+	"github.com/lookatitude/beluga-ai/v2/eval/metrics"
+)
+
+// ProtocolVersion is the IPC protocol version the scaffolded main.go
+// emits as its first stdout line: `{"beluga_eval_protocol":1}`. The
+// CLI rejects any child that fails to emit this line within
+// [DefaultProtocolProbeTimeout], steering the user to re-scaffold the
+// project or add the `BELUGA_ENV=eval` branch manually (S4 Risk 7).
+const ProtocolVersion = 1
+
+// protocolProbe is the exact JSON envelope the child emits to claim
+// protocol conformance. Matched as the first stdout line before the
+// populated-sample payload.
+type protocolProbe struct {
+	BelugaEvalProtocol int `json:"beluga_eval_protocol"`
+}
+
+// metricFactory returns a concrete eval.Metric for a given config-level
+// name. The CLI owns the name → constructor mapping because registering
+// every metric variant in the framework eval package would couple the
+// framework layer to CLI-visible metric names.
+type metricFactory func(cfg *CLIConfig) (eval.Metric, error)
+
+// builtInMetrics is the closed set of metric names the CLI recognises
+// today. Provider-backed metrics (braintrust_*, deepeval_*, ragas_*)
+// land via [CLIConfig.EvalProvider] in a follow-up.
+var builtInMetrics = map[string]metricFactory{
+	"exact_match": func(_ *CLIConfig) (eval.Metric, error) {
+		return metrics.NewExactMatch(), nil
+	},
+	"latency": func(_ *CLIConfig) (eval.Metric, error) {
+		return metrics.NewLatency(), nil
+	},
+}
+
+// ResolveMetrics turns the config's metric names into concrete
+// [eval.Metric] implementations. Unknown names produce a single error
+// listing every valid name so the user sees the full menu at once.
+func ResolveMetrics(cfg *CLIConfig) ([]eval.Metric, error) {
+	out := make([]eval.Metric, 0, len(cfg.Metrics))
+	var unknown []string
+	for _, name := range cfg.Metrics {
+		factory, ok := builtInMetrics[name]
+		if !ok {
+			unknown = append(unknown, name)
+			continue
+		}
+		m, err := factory(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("metric %q: %w", name, err)
+		}
+		out = append(out, m)
+	}
+	if len(unknown) > 0 {
+		valid := make([]string, 0, len(builtInMetrics))
+		for name := range builtInMetrics {
+			valid = append(valid, name)
+		}
+		return nil, fmt.Errorf("unknown metric(s) %v (valid: %v)", unknown, valid)
+	}
+	return out, nil
+}
+
+// Report is the CLI-level artefact shape. It mirrors [eval.EvalReport]
+// with the run-level identifier needed to join traces + metrics + JSON
+// artefact in downstream aggregation tools (S4 brief §Decision
+// summary, specialist-observability-expert §Q5).
+type Report struct {
+	RunID       string                 `json:"run_id"`
+	DatasetName string                 `json:"dataset"`
+	DatasetPath string                 `json:"dataset_path"`
+	StartedAt   time.Time              `json:"started_at"`
+	Duration    time.Duration          `json:"duration"`
+	Samples     []SampleReport         `json:"samples"`
+	Aggregate   map[string]float64     `json:"aggregate"`
+	Errors      []string               `json:"errors,omitempty"`
+	Skipped     int                    `json:"skipped,omitempty"`
+	DryRun      bool                   `json:"dry_run,omitempty"`
+	Extras      map[string]interface{} `json:"-"`
+}
+
+// SampleReport is a per-row view of one sample's scores and outcome.
+type SampleReport struct {
+	Index    int                `json:"index"`
+	RowID    string             `json:"row_id"`
+	Input    string             `json:"input"`
+	Output   string             `json:"output"`
+	Expected string             `json:"expected,omitempty"`
+	Scores   map[string]float64 `json:"scores"`
+	Error    string             `json:"error,omitempty"`
+}
+
+// builderFunc is indirected for testing so unit tests can stub the
+// binary build without invoking the Go toolchain.
+var builderFunc = devloop.BuildBinary
+
+// execCommand is indirected for testing so unit tests can stub
+// per-row subprocess execution.
+var execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	// #nosec G204 -- name is always an absolute path produced by
+	// devloop.BuildBinary under os.TempDir(). args is empty — the
+	// child receives its sample exclusively via the BELUGA_EVAL_SAMPLE_JSON
+	// env var, never via argv. No shell is involved.
+	return exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: see nosec justification above
+}
+
+// Run is the CLI entry point. It loads the dataset, resolves metrics,
+// builds the user binary once, execs it per row, parses the populated
+// [eval.EvalSample] back from stdout, and hands the populated samples
+// plus metrics to the framework eval runner for OTel-instrumented
+// scoring. A run with --dry-run skips the build + exec path entirely
+// and returns a report marked with DryRun=true.
+func Run(ctx context.Context, cfg *CLIConfig, stdout, stderr io.Writer) (*Report, error) {
+	if cfg == nil {
+		return nil, errors.New("nil config")
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	datasetPath := filepath.Clean(cfg.Dataset)
+	ds, err := eval.LoadDataset(datasetPath)
+	if err != nil {
+		return nil, fmt.Errorf("load dataset %s: %w", datasetPath, err)
+	}
+
+	samples := applyMaxRows(ds.Samples, cfg.MaxRows)
+	skipped := len(ds.Samples) - len(samples)
+
+	runID := newRunID()
+	started := time.Now()
+
+	if cfg.DryRun {
+		report := &Report{
+			RunID:       runID,
+			DatasetName: ds.Name,
+			DatasetPath: datasetPath,
+			StartedAt:   started,
+			Samples:     []SampleReport{},
+			Aggregate:   map[string]float64{},
+			Skipped:     skipped,
+			DryRun:      true,
+		}
+		fmt.Fprintf(stdout, "dry-run: %d rows queued (capped from %d), row_timeout=%s\n",
+			len(samples), len(ds.Samples), cfg.RowTimeout)
+		report.Duration = time.Since(started)
+		return report, nil
+	}
+
+	ms, err := ResolveMetrics(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	build, err := builderFunc(ctx, cfg.ProjectRoot, 0, stderr, stderr)
+	if err != nil {
+		return nil, fmt.Errorf("build user binary: %w", err)
+	}
+	defer removeBinary(build.OutputPath, stderr)
+
+	populated, execErrs := execAllRows(ctx, cfg, build.OutputPath, samples, runID, stderr)
+
+	runner := eval.NewRunner(
+		eval.WithDataset(populated),
+		eval.WithMetrics(ms...),
+		eval.WithDatasetName(datasetName(ds, datasetPath)),
+		eval.WithParallel(1), // scoring is in-process and cheap; exec was the parallel hot path
+	)
+	evalReport, err := runner.Run(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("eval runner: %w", err)
+	}
+
+	report := toCLIReport(evalReport, runID, ds, datasetPath, started, skipped)
+	for i, e := range execErrs {
+		if e == "" {
+			continue
+		}
+		if i < len(report.Samples) {
+			report.Samples[i].Error = e
+		}
+		report.Errors = append(report.Errors, e)
+	}
+	return report, nil
+}
+
+// execAllRows runs every sample through the user binary serially (mock
+// default) or in a worker pool (real-provider runs). Each invocation
+// lives under [CLIConfig.RowTimeout]; missing populated output is
+// reported as a per-row error without aborting the whole run.
+func execAllRows(ctx context.Context, cfg *CLIConfig, binary string, samples []eval.EvalSample, runID string, stderr io.Writer) ([]eval.EvalSample, []string) {
+	populated := make([]eval.EvalSample, len(samples))
+	errs := make([]string, len(samples))
+
+	sem := make(chan struct{}, cfg.Parallel)
+	done := make(chan int, len(samples))
+
+	for i := range samples {
+		sem <- struct{}{}
+		go func(idx int) {
+			defer func() { <-sem }()
+			defer func() { done <- idx }()
+
+			rowCtx, cancel := context.WithTimeout(ctx, cfg.RowTimeout)
+			defer cancel()
+
+			rowID := newRunID()
+			out, err := execOneRow(rowCtx, binary, cfg, samples[idx], runID, rowID, stderr)
+			if err != nil {
+				populated[idx] = samples[idx]
+				errs[idx] = err.Error()
+				return
+			}
+			populated[idx] = out
+		}(i)
+	}
+	for range samples {
+		<-done
+	}
+	return populated, errs
+}
+
+// execOneRow execs the user binary once with the sample JSON in the
+// environment, validates the protocol probe on the first stdout line,
+// and returns the populated sample decoded from the second line. Wall-
+// clock latency is recorded into out.Metadata["latency_ms"] unless the
+// child already set it — this is the canonical source of truth for the
+// built-in latency metric and decouples it from child-reported timing.
+func execOneRow(ctx context.Context, binary string, cfg *CLIConfig, sample eval.EvalSample, runID, rowID string, stderr io.Writer) (eval.EvalSample, error) {
+	payload, err := json.Marshal(sample)
+	if err != nil {
+		return sample, fmt.Errorf("marshal sample: %w", err)
+	}
+
+	loaded, err := devloop.LoadProjectEnv(cfg.ProjectRoot)
+	if err != nil {
+		return sample, fmt.Errorf("load project env: %w", err)
+	}
+	extras := []string{
+		"BELUGA_ENV=eval",
+		"BELUGA_EVAL_RUN_ID=" + runID,
+		"BELUGA_EVAL_ROW_ID=" + rowID,
+		"BELUGA_EVAL_SAMPLE_JSON=" + string(payload),
+	}
+	env := devloop.MergeEnv(os.Environ(), loaded, extras)
+
+	cmd := execCommand(ctx, binary)
+	cmd.Dir = cfg.ProjectRoot
+	cmd.Env = env
+	cmd.Stderr = stderr
+	// WaitDelay bounds cmd.Wait() when grandchildren (e.g., `sleep` inside
+	// a shell script) keep the stdout pipe open after ctx.Done kills the
+	// direct child. Without it, the reader below would block indefinitely
+	// waiting on EOF that never comes.
+	cmd.WaitDelay = 2 * time.Second
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return sample, fmt.Errorf("stdout pipe: %w", err)
+	}
+	started := time.Now()
+	if err := cmd.Start(); err != nil {
+		return sample, fmt.Errorf("start: %w", err)
+	}
+
+	type readOutcome struct {
+		sample eval.EvalSample
+		err    error
+	}
+	results := make(chan readOutcome, 1)
+	go func() {
+		out, err := readProtocolAndSample(stdoutPipe)
+		results <- readOutcome{out, err}
+	}()
+
+	var rr readOutcome
+	select {
+	case rr = <-results:
+	case <-ctx.Done():
+		// Force the reader to unblock by closing the stdout pipe — any
+		// grandchild holding the fd will simply get EPIPE on its next
+		// write. cmd.WaitDelay below ensures Wait() still returns.
+		_ = stdoutPipe.Close()
+		rr = <-results
+		if rr.err == nil {
+			rr.err = ctx.Err()
+		}
+	}
+
+	waitErr := cmd.Wait()
+	elapsed := time.Since(started)
+
+	switch {
+	case rr.err != nil:
+		return sample, rr.err
+	case waitErr != nil:
+		return sample, fmt.Errorf("child exited: %w", waitErr)
+	}
+
+	out := rr.sample
+	if out.Metadata == nil {
+		out.Metadata = map[string]any{}
+	}
+	if _, ok := out.Metadata["latency_ms"]; !ok {
+		out.Metadata["latency_ms"] = float64(elapsed.Milliseconds())
+	}
+	return out, nil
+}
+
+// readProtocolAndSample consumes the child's stdout: first line MUST
+// be the protocol probe; the next non-empty line MUST be the populated
+// sample JSON. Any deviation is returned as a typed error so callers
+// can distinguish "project not scaffolded for eval" from "child
+// crashed mid-response".
+func readProtocolAndSample(r io.Reader) (eval.EvalSample, error) {
+	var empty eval.EvalSample
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	if !sc.Scan() {
+		if err := sc.Err(); err != nil {
+			return empty, fmt.Errorf("read protocol probe: %w", err)
+		}
+		return empty, fmt.Errorf("no output from child — project may not have the BELUGA_ENV=eval branch; re-scaffold or add manually")
+	}
+	var probe protocolProbe
+	if err := json.Unmarshal(sc.Bytes(), &probe); err != nil || probe.BelugaEvalProtocol != ProtocolVersion {
+		return empty, fmt.Errorf("child did not emit eval protocol probe on first line (expected %q, got %q)",
+			fmt.Sprintf(`{"beluga_eval_protocol":%d}`, ProtocolVersion), sc.Text())
+	}
+	var payload eval.EvalSample
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(line, &payload); err != nil {
+			return empty, fmt.Errorf("decode populated sample: %w", err)
+		}
+		return payload, nil
+	}
+	if err := sc.Err(); err != nil {
+		return empty, fmt.Errorf("read populated sample: %w", err)
+	}
+	return empty, errors.New("child emitted protocol probe but no populated sample")
+}
+
+// applyMaxRows returns the first n samples when n > 0, else the full
+// slice. A negative n is rejected upstream in [CLIConfig.Validate].
+func applyMaxRows(samples []eval.EvalSample, n int) []eval.EvalSample {
+	if n <= 0 || n >= len(samples) {
+		return samples
+	}
+	return samples[:n]
+}
+
+// newRunID produces a 16-hex-char (64-bit) identifier for run/row
+// correlation. crypto/rand is used per the framework security rule
+// against math/rand in identifier paths.
+func newRunID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("err-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// datasetName returns the dataset's declared Name, falling back to the
+// filename (without extension) when Name is unset. Used as both the
+// beluga.eval.dataset OTel label and the report's dataset identifier.
+func datasetName(ds *eval.Dataset, path string) string {
+	if ds.Name != "" {
+		return ds.Name
+	}
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	return base[:len(base)-len(ext)]
+}
+
+// toCLIReport adapts the framework-layer report into the CLI artefact
+// shape. The CLI adds run_id and source-dataset metadata that the
+// framework layer deliberately does not know about.
+func toCLIReport(rep *eval.EvalReport, runID string, ds *eval.Dataset, path string, started time.Time, skipped int) *Report {
+	report := &Report{
+		RunID:       runID,
+		DatasetName: datasetName(ds, path),
+		DatasetPath: path,
+		StartedAt:   started,
+		Duration:    rep.Duration,
+		Aggregate:   rep.Metrics,
+		Samples:     make([]SampleReport, len(rep.Samples)),
+		Skipped:     skipped,
+	}
+	for i, s := range rep.Samples {
+		sr := SampleReport{
+			Index:    i,
+			RowID:    fmt.Sprintf("%s-%04d", runID, i),
+			Input:    s.Sample.Input,
+			Output:   s.Sample.Output,
+			Expected: s.Sample.ExpectedOutput,
+			Scores:   s.Scores,
+		}
+		if s.Error != nil {
+			sr.Error = s.Error.Error()
+			report.Errors = append(report.Errors, s.Error.Error())
+		}
+		report.Samples[i] = sr
+	}
+	return report
+}
+
+func removeBinary(path string, stderr io.Writer) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(stderr, "warning: remove %s: %v\n", path, err)
+	}
+}

--- a/cmd/beluga/eval/runner_test.go
+++ b/cmd/beluga/eval/runner_test.go
@@ -228,6 +228,51 @@ func TestRun_ChildMissingProtocol_RowErrored(t *testing.T) {
 	assert.Contains(t, strings.Join(report.Errors, "|"), "eval protocol probe")
 }
 
+// Exec failures must produce exactly one entry in report.Errors and
+// preserve the exec error on the per-sample Error field. Before the
+// zero-out-latency_ms fix, the default latency metric synthesized a
+// spurious "missing metadata key \"latency_ms\"" error on the broken
+// row; toCLIReport appended that to report.Errors and overwrote
+// report.Samples[i].Error, so a single exec failure leaked as two
+// entries and the metric error silently discarded the exec error.
+// (Greptile P1 on PR #326 at cmd/beluga/eval/runner.go:199.)
+func TestRun_ExecFailure_NoDoubleCount(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fake-beluga-app")
+
+	ds := eval.Dataset{Samples: []eval.EvalSample{{Input: "q", ExpectedOutput: "a"}}}
+	path := writeDataset(t, dir, ds)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		writeFakeBinary(t, binaryPath, []string{"not a probe"})
+		// #nosec G204 -- test-only binary written above.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	require.NoError(t, err, "per-row failures are row-level, not run-level")
+	require.Len(t, report.Samples, 1)
+
+	require.Len(t, report.Errors, 1,
+		"single exec failure must produce exactly one error entry; got %d: %v",
+		len(report.Errors), report.Errors)
+	assert.Contains(t, report.Errors[0], "protocol probe",
+		"report.Errors[0] must preserve the exec/probe error (not a synthesized metric error)")
+	assert.Contains(t, report.Samples[0].Error, "protocol probe",
+		"per-sample Error must preserve the exec error; overwrite would discard it")
+	for _, e := range report.Errors {
+		assert.NotContains(t, e, `latency: missing metadata key`,
+			"spurious latency metadata error must not leak — exec-failed rows synthesize latency_ms=0")
+	}
+}
+
 func TestRun_MaxRows_Truncates(t *testing.T) {
 	dir := t.TempDir()
 	binaryPath := filepath.Join(dir, "fake-beluga-app")

--- a/cmd/beluga/eval/runner_test.go
+++ b/cmd/beluga/eval/runner_test.go
@@ -131,13 +131,18 @@ func TestRun_DryRun_NoBuildOrExec(t *testing.T) {
 	}
 	require.NoError(t, cfg.ApplyDefaults())
 
-	var stdout bytes.Buffer
-	report, err := Run(context.Background(), cfg, &stdout, io.Discard)
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
 	require.NoError(t, err)
 	require.NotNil(t, report)
 	assert.True(t, report.DryRun)
 	assert.Equal(t, "smoke", report.DatasetName)
 	assert.Empty(t, report.Samples)
+
+	// The CLI sends the report through RenderText (see cmd/beluga/eval.go);
+	// the DryRun branch is the single canonical source for the "dry-run"
+	// stdout line — Run() itself no longer prints it.
+	var stdout bytes.Buffer
+	require.NoError(t, RenderText(&stdout, report))
 	assert.Contains(t, stdout.String(), "dry-run")
 }
 
@@ -339,6 +344,55 @@ func TestRun_RespectsRowTimeout(t *testing.T) {
 	require.Len(t, report.Samples, 1)
 	assert.NotEmpty(t, report.Samples[0].Error, "timed-out row must record an error")
 	assert.Less(t, elapsed, 30*time.Second, "row timeout must bound wall-clock")
+}
+
+// A child that emits no probe (e.g., a pre-eval v2.12.0 binary, or a
+// child that crashes before printing anything) must trip
+// DefaultProtocolProbeTimeout (5s) rather than blocking until
+// RowTimeout (30s default). Without this bound, users on a pre-eval
+// scaffold see a 30s hang before the actionable re-scaffold error
+// surfaces (S4 brief Risk 7).
+func TestRun_ProtocolProbeTimeout_BoundsNoProbeChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary runner test is posix-only")
+	}
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "no-probe-beluga-app")
+
+	ds := eval.Dataset{Samples: []eval.EvalSample{{Input: "q", ExpectedOutput: "a"}}}
+	path := writeDataset(t, dir, ds)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	// Binary that never emits the probe line and blocks indefinitely.
+	// Without the probe-phase timeout, execOneRow would block until
+	// RowTimeout (30s) rather than surfacing within 5s.
+	require.NoError(t, os.WriteFile(binaryPath, []byte("#!/bin/sh\nsleep 60\n"), 0o700)) //nolint:gosec // G306: test-only fake binary
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		// #nosec G204 -- test-only binary written above.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+		// Deliberately much larger than DefaultProtocolProbeTimeout so
+		// a failure to wire the probe timeout would surface as a
+		// 30s-elapsed assertion failure rather than a false positive.
+		RowTimeout: 30 * time.Second,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	start := time.Now()
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	elapsed := time.Since(start)
+	require.NoError(t, err, "per-row probe-timeout failures are row-level, not run-level")
+	require.Len(t, report.Samples, 1)
+	assert.NotEmpty(t, report.Samples[0].Error, "no-probe child must produce a row error")
+	assert.Contains(t, strings.Join(report.Errors, "|"), "protocol probe",
+		"error message must attribute the failure to the probe timeout, not the row timeout")
+	// 5s probe timeout + 2s cmd.WaitDelay buffer for grandchild reaping.
+	assert.Less(t, elapsed, DefaultProtocolProbeTimeout+5*time.Second,
+		"probe timeout must bound wall-clock well below RowTimeout")
 }
 
 func TestNewRunID_HexAndStable(t *testing.T) {

--- a/cmd/beluga/eval/runner_test.go
+++ b/cmd/beluga/eval/runner_test.go
@@ -1,0 +1,350 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lookatitude/beluga-ai/v2/cmd/beluga/devloop"
+	"github.com/lookatitude/beluga-ai/v2/eval"
+)
+
+// writeDataset serialises the given Dataset to a tempdir JSON file and
+// returns its path. Centralises the boilerplate so per-test setup stays
+// legible.
+func writeDataset(t *testing.T, dir string, ds eval.Dataset) string {
+	t.Helper()
+	path := filepath.Join(dir, "dataset.json")
+	require.NoError(t, ds.Save(path))
+	return path
+}
+
+// writeFakeBinary writes an executable shell/batch script at path that
+// emits the supplied stdout lines in order. On non-posix platforms the
+// tests skip since the CLI runner is exercised end-to-end in
+// eval-integration CI; the Linux-only surface matches S4 §Q5.
+func writeFakeBinary(t *testing.T, path string, stdoutLines []string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary runner test is posix-only")
+	}
+	var body strings.Builder
+	body.WriteString("#!/bin/sh\n")
+	for _, line := range stdoutLines {
+		body.WriteString("printf '%s\\n' ")
+		body.WriteString(shellQuote(line))
+		body.WriteString("\n")
+	}
+	require.NoError(t, os.WriteFile(path, []byte(body.String()), 0o700)) //nolint:gosec // G306: test-only fake binary
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// stubBuilder returns a builderFunc that yields a pre-created binary
+// at fixedPath instead of invoking the Go toolchain.
+func stubBuilder(fixedPath string) func(ctx context.Context, projectRoot string, seq int, stdout, stderr io.Writer) (*devloop.BuildResult, error) {
+	return func(_ context.Context, _ string, _ int, _, _ io.Writer) (*devloop.BuildResult, error) {
+		return &devloop.BuildResult{OutputPath: fixedPath}, nil
+	}
+}
+
+func installBuilder(t *testing.T, fn func(ctx context.Context, projectRoot string, seq int, stdout, stderr io.Writer) (*devloop.BuildResult, error)) {
+	t.Helper()
+	prev := builderFunc
+	builderFunc = fn
+	t.Cleanup(func() { builderFunc = prev })
+}
+
+func installExec(t *testing.T, fn func(ctx context.Context, name string, args ...string) *exec.Cmd) {
+	t.Helper()
+	prev := execCommand
+	execCommand = fn
+	t.Cleanup(func() { execCommand = prev })
+}
+
+// --- tests ---
+
+func TestResolveMetrics_BuiltIns(t *testing.T) {
+	cfg := &CLIConfig{Metrics: []string{"exact_match", "latency"}}
+	got, err := ResolveMetrics(cfg)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	names := []string{got[0].Name(), got[1].Name()}
+	assert.ElementsMatch(t, []string{"exact_match", "latency"}, names)
+}
+
+func TestResolveMetrics_UnknownNameListsValid(t *testing.T) {
+	cfg := &CLIConfig{Metrics: []string{"not_a_metric"}}
+	_, err := ResolveMetrics(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not_a_metric")
+	assert.Contains(t, err.Error(), "exact_match")
+}
+
+func TestRun_RequiresDataset(t *testing.T) {
+	cfg := &CLIConfig{}
+	require.NoError(t, cfg.ApplyDefaults())
+	_, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dataset")
+}
+
+func TestRun_DryRun_NoBuildOrExec(t *testing.T) {
+	dir := t.TempDir()
+	ds := eval.Dataset{
+		Name: "smoke",
+		Samples: []eval.EvalSample{
+			{Input: "q1", ExpectedOutput: "a1"},
+			{Input: "q2", ExpectedOutput: "a2"},
+		},
+	}
+	path := writeDataset(t, dir, ds)
+
+	// Both builder and execCommand should remain untouched: install
+	// panicky stubs so any accidental call fails the test loudly.
+	installBuilder(t, func(context.Context, string, int, io.Writer, io.Writer) (*devloop.BuildResult, error) {
+		t.Fatal("builder should not run in --dry-run")
+		return nil, nil
+	})
+	installExec(t, func(context.Context, string, ...string) *exec.Cmd {
+		t.Fatal("exec should not run in --dry-run")
+		return nil
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		DryRun:      true,
+		ProjectRoot: dir,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	var stdout bytes.Buffer
+	report, err := Run(context.Background(), cfg, &stdout, io.Discard)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.True(t, report.DryRun)
+	assert.Equal(t, "smoke", report.DatasetName)
+	assert.Empty(t, report.Samples)
+	assert.Contains(t, stdout.String(), "dry-run")
+}
+
+func TestRun_ExecOncePerRow_PopulatesSamples(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fake-beluga-app")
+
+	ds := eval.Dataset{
+		Name: "exec-test",
+		Samples: []eval.EvalSample{
+			{Input: "capital of France?", ExpectedOutput: "Paris"},
+			{Input: "capital of Spain?", ExpectedOutput: "Madrid"},
+		},
+	}
+	path := writeDataset(t, dir, ds)
+
+	// Fake binary emits the protocol probe and a populated sample
+	// whose Output matches the ExpectedOutput so exact_match scores
+	// 1.0 for every row.
+	populatedParis := eval.EvalSample{Input: "capital of France?", ExpectedOutput: "Paris", Output: "Paris"}
+	populatedMadrid := eval.EvalSample{Input: "capital of Spain?", ExpectedOutput: "Madrid", Output: "Madrid"}
+	parisJSON, err := json.Marshal(populatedParis)
+	require.NoError(t, err)
+	madridJSON, err := json.Marshal(populatedMadrid)
+	require.NoError(t, err)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	// Swap the response on each call so row 0 → Paris, row 1 → Madrid.
+	calls := 0
+	responses := [][]byte{parisJSON, madridJSON}
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		writeFakeBinary(t, binaryPath, []string{
+			`{"beluga_eval_protocol":1}`,
+			string(responses[calls%len(responses)]),
+		})
+		calls++
+		// #nosec G204 -- test-only binary written above in fixed tempdir.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	require.Len(t, report.Samples, 2, "one row per sample")
+
+	for _, sr := range report.Samples {
+		assert.Empty(t, sr.Error, "no per-row errors")
+		assert.Equal(t, 1.0, sr.Scores["exact_match"], "exact_match scores 1.0 when Output=Expected")
+	}
+	assert.Equal(t, 1.0, report.Aggregate["exact_match"])
+}
+
+func TestRun_ChildMissingProtocol_RowErrored(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fake-beluga-app")
+
+	ds := eval.Dataset{Samples: []eval.EvalSample{{Input: "q", ExpectedOutput: "a"}}}
+	path := writeDataset(t, dir, ds)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		writeFakeBinary(t, binaryPath, []string{"not a probe"})
+		// #nosec G204 -- test-only binary written above.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	require.NoError(t, err, "row failures are per-row, not run-level")
+	require.Len(t, report.Samples, 1)
+	assert.NotEmpty(t, report.Samples[0].Error)
+	assert.Contains(t, strings.Join(report.Errors, "|"), "eval protocol probe")
+}
+
+func TestRun_MaxRows_Truncates(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "fake-beluga-app")
+
+	ds := eval.Dataset{Samples: make([]eval.EvalSample, 5)}
+	for i := range ds.Samples {
+		ds.Samples[i] = eval.EvalSample{Input: "q", ExpectedOutput: "a", Output: "a"}
+	}
+	path := writeDataset(t, dir, ds)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	populated := eval.EvalSample{Input: "q", ExpectedOutput: "a", Output: "a"}
+	populatedJSON, err := json.Marshal(populated)
+	require.NoError(t, err)
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		writeFakeBinary(t, binaryPath, []string{
+			`{"beluga_eval_protocol":1}`,
+			string(populatedJSON),
+		})
+		// #nosec G204 -- test-only binary written above.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+		MaxRows:     2,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	require.NoError(t, err)
+	assert.Len(t, report.Samples, 2, "max_rows caps the run")
+	assert.Equal(t, 3, report.Skipped, "remaining rows counted as skipped")
+}
+
+func TestReadProtocolAndSample_HappyPath(t *testing.T) {
+	sample := eval.EvalSample{Input: "q", Output: "a"}
+	payload, err := json.Marshal(sample)
+	require.NoError(t, err)
+	buf := bytes.NewBufferString(`{"beluga_eval_protocol":1}` + "\n" + string(payload) + "\n")
+	got, err := readProtocolAndSample(buf)
+	require.NoError(t, err)
+	assert.Equal(t, sample.Output, got.Output)
+}
+
+func TestReadProtocolAndSample_MissingProbe(t *testing.T) {
+	buf := bytes.NewBufferString(`{"not":"a probe"}` + "\n")
+	_, err := readProtocolAndSample(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eval protocol probe")
+}
+
+func TestReadProtocolAndSample_NoSampleAfterProbe(t *testing.T) {
+	buf := bytes.NewBufferString(`{"beluga_eval_protocol":1}` + "\n")
+	_, err := readProtocolAndSample(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "populated sample")
+}
+
+func TestApplyMaxRows_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		in   int
+		want int
+	}{
+		{"zero → full", 0, 5, 5},
+		{"negative → full", -1, 5, 5},
+		{"cap smaller", 2, 5, 2},
+		{"cap equal", 5, 5, 5},
+		{"cap larger", 10, 5, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			samples := make([]eval.EvalSample, tt.in)
+			got := applyMaxRows(samples, tt.n)
+			assert.Len(t, got, tt.want)
+		})
+	}
+}
+
+func TestRun_RespectsRowTimeout(t *testing.T) {
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "slow-beluga-app")
+
+	ds := eval.Dataset{Samples: []eval.EvalSample{{Input: "q", ExpectedOutput: "a"}}}
+	path := writeDataset(t, dir, ds)
+
+	installBuilder(t, stubBuilder(binaryPath))
+	// Fake binary blocks forever — RowTimeout must kill it.
+	writeFakeBinary(t, binaryPath, []string{
+		`{"beluga_eval_protocol":1}`,
+	})
+	// Append a trailing `sleep 60` so the process hangs after the
+	// probe, exceeding RowTimeout.
+	require.NoError(t, os.WriteFile(binaryPath, []byte("#!/bin/sh\nprintf '{\"beluga_eval_protocol\":1}\\n'\nsleep 60\n"), 0o700)) //nolint:gosec // G306: test-only fake binary
+	installExec(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		// #nosec G204 -- test-only binary written above.
+		return exec.CommandContext(ctx, name, args...)
+	})
+
+	cfg := &CLIConfig{
+		Dataset:     path,
+		ProjectRoot: dir,
+		RowTimeout:  500 * time.Millisecond,
+	}
+	require.NoError(t, cfg.ApplyDefaults())
+
+	start := time.Now()
+	report, err := Run(context.Background(), cfg, io.Discard, io.Discard)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	require.Len(t, report.Samples, 1)
+	assert.NotEmpty(t, report.Samples[0].Error, "timed-out row must record an error")
+	assert.Less(t, elapsed, 30*time.Second, "row timeout must bound wall-clock")
+}
+
+func TestNewRunID_HexAndStable(t *testing.T) {
+	got := newRunID()
+	assert.Len(t, got, 16)
+	for _, r := range got {
+		assert.True(t, (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f'), "hex digits only")
+	}
+}

--- a/cmd/beluga/eval/schema.go
+++ b/cmd/beluga/eval/schema.go
@@ -1,0 +1,16 @@
+package eval
+
+import _ "embed"
+
+//go:embed schema.json
+var datasetSchema []byte
+
+// DatasetSchema returns the embedded JSON Schema for beluga eval
+// dataset files (draft 2020-12). The CI-integration workflow validates
+// eval-report.json against this schema; the hidden `beluga eval schema`
+// subcommand prints it to stdout for editor consumption.
+func DatasetSchema() []byte {
+	out := make([]byte, len(datasetSchema))
+	copy(out, datasetSchema)
+	return out
+}

--- a/cmd/beluga/eval/schema.json
+++ b/cmd/beluga/eval/schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://beluga.ai/schemas/eval-dataset.v1.json",
+  "title": "Beluga eval dataset",
+  "description": "Dataset file consumed by `beluga eval`. Mirrors eval.Dataset with optional multi-turn (Turns) and trajectory (ExpectedTools) extensions introduced in DX-1 Slice 4.",
+  "type": "object",
+  "required": ["samples"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Human-readable dataset identifier. Defaults to the filename stem when empty."
+    },
+    "samples": {
+      "type": "array",
+      "description": "Ordered list of evaluation samples.",
+      "items": { "$ref": "#/$defs/sample" }
+    }
+  },
+  "$defs": {
+    "sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Input": {
+          "type": "string",
+          "description": "Original prompt or question handed to the agent."
+        },
+        "Output": {
+          "type": "string",
+          "description": "Populated by the agent at eval time. May be empty in source datasets."
+        },
+        "ExpectedOutput": {
+          "type": "string",
+          "description": "Ground-truth reference answer. Empty values disable the exact_match metric for this sample."
+        },
+        "RetrievedDocs": {
+          "type": "array",
+          "description": "Optional RAG context documents carried for RAG-specific metrics.",
+          "items": { "type": "object" }
+        },
+        "Metadata": {
+          "type": "object",
+          "description": "Arbitrary key/value pairs consumed by metrics (e.g., latency_ms, input_tokens, cost_usd). The CLI injects latency_ms when the child does not.",
+          "additionalProperties": true
+        },
+        "Turns": {
+          "type": "array",
+          "description": "Multi-turn history for trajectory evaluation. Backward-compatible S4 extension.",
+          "items": { "$ref": "#/$defs/turn" }
+        },
+        "ExpectedTools": {
+          "type": "array",
+          "description": "Ordered names of tools a correct trajectory must invoke. Backward-compatible S4 extension.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "turn": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Role": {
+          "type": "string",
+          "enum": ["user", "assistant", "tool", "system"]
+        },
+        "Content": { "type": "string" },
+        "ToolCalls": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/cmd/beluga/root.go
+++ b/cmd/beluga/root.go
@@ -37,6 +37,7 @@ func newRootCmd() *cobra.Command {
 		newRunCmd(),
 		newDevCmd(),
 		newTestCmd(),
+		newEvalCmd(),
 		newDeployCmd(),
 	)
 

--- a/cmd/beluga/scaffold/templates/basic/.beluga/eval.smoke.json.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/.beluga/eval.smoke.json.tmpl
@@ -1,0 +1,50 @@
+{
+  "name": "__BELUGA_PROJECT_NAME__-smoke",
+  "samples": [
+    {
+      "Input": "Please echo: hello",
+      "ExpectedOutput": "hello",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"hello\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "hello"},
+        {"Role": "assistant", "Content": "hello"}
+      ],
+      "ExpectedTools": ["echo"]
+    },
+    {
+      "Input": "Please echo: world",
+      "ExpectedOutput": "world",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"world\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "world"},
+        {"Role": "assistant", "Content": "world"}
+      ],
+      "ExpectedTools": ["echo"]
+    },
+    {
+      "Input": "Please echo: beluga",
+      "ExpectedOutput": "beluga",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"beluga\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "beluga"},
+        {"Role": "assistant", "Content": "beluga"}
+      ],
+      "ExpectedTools": ["echo"]
+    }
+  ]
+}

--- a/cmd/beluga/scaffold/templates/basic/.beluga/eval.yaml.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/.beluga/eval.yaml.tmpl
@@ -1,0 +1,22 @@
+# beluga eval configuration for __BELUGA_PROJECT_NAME__.
+# Flag values passed to `beluga eval` beat the values in this file;
+# unset fields fall back to the CLI built-in defaults. See
+# framework/docs/reference/cli.md for the full schema.
+
+# Metrics to run per row. `exact_match` compares Output to
+# ExpectedOutput verbatim; `latency` reports the per-row wall-clock
+# populated into Metadata["latency_ms"]. Both work with the mock
+# provider so the default smoke eval needs zero API keys.
+metrics:
+  - exact_match
+  - latency
+
+# Per-row subprocess wall-clock cap. The CLI enforces a mandatory
+# default of 30s when this field is absent (framework security rule:
+# every external call must have a timeout).
+row_timeout: 30s
+
+# Worker-pool size for parallel row dispatch. Keep at 1 when using the
+# mock provider — its fixture queue is shared across callers and a
+# higher value causes cross-contamination between rows.
+parallel: 1

--- a/cmd/beluga/scaffold/templates/basic/.github/workflows/ci.yml.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/.github/workflows/ci.yml.tmpl
@@ -52,6 +52,12 @@ jobs:
           check-latest: false
           cache: true
 
+      # `go install` inside the module installs the beluga version pinned
+      # in this project's go.mod, so the CLI and framework stay in lockstep.
+      # setup-go puts $HOME/go/bin on PATH automatically.
+      - name: Install beluga CLI
+        run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
+
       - name: Make eval-ci
         run: make eval-ci
 
@@ -81,10 +87,12 @@ jobs:
   #       with:
   #         go-version-file: go.mod
   #         cache: true
+  #     - name: Install beluga CLI
+  #       run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
   #     - name: Run real-provider eval
   #       env:
   #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  #       run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+  #       run: beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
   #     - name: Upload eval report
   #       if: always()
   #       uses: actions/upload-artifact@v4

--- a/cmd/beluga/scaffold/templates/basic/.github/workflows/ci.yml.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/.github/workflows/ci.yml.tmpl
@@ -32,3 +32,62 @@ jobs:
 
       - name: Make check
         run: make check
+
+  # eval-smoke is the Tier-1 evaluation gate — every PR runs the
+  # scaffolded agent against .beluga/eval.smoke.json with the mock LLM
+  # provider so no API keys or paid calls are required. Target budget
+  # is <30s cold-cache. The eval-report.json artefact is uploaded for
+  # downstream tools (dorny/test-reporter, Braintrust push) to consume.
+  eval-smoke:
+    name: eval smoke (mock provider)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: false
+          cache: true
+
+      - name: Make eval-ci
+        run: make eval-ci
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: eval-report.json
+          if-no-files-found: warn
+
+  # Tier-2 real-provider eval template (opt-in).
+  # Uncomment + configure with a provider secret to enable a scheduled or
+  # manual-dispatch run against a real LLM. The template is opt-in by
+  # structure — Tier 1 (eval-smoke above) stays the only evaluation
+  # gate on PRs until this job is explicitly enabled.
+  #
+  # eval-real:
+  #   name: eval full (real provider)
+  #   runs-on: ubuntu-latest
+  #   # Trigger only on manual dispatch or nightly schedule, never on PR
+  #   # — real-provider eval makes paid API calls and must be controlled.
+  #   if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: go.mod
+  #         cache: true
+  #     - name: Run real-provider eval
+  #       env:
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  #       run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+  #     - name: Upload eval report
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: eval-report-real
+  #         path: eval-report.json

--- a/cmd/beluga/scaffold/templates/basic/Makefile.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/Makefile.tmpl
@@ -31,12 +31,19 @@ check: build test lint
 # to keep the eval child's stdout clean (the IPC payload is JSON on
 # stdout; a stdout OTel exporter would corrupt it). See framework
 # docs/reference/cli.md for the canonical eval env contract.
+#
+# Requires the `beluga` binary on PATH. Install once (versioned to your
+# go.mod via the current module):
+#   go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
+# `go run github.com/.../cmd/beluga` would force a resolved go.sum entry
+# for every transitive dep of the full CLI (fsnotify, cobra, every
+# provider) — which a scaffolded project's tidy'd go.sum does not carry.
 eval-ci:
 	BELUGA_LLM_PROVIDER=mock \
 	BELUGA_DETERMINISTIC=1 \
 	BELUGA_SEED=42 \
 	OTEL_SDK_DISABLED=true \
-	go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+	beluga eval .beluga/eval.smoke.json
 
 # security runs gosec and govulncheck. They are not in `check` by default
 # because gosec can be chatty on new projects; wire them into CI when you

--- a/cmd/beluga/scaffold/templates/basic/Makefile.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/Makefile.tmpl
@@ -1,4 +1,4 @@
-.PHONY: build test test-ci lint check security
+.PHONY: build test test-ci lint check security eval-ci
 
 # Release binaries: copy from framework's own .goreleaser.yml when you
 # need tagged release automation (https://goreleaser.com).
@@ -24,6 +24,19 @@ lint:
 	golangci-lint run ./...
 
 check: build test lint
+
+# eval-ci runs the smoke evaluation with the mock LLM provider and a
+# deterministic fixture dataset so CI gets pass/fail signal without
+# paid API calls. The env vars mirror test-ci plus OTEL_SDK_DISABLED
+# to keep the eval child's stdout clean (the IPC payload is JSON on
+# stdout; a stdout OTel exporter would corrupt it). See framework
+# docs/reference/cli.md for the canonical eval env contract.
+eval-ci:
+	BELUGA_LLM_PROVIDER=mock \
+	BELUGA_DETERMINISTIC=1 \
+	BELUGA_SEED=42 \
+	OTEL_SDK_DISABLED=true \
+	go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
 
 # security runs gosec and govulncheck. They are not in `check` by default
 # because gosec can be chatty on new projects; wire them into CI when you

--- a/cmd/beluga/scaffold/templates/basic/main.go.tmpl
+++ b/cmd/beluga/scaffold/templates/basic/main.go.tmpl
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -23,7 +24,9 @@ import (
 	"github.com/lookatitude/beluga-ai/v2/agent"
 	"github.com/lookatitude/beluga-ai/v2/config"
 	"github.com/lookatitude/beluga-ai/v2/core"
+	"github.com/lookatitude/beluga-ai/v2/eval"
 	"github.com/lookatitude/beluga-ai/v2/llm"
+	"github.com/lookatitude/beluga-ai/v2/llm/providers/mock"
 	"github.com/lookatitude/beluga-ai/v2/o11y"
 	"github.com/lookatitude/beluga-ai/v2/tool"
 
@@ -53,7 +56,33 @@ func newEchoTool() tool.Tool {
 	)
 }
 
+// newAgent constructs the __BELUGA_AGENT_NAME__ agent with its persona and
+// tools. Shared by the normal `beluga run` path and the `BELUGA_ENV=eval`
+// branch so both trajectories exercise the same wiring.
+func newAgent(model llm.ChatModel) agent.Agent {
+	return agent.New("__BELUGA_AGENT_NAME__",
+		agent.WithLLM(model),
+		agent.WithPersona(agent.Persona{
+			Role:      "helpful assistant",
+			Goal:      "answer questions accurately",
+			Backstory: "You are concise and direct. When asked to echo something, always use the echo tool.",
+			Traits:    []string{"concise", "accurate"},
+		}),
+		agent.WithTools([]tool.Tool{newEchoTool()}),
+		// agent.WithPlannerName("reflexion"), // see: docs/architecture/06-reasoning-strategies.md
+	)
+}
+
 func main() {
+	// BELUGA_ENV=eval dispatches the per-row exec-once IPC from
+	// `beluga eval` — the parent hands us a single EvalSample via env var,
+	// we populate Output + latency_ms and emit the sample back on stdout.
+	// The normal `beluga run` / `beluga dev` flow skips this branch.
+	if os.Getenv("BELUGA_ENV") == "eval" {
+		runEvalMode()
+		return
+	}
+
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
 		log.Fatal("OPENAI_API_KEY is not set.\n" +
@@ -83,20 +112,7 @@ func main() {
 		log.Fatalf("llm.New: %v", err)
 	}
 
-	a := agent.ApplyMiddleware(
-		agent.New("__BELUGA_AGENT_NAME__",
-			agent.WithLLM(model),
-			agent.WithPersona(agent.Persona{
-				Role:      "helpful assistant",
-				Goal:      "answer questions accurately",
-				Backstory: "You are concise and direct. When asked to echo something, always use the echo tool.",
-				Traits:    []string{"concise", "accurate"},
-			}),
-			agent.WithTools([]tool.Tool{newEchoTool()}),
-			// agent.WithPlannerName("reflexion"), // see: docs/architecture/06-reasoning-strategies.md
-		),
-		agent.WithTracing(),
-	)
+	a := agent.ApplyMiddleware(newAgent(model), agent.WithTracing())
 
 	answer, err := a.Invoke(ctx, "Please echo: hello world")
 	if err != nil {
@@ -104,4 +120,83 @@ func main() {
 	}
 
 	fmt.Println(answer)
+}
+
+// runEvalMode handles the BELUGA_ENV=eval branch. `beluga eval` dispatches
+// one process per dataset row with BELUGA_EVAL_SAMPLE_JSON carrying the
+// input sample; we populate the sample's Output + Metadata and emit it
+// back as JSON on stdout. The parent CLI joins runID/rowID from env vars.
+//
+// Stdout contract: the first line is the protocol probe
+// `{"beluga_eval_protocol":1}`; the second line is the populated
+// EvalSample JSON. OTel bootstrap is intentionally skipped here — the
+// parent owns the eval.run / eval.row spans, and a stdout exporter on the
+// child would corrupt the IPC payload. Export wiring happens in
+// `make eval-ci` via OTEL_SDK_DISABLED=true.
+func runEvalMode() {
+	payload := os.Getenv("BELUGA_EVAL_SAMPLE_JSON")
+	if payload == "" {
+		log.Fatal("BELUGA_EVAL_SAMPLE_JSON is empty; run via `beluga eval`")
+	}
+	var sample eval.EvalSample
+	if err := json.Unmarshal([]byte(payload), &sample); err != nil {
+		log.Fatalf("decode BELUGA_EVAL_SAMPLE_JSON: %v", err)
+	}
+
+	// Protocol probe MUST be the first line on stdout — the parent
+	// scanner rejects any child whose first line fails to match.
+	if _, err := fmt.Fprintln(os.Stdout, `{"beluga_eval_protocol":1}`); err != nil {
+		log.Fatalf("write probe: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	model, err := buildEvalModel(sample)
+	if err != nil {
+		log.Fatalf("build eval model: %v", err)
+	}
+
+	a := newAgent(model)
+
+	started := time.Now()
+	answer, err := a.Invoke(ctx, sample.Input)
+	elapsed := time.Since(started)
+	if err != nil {
+		log.Fatalf("agent.Invoke: %v", err)
+	}
+
+	sample.Output = answer
+	if sample.Metadata == nil {
+		sample.Metadata = map[string]any{}
+	}
+	sample.Metadata["latency_ms"] = float64(elapsed.Milliseconds())
+
+	if err := json.NewEncoder(os.Stdout).Encode(sample); err != nil {
+		log.Fatalf("encode sample: %v", err)
+	}
+}
+
+// buildEvalModel picks the LLM backend for eval mode.
+// BELUGA_LLM_PROVIDER=mock seeds a mock provider with fixtures derived
+// from sample.Turns so `make eval-ci` replays a recorded assistant
+// trajectory deterministically without API keys; any other value falls
+// through to the configured __BELUGA_PROVIDER_NAME__ provider.
+func buildEvalModel(sample eval.EvalSample) (llm.ChatModel, error) {
+	if os.Getenv("BELUGA_LLM_PROVIDER") == "mock" {
+		return mock.New(
+			config.ProviderConfig{Provider: "mock", Model: "__BELUGA_MODEL_NAME__"},
+			mock.WithFixtures(mock.FixturesFromTurns(sample.Turns)),
+		)
+	}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return nil, core.Errorf(core.ErrInvalidInput,
+			"OPENAI_API_KEY is not set (required for real-provider eval)")
+	}
+	return llm.New("__BELUGA_PROVIDER_NAME__", config.ProviderConfig{
+		Provider: "__BELUGA_PROVIDER_NAME__",
+		APIKey:   apiKey,
+		Model:    "__BELUGA_MODEL_NAME__",
+	})
 }

--- a/cmd/beluga/scaffold/templates_builtin_test.go
+++ b/cmd/beluga/scaffold/templates_builtin_test.go
@@ -38,10 +38,11 @@ func TestBuiltinTemplates_BasicRegistered(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("walk basic template: %v", err)
 	}
-	// 8 expected files: main.go.tmpl, go.mod.tmpl, .env.example.tmpl,
-	// .gitignore.tmpl, .beluga/project.yaml.tmpl, Dockerfile.tmpl,
-	// Makefile.tmpl, .github/workflows/ci.yml.tmpl.
-	if count < 8 {
-		t.Errorf("basic template should have at least 8 files, got %d", count)
+	// 10 expected files: main.go.tmpl, go.mod.tmpl, .env.example.tmpl,
+	// .gitignore.tmpl, .beluga/project.yaml.tmpl, .beluga/eval.yaml.tmpl,
+	// .beluga/eval.smoke.json.tmpl, Dockerfile.tmpl, Makefile.tmpl,
+	// .github/workflows/ci.yml.tmpl.
+	if count < 10 {
+		t.Errorf("basic template should have at least 10 files, got %d", count)
 	}
 }

--- a/cmd/beluga/scaffold/testdata/golden/basic/.beluga/eval.smoke.json
+++ b/cmd/beluga/scaffold/testdata/golden/basic/.beluga/eval.smoke.json
@@ -1,0 +1,50 @@
+{
+  "name": "sample-smoke",
+  "samples": [
+    {
+      "Input": "Please echo: hello",
+      "ExpectedOutput": "hello",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"hello\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "hello"},
+        {"Role": "assistant", "Content": "hello"}
+      ],
+      "ExpectedTools": ["echo"]
+    },
+    {
+      "Input": "Please echo: world",
+      "ExpectedOutput": "world",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"world\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "world"},
+        {"Role": "assistant", "Content": "world"}
+      ],
+      "ExpectedTools": ["echo"]
+    },
+    {
+      "Input": "Please echo: beluga",
+      "ExpectedOutput": "beluga",
+      "Turns": [
+        {
+          "Role": "assistant",
+          "ToolCalls": [
+            {"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"beluga\"}"}
+          ]
+        },
+        {"Role": "tool", "Content": "beluga"},
+        {"Role": "assistant", "Content": "beluga"}
+      ],
+      "ExpectedTools": ["echo"]
+    }
+  ]
+}

--- a/cmd/beluga/scaffold/testdata/golden/basic/.beluga/eval.yaml
+++ b/cmd/beluga/scaffold/testdata/golden/basic/.beluga/eval.yaml
@@ -1,0 +1,22 @@
+# beluga eval configuration for sample.
+# Flag values passed to `beluga eval` beat the values in this file;
+# unset fields fall back to the CLI built-in defaults. See
+# framework/docs/reference/cli.md for the full schema.
+
+# Metrics to run per row. `exact_match` compares Output to
+# ExpectedOutput verbatim; `latency` reports the per-row wall-clock
+# populated into Metadata["latency_ms"]. Both work with the mock
+# provider so the default smoke eval needs zero API keys.
+metrics:
+  - exact_match
+  - latency
+
+# Per-row subprocess wall-clock cap. The CLI enforces a mandatory
+# default of 30s when this field is absent (framework security rule:
+# every external call must have a timeout).
+row_timeout: 30s
+
+# Worker-pool size for parallel row dispatch. Keep at 1 when using the
+# mock provider — its fixture queue is shared across callers and a
+# higher value causes cross-contamination between rows.
+parallel: 1

--- a/cmd/beluga/scaffold/testdata/golden/basic/.github/workflows/ci.yml
+++ b/cmd/beluga/scaffold/testdata/golden/basic/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
           check-latest: false
           cache: true
 
+      # `go install` inside the module installs the beluga version pinned
+      # in this project's go.mod, so the CLI and framework stay in lockstep.
+      # setup-go puts $HOME/go/bin on PATH automatically.
+      - name: Install beluga CLI
+        run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
+
       - name: Make eval-ci
         run: make eval-ci
 
@@ -81,10 +87,12 @@ jobs:
   #       with:
   #         go-version-file: go.mod
   #         cache: true
+  #     - name: Install beluga CLI
+  #       run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
   #     - name: Run real-provider eval
   #       env:
   #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  #       run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+  #       run: beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
   #     - name: Upload eval report
   #       if: always()
   #       uses: actions/upload-artifact@v4

--- a/cmd/beluga/scaffold/testdata/golden/basic/.github/workflows/ci.yml
+++ b/cmd/beluga/scaffold/testdata/golden/basic/.github/workflows/ci.yml
@@ -32,3 +32,62 @@ jobs:
 
       - name: Make check
         run: make check
+
+  # eval-smoke is the Tier-1 evaluation gate — every PR runs the
+  # scaffolded agent against .beluga/eval.smoke.json with the mock LLM
+  # provider so no API keys or paid calls are required. Target budget
+  # is <30s cold-cache. The eval-report.json artefact is uploaded for
+  # downstream tools (dorny/test-reporter, Braintrust push) to consume.
+  eval-smoke:
+    name: eval smoke (mock provider)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: false
+          cache: true
+
+      - name: Make eval-ci
+        run: make eval-ci
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: eval-report.json
+          if-no-files-found: warn
+
+  # Tier-2 real-provider eval template (opt-in).
+  # Uncomment + configure with a provider secret to enable a scheduled or
+  # manual-dispatch run against a real LLM. The template is opt-in by
+  # structure — Tier 1 (eval-smoke above) stays the only evaluation
+  # gate on PRs until this job is explicitly enabled.
+  #
+  # eval-real:
+  #   name: eval full (real provider)
+  #   runs-on: ubuntu-latest
+  #   # Trigger only on manual dispatch or nightly schedule, never on PR
+  #   # — real-provider eval makes paid API calls and must be controlled.
+  #   if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version-file: go.mod
+  #         cache: true
+  #     - name: Run real-provider eval
+  #       env:
+  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  #       run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+  #     - name: Upload eval report
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: eval-report-real
+  #         path: eval-report.json

--- a/cmd/beluga/scaffold/testdata/golden/basic/Makefile
+++ b/cmd/beluga/scaffold/testdata/golden/basic/Makefile
@@ -31,12 +31,19 @@ check: build test lint
 # to keep the eval child's stdout clean (the IPC payload is JSON on
 # stdout; a stdout OTel exporter would corrupt it). See framework
 # docs/reference/cli.md for the canonical eval env contract.
+#
+# Requires the `beluga` binary on PATH. Install once (versioned to your
+# go.mod via the current module):
+#   go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
+# `go run github.com/.../cmd/beluga` would force a resolved go.sum entry
+# for every transitive dep of the full CLI (fsnotify, cobra, every
+# provider) — which a scaffolded project's tidy'd go.sum does not carry.
 eval-ci:
 	BELUGA_LLM_PROVIDER=mock \
 	BELUGA_DETERMINISTIC=1 \
 	BELUGA_SEED=42 \
 	OTEL_SDK_DISABLED=true \
-	go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+	beluga eval .beluga/eval.smoke.json
 
 # security runs gosec and govulncheck. They are not in `check` by default
 # because gosec can be chatty on new projects; wire them into CI when you

--- a/cmd/beluga/scaffold/testdata/golden/basic/Makefile
+++ b/cmd/beluga/scaffold/testdata/golden/basic/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-ci lint check security
+.PHONY: build test test-ci lint check security eval-ci
 
 # Release binaries: copy from framework's own .goreleaser.yml when you
 # need tagged release automation (https://goreleaser.com).
@@ -24,6 +24,19 @@ lint:
 	golangci-lint run ./...
 
 check: build test lint
+
+# eval-ci runs the smoke evaluation with the mock LLM provider and a
+# deterministic fixture dataset so CI gets pass/fail signal without
+# paid API calls. The env vars mirror test-ci plus OTEL_SDK_DISABLED
+# to keep the eval child's stdout clean (the IPC payload is JSON on
+# stdout; a stdout OTel exporter would corrupt it). See framework
+# docs/reference/cli.md for the canonical eval env contract.
+eval-ci:
+	BELUGA_LLM_PROVIDER=mock \
+	BELUGA_DETERMINISTIC=1 \
+	BELUGA_SEED=42 \
+	OTEL_SDK_DISABLED=true \
+	go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
 
 # security runs gosec and govulncheck. They are not in `check` by default
 # because gosec can be chatty on new projects; wire them into CI when you

--- a/cmd/beluga/scaffold/testdata/golden/basic/main.go
+++ b/cmd/beluga/scaffold/testdata/golden/basic/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -23,7 +24,9 @@ import (
 	"github.com/lookatitude/beluga-ai/v2/agent"
 	"github.com/lookatitude/beluga-ai/v2/config"
 	"github.com/lookatitude/beluga-ai/v2/core"
+	"github.com/lookatitude/beluga-ai/v2/eval"
 	"github.com/lookatitude/beluga-ai/v2/llm"
+	"github.com/lookatitude/beluga-ai/v2/llm/providers/mock"
 	"github.com/lookatitude/beluga-ai/v2/o11y"
 	"github.com/lookatitude/beluga-ai/v2/tool"
 
@@ -53,7 +56,33 @@ func newEchoTool() tool.Tool {
 	)
 }
 
+// newAgent constructs the sample-agent agent with its persona and
+// tools. Shared by the normal `beluga run` path and the `BELUGA_ENV=eval`
+// branch so both trajectories exercise the same wiring.
+func newAgent(model llm.ChatModel) agent.Agent {
+	return agent.New("sample-agent",
+		agent.WithLLM(model),
+		agent.WithPersona(agent.Persona{
+			Role:      "helpful assistant",
+			Goal:      "answer questions accurately",
+			Backstory: "You are concise and direct. When asked to echo something, always use the echo tool.",
+			Traits:    []string{"concise", "accurate"},
+		}),
+		agent.WithTools([]tool.Tool{newEchoTool()}),
+		// agent.WithPlannerName("reflexion"), // see: docs/architecture/06-reasoning-strategies.md
+	)
+}
+
 func main() {
+	// BELUGA_ENV=eval dispatches the per-row exec-once IPC from
+	// `beluga eval` — the parent hands us a single EvalSample via env var,
+	// we populate Output + latency_ms and emit the sample back on stdout.
+	// The normal `beluga run` / `beluga dev` flow skips this branch.
+	if os.Getenv("BELUGA_ENV") == "eval" {
+		runEvalMode()
+		return
+	}
+
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
 		log.Fatal("OPENAI_API_KEY is not set.\n" +
@@ -83,20 +112,7 @@ func main() {
 		log.Fatalf("llm.New: %v", err)
 	}
 
-	a := agent.ApplyMiddleware(
-		agent.New("sample-agent",
-			agent.WithLLM(model),
-			agent.WithPersona(agent.Persona{
-				Role:      "helpful assistant",
-				Goal:      "answer questions accurately",
-				Backstory: "You are concise and direct. When asked to echo something, always use the echo tool.",
-				Traits:    []string{"concise", "accurate"},
-			}),
-			agent.WithTools([]tool.Tool{newEchoTool()}),
-			// agent.WithPlannerName("reflexion"), // see: docs/architecture/06-reasoning-strategies.md
-		),
-		agent.WithTracing(),
-	)
+	a := agent.ApplyMiddleware(newAgent(model), agent.WithTracing())
 
 	answer, err := a.Invoke(ctx, "Please echo: hello world")
 	if err != nil {
@@ -104,4 +120,83 @@ func main() {
 	}
 
 	fmt.Println(answer)
+}
+
+// runEvalMode handles the BELUGA_ENV=eval branch. `beluga eval` dispatches
+// one process per dataset row with BELUGA_EVAL_SAMPLE_JSON carrying the
+// input sample; we populate the sample's Output + Metadata and emit it
+// back as JSON on stdout. The parent CLI joins runID/rowID from env vars.
+//
+// Stdout contract: the first line is the protocol probe
+// `{"beluga_eval_protocol":1}`; the second line is the populated
+// EvalSample JSON. OTel bootstrap is intentionally skipped here — the
+// parent owns the eval.run / eval.row spans, and a stdout exporter on the
+// child would corrupt the IPC payload. Export wiring happens in
+// `make eval-ci` via OTEL_SDK_DISABLED=true.
+func runEvalMode() {
+	payload := os.Getenv("BELUGA_EVAL_SAMPLE_JSON")
+	if payload == "" {
+		log.Fatal("BELUGA_EVAL_SAMPLE_JSON is empty; run via `beluga eval`")
+	}
+	var sample eval.EvalSample
+	if err := json.Unmarshal([]byte(payload), &sample); err != nil {
+		log.Fatalf("decode BELUGA_EVAL_SAMPLE_JSON: %v", err)
+	}
+
+	// Protocol probe MUST be the first line on stdout — the parent
+	// scanner rejects any child whose first line fails to match.
+	if _, err := fmt.Fprintln(os.Stdout, `{"beluga_eval_protocol":1}`); err != nil {
+		log.Fatalf("write probe: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	model, err := buildEvalModel(sample)
+	if err != nil {
+		log.Fatalf("build eval model: %v", err)
+	}
+
+	a := newAgent(model)
+
+	started := time.Now()
+	answer, err := a.Invoke(ctx, sample.Input)
+	elapsed := time.Since(started)
+	if err != nil {
+		log.Fatalf("agent.Invoke: %v", err)
+	}
+
+	sample.Output = answer
+	if sample.Metadata == nil {
+		sample.Metadata = map[string]any{}
+	}
+	sample.Metadata["latency_ms"] = float64(elapsed.Milliseconds())
+
+	if err := json.NewEncoder(os.Stdout).Encode(sample); err != nil {
+		log.Fatalf("encode sample: %v", err)
+	}
+}
+
+// buildEvalModel picks the LLM backend for eval mode.
+// BELUGA_LLM_PROVIDER=mock seeds a mock provider with fixtures derived
+// from sample.Turns so `make eval-ci` replays a recorded assistant
+// trajectory deterministically without API keys; any other value falls
+// through to the configured openai provider.
+func buildEvalModel(sample eval.EvalSample) (llm.ChatModel, error) {
+	if os.Getenv("BELUGA_LLM_PROVIDER") == "mock" {
+		return mock.New(
+			config.ProviderConfig{Provider: "mock", Model: "gpt-4o-mini"},
+			mock.WithFixtures(mock.FixturesFromTurns(sample.Turns)),
+		)
+	}
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return nil, core.Errorf(core.ErrInvalidInput,
+			"OPENAI_API_KEY is not set (required for real-provider eval)")
+	}
+	return llm.New("openai", config.ProviderConfig{
+		Provider: "openai",
+		APIKey:   apiKey,
+		Model:    "gpt-4o-mini",
+	})
 }

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,7 @@ Task-oriented how-to documents. Each guide assumes you've read [Architecture Ove
 
 - [Build Your First Agent](./first-agent.md) — a working LLM agent in under 5 minutes.
 - [Dev Loop](./dev-loop.md) — `beluga run`, `beluga dev`, and `beluga test` end-to-end, no API key required.
+- [Evaluate Your First Agent](./evaluation.md) — `beluga eval` from hand-authored dataset to mock-mode smoke to CI gating.
 
 ## Extending the framework
 
@@ -23,6 +24,7 @@ Task-oriented how-to documents. Each guide assumes you've read [Architecture Ove
 
 - **I just want to see it work.** → [First Agent](./first-agent.md).
 - **I want a hot-rebuild loop with a deterministic backend.** → [Dev Loop](./dev-loop.md).
+- **I want to measure whether my agent is actually good.** → [Evaluation](./evaluation.md).
 - **I want to use my own LLM.** → [Custom Provider](./custom-provider.md).
 - **My agent needs a reasoning style not in the box.** → [Custom Planner](./custom-planner.md).
 - **I have two agents that should talk to each other.** → [Multi-Agent Team](./multi-agent-team.md).

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -1,0 +1,222 @@
+# Evaluate your first agent — `beluga eval`
+
+**You will build:** a hand-authored dataset, run it against your scaffolded agent in mock mode (zero API cost), interpret the populated `eval-report.json`, switch to a real LLM for a full-quality pass, and wire it into CI.
+**Prerequisites:** Go 1.25+, a working `beluga` CLI on `$PATH` (`go install github.com/lookatitude/beluga-ai/v2/cmd/beluga@latest`), and a scaffolded project (`beluga init …`). If you are brand new to Beluga, work through [Build Your First Agent](./first-agent.md) and [Dev Loop](./dev-loop.md) first.
+**Related:** [CLI reference — `beluga eval`](../reference/cli.md#beluga-eval), [Architecture Overview — Layer 7](../architecture/01-overview.md#layer-7--application), [DOC-14 Observability](../architecture/14-observability.md).
+
+`beluga eval` is the fourth and final slice of the DX-1 CLI epic. It lets you measure whether your agent is actually *good* — whether responses match expected outputs, whether a prompt change made things better or worse, whether a model swap regressed behaviour on a curated test set. The CLI builds your scaffolded binary with the existing `devloop.BuildBinary` pipeline, exec's it once per dataset row, reads the populated sample back from stdout, scores each configured metric, renders a stdout summary, writes `eval-report.json`, and exits with an aggregate pass/fail code suitable for CI gating.
+
+## 1. Hand-author a dataset
+
+A dataset is a plain JSON file. The `basic` template ships one at `.beluga/eval.smoke.json`; to start from scratch, create `my-eval.json`:
+
+```json
+{
+  "name": "my-smoke",
+  "samples": [
+    {
+      "Input": "Please echo: hello",
+      "ExpectedOutput": "hello",
+      "Turns": [
+        {"Role": "assistant", "ToolCalls": [{"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"hello\"}"}]},
+        {"Role": "tool", "Content": "hello"},
+        {"Role": "assistant", "Content": "hello"}
+      ],
+      "ExpectedTools": ["echo"]
+    },
+    {
+      "Input": "Please echo: world",
+      "ExpectedOutput": "world",
+      "Turns": [
+        {"Role": "assistant", "ToolCalls": [{"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"world\"}"}]},
+        {"Role": "tool", "Content": "world"},
+        {"Role": "assistant", "Content": "world"}
+      ],
+      "ExpectedTools": ["echo"]
+    }
+  ]
+}
+```
+
+Three fields matter per row:
+
+- **`Input`** — the prompt handed to `agent.Invoke`.
+- **`ExpectedOutput`** — the ground-truth reference answer. An empty string disables the `exact_match` metric for that row.
+- **`Turns`** (optional) — a pre-recorded assistant trajectory used by the mock LLM provider to replay deterministic behaviour without an API key. Each assistant turn maps to one mock fixture via `mock.FixturesFromTurns`. You only need `Turns` for mock-mode smoke evals; real-provider runs ignore them.
+
+The canonical JSON Schema is embedded in the binary:
+
+```bash
+beluga eval schema > eval-dataset.schema.json
+```
+
+Point your editor's JSON-Schema setting at that file to get autocomplete and validation as you author datasets.
+
+## 2. Run the mock-mode smoke eval
+
+The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars for a deterministic, zero-cost smoke:
+
+```bash
+make eval-ci
+```
+
+Which expands to:
+
+```bash
+BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
+  go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+```
+
+What happens under the hood:
+
+1. The CLI loads your dataset and `.beluga/eval.yaml` (metrics, row_timeout, parallel).
+2. It builds your `main.go` via `devloop.BuildBinary`.
+3. For each row it exec's the binary once with `BELUGA_ENV=eval` + `BELUGA_EVAL_SAMPLE_JSON=<row-json>`.
+4. The scaffolded `main.go`'s eval-mode branch reads the row, seeds a `mock.ChatModel` with `mock.FixturesFromTurns(sample.Turns)`, invokes the agent, populates `sample.Output` + `Metadata["latency_ms"]`, and emits the populated sample JSON on stdout. The first line is the protocol probe `{"beluga_eval_protocol":1}`; the second line is the populated sample.
+5. The CLI scores each configured metric (`exact_match`, `latency`) against the populated sample.
+6. It renders a stdout table, writes `eval-report.json` to the project root, and exits.
+
+```
+IDX  ROW_ID  INPUT                                 OUTPUT  EXPECTED  exact_match  latency  ERROR
+0    …       Please echo: hello                    hello   hello     1.00         1.00
+1    …       Please echo: world                    world   world     1.00         1.00
+2    …       Please echo: beluga                   beluga  beluga    1.00         1.00
+
+run_id:  c1c…
+dataset: sample-smoke (.beluga/eval.smoke.json)
+samples: 3
+duration: 420ms
+aggregate:
+  exact_match: 1.0000
+  latency: 1.0000
+```
+
+`beluga eval` exits `0` when no row produces an exec error. Per-row metric failures are reported in the aggregate but do not flip the exit code — the convention is that `make eval-ci` exits green iff the mock trajectory is replayable end-to-end; aggregate-level pass-rate gating belongs in your CI assertion step (see §5).
+
+## 3. Inspect `eval-report.json`
+
+Every run writes `eval-report.json` at the project root — a stable location for CI artefact upload. Structure:
+
+```json
+{
+  "run_id": "c1c…",
+  "dataset": "sample-smoke",
+  "dataset_path": ".beluga/eval.smoke.json",
+  "started_at": "2026-04-22T11:02:01Z",
+  "duration": "420ms",
+  "samples": [
+    {
+      "index": 0,
+      "row_id": "…",
+      "input": "Please echo: hello",
+      "output": "hello",
+      "expected": "hello",
+      "scores": {"exact_match": 1.0, "latency": 1.0}
+    }
+  ],
+  "aggregate": {"exact_match": 1.0, "latency": 1.0},
+  "errors": []
+}
+```
+
+The `run_id` is the join key for traces + metrics + artefact. When OTel is enabled (see §6) the same UUID appears on the `eval.run` span as the `beluga.eval.run_id` resource attribute and on every sample in the `beluga.eval.metric.score` Histogram — you can pull the three together into a single view in any OTel backend that supports cross-signal joins.
+
+## 4. Switch to a real provider
+
+Mock mode replays `Turns`; real providers actually call the model. Swap by unsetting `BELUGA_LLM_PROVIDER`:
+
+```bash
+export OPENAI_API_KEY=sk-…
+beluga eval my-eval.json
+```
+
+The scaffolded `main.go.tmpl`'s `buildEvalModel` helper defaults to the `openai` provider when `BELUGA_LLM_PROVIDER` is anything other than `mock`. To use a different provider, edit the `buildEvalModel` function in your scaffolded `main.go` — swap the blank-import, change the `llm.New("openai", …)` call to `llm.New("anthropic", …)` or another registered provider.
+
+Real-provider runs produce per-sample non-determinism: run the same dataset twice against `gpt-4o-mini` and you may see different outputs. That is expected — the agent is sampling. For gate-worthy metrics on a real provider, prefer LLM-judge metrics (reserved for S4.5) over `exact_match`, or use a dataset small enough that human review of any regression is cheap.
+
+## 5. Gate CI on the smoke eval
+
+The scaffolded `.github/workflows/ci.yml` ships a Tier-1 `eval-smoke` job on every PR:
+
+```yaml
+eval-smoke:
+  name: eval smoke (mock provider)
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Make eval-ci
+      run: make eval-ci
+    - name: Upload eval report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: eval-report
+        path: eval-report.json
+```
+
+Budget: under 30 seconds on a cold-cache `ubuntu-latest` runner. Uses zero API keys. The uploaded `eval-report.json` is consumable by any downstream tool that reads the aggregated JSON (Braintrust push, dashboard publisher, regression bot).
+
+The workflow also ships a **commented Tier-2 template** for real-provider eval. Uncomment it and add an `OPENAI_API_KEY` secret to enable a `workflow_dispatch`- or `schedule`-triggered full-quality pass:
+
+```yaml
+eval-real:
+  name: eval full (real provider)
+  runs-on: ubuntu-latest
+  if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Run real-provider eval
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+```
+
+The template's structure — `if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'` plus `secrets.OPENAI_API_KEY` — is the opt-in gate. Tier-1 stays the only evaluation on PRs until Tier-2 is explicitly uncommented; a GitHub Actions `schedule:` trigger alone is not an opt-in gate because it still runs without human review.
+
+For PR-check annotations, pass `--format junit` and wire `dorny/test-reporter`:
+
+```yaml
+- name: Run make eval-ci with junit
+  run: |
+    BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
+      go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --format junit .beluga/eval.smoke.json
+- uses: dorny/test-reporter@v1
+  if: always()
+  with:
+    name: eval smoke
+    path: eval-report.junit.xml
+    reporter: java-junit
+```
+
+## 6. Observability
+
+The framework-layer eval runner emits OTel spans per the [OpenTelemetry GenAI `gen_ai.evaluation.*` semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (Development status):
+
+- **`eval.run`** span wraps the full CLI invocation. `gen_ai.operation.name = "eval"`; `beluga.eval.run_id` is a resource attribute.
+- **`eval.row`** child span per dataset row. `gen_ai.operation.name = "eval"`; `beluga.eval.row_id` is a span attribute.
+- **`gen_ai.evaluation.result`** events on the `eval.row` span, one per metric. Spec attributes: `gen_ai.evaluation.name`, `.score.value`, `.score.label`, `.explanation`.
+- **`beluga.eval.metric.score`** OTel Histogram with two label dimensions: `beluga.eval.metric_name` and `beluga.eval.dataset`. Never `row_id` or `row_index` — cardinality rule.
+
+`make eval-ci` sets `OTEL_SDK_DISABLED=true` so the stdout IPC stays clean and CI logs are quiet. Drop `OTEL_SDK_DISABLED=true` to collect spans locally with the `o11y` package's stdout exporter (`BELUGA_OTEL_STDOUT=1`) or forward them to an OTLP endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT=…`). The `o11y.BootstrapFromEnv` contract from `beluga run` applies here unchanged.
+
+## Common mistakes
+
+- **Editing `Turns` and expecting a real provider to respect them.** `Turns` is consumed only by the mock LLM provider to derive fixtures. Real-provider runs ignore the field — the agent calls the real model and the model decides which tools to invoke. Test trajectories with the mock; measure quality with the real provider.
+- **Setting `--parallel > 1` with `BELUGA_LLM_PROVIDER=mock`.** Per-row exec isolation keeps each row's mock queue independent (each row is a fresh process), so the CLI's default of `--parallel 1` is about preserving deterministic report ordering, not avoiding queue contamination. Still — keep it at `1` in mock mode unless you have a specific reason; the brief's `specialist-ai-ml-expert.md` §Q4 covers the design tradeoff.
+- **Using `exact_match` as the quality gate on real-provider runs.** LLM sampling produces paraphrases that `exact_match` scores as 0. For real-provider quality gating, the LLM-judge metric family (reserved for S4.5) is the right tool; until then, use real-provider runs for observability only and gate CI on the mock smoke.
+- **Pointing `go run ./cmd/beluga` inside the scaffolded project.** The scaffolded project's `go.mod` declares `github.com/lookatitude/beluga-ai/v2` as a `require`, so the correct invocation is `go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval …` (module path). `./cmd/beluga` is the framework-internal path and is not resolvable from a scaffolded project.
+- **Running `beluga eval` against a pre-v2.13 scaffolded project.** Projects scaffolded before the DX-1 S4 changes lack the `BELUGA_ENV=eval` branch in `main.go`. The CLI rejects any child whose first stdout line is not the `{"beluga_eval_protocol":1}` probe within 5 seconds — add the branch manually (copy from the current template) or re-scaffold.
+
+## Related reading
+
+- [CLI reference — `beluga eval`](../reference/cli.md#beluga-eval) — exhaustive flag table and IPC contract.
+- [Dev Loop guide](./dev-loop.md) — the `beluga run` / `dev` / `test` pipeline that shares the same `devloop.BuildBinary` + mock-provider infrastructure.
+- [DOC-14 Observability](../architecture/14-observability.md) — the OTel GenAI convention landscape.
+- [`eval/` package](../../eval/) — the framework-layer runner, metrics, and providers.
+- [`cmd/beluga/eval/`](../../cmd/beluga/eval/) — the Layer 7 CLI adapter.

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -54,17 +54,18 @@ Point your editor's JSON-Schema setting at that file to get autocomplete and val
 
 ## 2. Run the mock-mode smoke eval
 
-The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars for a deterministic, zero-cost smoke:
+The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars for a deterministic, zero-cost smoke. It invokes the `beluga` binary on PATH (same convention as `beluga dev` / `beluga run` / `beluga test`), so install the CLI once per environment first — `go install` inside your project picks the beluga version pinned by your `go.mod`:
 
 ```bash
+go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
 make eval-ci
 ```
 
-Which expands to:
+`make eval-ci` expands to:
 
 ```bash
 BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
-  go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+  beluga eval .beluga/eval.smoke.json
 ```
 
 What happens under the hood:
@@ -171,10 +172,12 @@ eval-real:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+    - name: Install beluga CLI
+      run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
     - name: Run real-provider eval
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      run: go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
+      run: beluga eval --max-rows 20 --max-cost 5.00 .beluga/eval.smoke.json
 ```
 
 The template's structure — `if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'` plus `secrets.OPENAI_API_KEY` — is the opt-in gate. Tier-1 stays the only evaluation on PRs until Tier-2 is explicitly uncommented; a GitHub Actions `schedule:` trigger alone is not an opt-in gate because it still runs without human review.
@@ -182,10 +185,12 @@ The template's structure — `if: github.event_name == 'workflow_dispatch' || gi
 For PR-check annotations, pass `--format junit` and wire `dorny/test-reporter`:
 
 ```yaml
+- name: Install beluga CLI
+  run: go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
 - name: Run make eval-ci with junit
   run: |
     BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
-      go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval --format junit .beluga/eval.smoke.json
+      beluga eval --format junit .beluga/eval.smoke.json
 - uses: dorny/test-reporter@v1
   if: always()
   with:
@@ -210,7 +215,7 @@ The framework-layer eval runner emits OTel spans per the [OpenTelemetry GenAI `g
 - **Editing `Turns` and expecting a real provider to respect them.** `Turns` is consumed only by the mock LLM provider to derive fixtures. Real-provider runs ignore the field — the agent calls the real model and the model decides which tools to invoke. Test trajectories with the mock; measure quality with the real provider.
 - **Setting `--parallel > 1` with `BELUGA_LLM_PROVIDER=mock`.** Per-row exec isolation keeps each row's mock queue independent (each row is a fresh process), so the CLI's default of `--parallel 1` is about preserving deterministic report ordering, not avoiding queue contamination. Still — keep it at `1` in mock mode unless you have a specific reason; the brief's `specialist-ai-ml-expert.md` §Q4 covers the design tradeoff.
 - **Using `exact_match` as the quality gate on real-provider runs.** LLM sampling produces paraphrases that `exact_match` scores as 0. For real-provider quality gating, the LLM-judge metric family (reserved for S4.5) is the right tool; until then, use real-provider runs for observability only and gate CI on the mock smoke.
-- **Pointing `go run ./cmd/beluga` inside the scaffolded project.** The scaffolded project's `go.mod` declares `github.com/lookatitude/beluga-ai/v2` as a `require`, so the correct invocation is `go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval …` (module path). `./cmd/beluga` is the framework-internal path and is not resolvable from a scaffolded project.
+- **Running `go run github.com/.../cmd/beluga eval` inside the scaffolded project.** That invocation forces the scaffolded project's `go.sum` to resolve every transitive dependency of the full CLI (fsnotify, cobra, every provider), which `go mod tidy` on your project does not pull in. Instead, install the binary into your PATH — `go install github.com/lookatitude/beluga-ai/v2/cmd/beluga` from within your project picks the beluga version pinned by your `go.mod` — then call `beluga eval …`. `make eval-ci` uses the PATH-resolved binary by design.
 - **Running `beluga eval` against a pre-v2.13 scaffolded project.** Projects scaffolded before the DX-1 S4 changes lack the `BELUGA_ENV=eval` branch in `main.go`. The CLI rejects any child whose first stdout line is not the `{"beluga_eval_protocol":1}` probe within 5 seconds — add the branch manually (copy from the current template) or re-scaffold.
 
 ## Related reading

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -221,14 +221,17 @@ See [`cmd/beluga/scaffold/templates/basic/.beluga/eval.yaml.tmpl`](../../cmd/bel
 
 Passing `--format junit` additionally writes `<report>.junit.xml` alongside (a single `<testsuite>` wrapping every sample; per-row `exec_error` or `exact_match=0` become `<failure>` children), consumable by [`dorny/test-reporter`](https://github.com/dorny/test-reporter) for PR-check annotations. Source: [`cmd/beluga/eval/render.go`](../../cmd/beluga/eval/render.go).
 
-**CI integration.** The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars so CI gets deterministic, mock-provider pass/fail signal without API keys:
+**CI integration.** The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars so CI gets deterministic, mock-provider pass/fail signal without API keys. The target invokes the `beluga` binary on PATH — matching the convention of `beluga dev` / `beluga run` / `beluga test` — so install it once per environment:
 
 ```
+go install github.com/lookatitude/beluga-ai/v2/cmd/beluga
 BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
-  go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+  beluga eval .beluga/eval.smoke.json
 ```
 
-The scaffolded `ci.yml` gates every PR on `make eval-ci` via the Tier-1 `eval-smoke` job and uploads `eval-report.json` as a workflow artefact. A commented Tier-2 template exposes the real-provider opt-in; the template structure is the opt-in gate — Tier-1 stays the only mandatory evaluation on PRs until Tier-2 is explicitly enabled. See [Evaluation guide](../guides/evaluation.md) for the full CI tier model.
+Running from inside your scaffolded project, `go install` picks the beluga version pinned by your `go.mod`, keeping the CLI and framework in lockstep. `go run github.com/.../cmd/beluga eval ...` does **not** work: it requires the project's `go.sum` to carry checksums for every transitive dependency of the full CLI (fsnotify, cobra, every provider) that `go mod tidy` on your project does not pull in.
+
+The scaffolded `ci.yml` gates every PR on `make eval-ci` via the Tier-1 `eval-smoke` job (which installs `beluga` via `go install` before calling `make eval-ci`) and uploads `eval-report.json` as a workflow artefact. A commented Tier-2 template exposes the real-provider opt-in; the template structure is the opt-in gate — Tier-1 stays the only mandatory evaluation on PRs until Tier-2 is explicitly enabled. See [Evaluation guide](../guides/evaluation.md) for the full CI tier model.
 
 **Observability.** When `OTEL_SDK_DISABLED` is not set, the framework-layer eval runner emits spans per the OpenTelemetry GenAI `gen_ai.evaluation.*` semantic convention: an `eval.run` span wraps the full CLI invocation, an `eval.row` child span wraps each dataset row, and per-metric scores attach as `gen_ai.evaluation.result` events on the row span. The aggregated `beluga.eval.metric.score` Histogram is emitted with two label dimensions — `beluga.eval.metric_name` and `beluga.eval.dataset` — **never** `row_id` or `row_index` (cardinality rule). The `beluga.eval.run_id` OTel resource attribute is the join key across traces + metrics + JSON artefact. See [DOC-14 Observability](../architecture/14-observability.md).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # Reference: CLI
 
-The `beluga` command-line tool is the reference Layer 7 application shipped with the framework. It is a cobra-based CLI with seven subcommands: `version`, `providers`, `init`, `run`, `dev`, `test`, and `deploy`.
+The `beluga` command-line tool is the reference Layer 7 application shipped with the framework. It is a cobra-based CLI with eight subcommands: `version`, `providers`, `init`, `run`, `dev`, `test`, `eval`, and `deploy`.
 
 Source: [`cmd/beluga/`](../../cmd/beluga/).
 
@@ -130,6 +130,110 @@ Run agent tests via `go test`. Resolves the toolchain via `exec.LookPath("go")` 
 
 Source: `canonicalTestEnv` in [`cmd/beluga/test.go`](../../cmd/beluga/test.go). Tests can assert the exact values via `os.Environ()` if they need to distinguish a `beluga test` run from a bare `go test`.
 
+### `beluga eval`
+
+Run dataset-driven evaluations against the scaffolded agent. `beluga eval` builds the user binary via the same `devloop.BuildBinary` pipeline as `beluga run`, then exec's it **once per dataset row** with the row handed in through the `BELUGA_EVAL_SAMPLE_JSON` environment variable. The child populates the sample and emits it back on stdout; the parent scores each configured metric, renders a stdout summary table, writes `eval-report.json` to the project root, and exits with the aggregate pass/fail code.
+
+```bash
+beluga eval .beluga/eval.smoke.json
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--project-root` | `.` | Directory containing `go.mod` + `.beluga/project.yaml`. Resolved via `filepath.Abs`. |
+| `--dataset` | — | Dataset JSON path (defaults to the positional argument). |
+| `--config` | `<project-root>/.beluga/eval.yaml` | Config file path. Flag values override YAML; YAML overrides defaults. |
+| `--metric` | — | Metric name (repeatable). Overrides any `metrics:` list in the config. Built-in names: `exact_match`, `latency`. |
+| `--row-timeout` | `30s` | Mandatory per-row subprocess wall-clock cap. Framework security rule — every external call must have a timeout. |
+| `--max-rows` | `0` (no cap) | Execute only the first N rows. Useful for partial runs and incremental gating. |
+| `--parallel` | `1` | Worker-pool size for per-row subprocess dispatch. Keep at `1` in mock mode — the mock fixture queue is shared across callers and a higher value causes cross-contamination. |
+| `--dry-run` | `false` | Print the planned run (row count, row_timeout) without launching subprocesses. |
+| `--format` | — | Additive output format alongside the default JSON report. Currently only `junit` (writes `<report>.junit.xml` for `dorny/test-reporter`). |
+| `--eval-provider` | — | Reserved for S4.5. Braintrust/DeepEval/RAGAS provider dispatch. |
+| `--judge-model` | — | Reserved for S4.5. LLM-judge model name. |
+| `--max-cost` | — | Reserved for S4.5. Hard-cap total USD cost across rows. |
+
+**IPC contract.** The CLI never imports user code. Instead it exec's the scaffolded binary once per dataset row with the following environment:
+
+| Key | Purpose |
+|---|---|
+| `BELUGA_ENV=eval` | Dispatches the scaffolded `main.go` to its eval-mode branch (`runEvalMode()`). |
+| `BELUGA_EVAL_SAMPLE_JSON` | JSON-encoded `eval.EvalSample` carrying `Input`, `ExpectedOutput`, `Turns`, `ExpectedTools`, `Metadata`. |
+| `BELUGA_EVAL_RUN_ID` | Run-scoped UUID-v4 that matches the `run_id` field in `eval-report.json` and the `beluga.eval.run_id` OTel resource attribute, so downstream aggregation tools can join traces + metrics + CLI artefact. |
+| `BELUGA_EVAL_ROW_ID` | Row-scoped UUID-v4 surfaced as the `row_id` field in the report and the `beluga.eval.row_id` span attribute. |
+
+The child must emit `{"beluga_eval_protocol":1}` as its first stdout line (the protocol probe) followed by the populated `eval.EvalSample` JSON. The CLI rejects any child whose first line is not the probe within 5s, directing the user to re-scaffold the project or add the `BELUGA_ENV=eval` branch manually. Source: `ProtocolVersion` in [`cmd/beluga/eval/runner.go`](../../cmd/beluga/eval/runner.go).
+
+**Dataset schema.** The dataset file format is a backward-compatible extension of `eval.Dataset`:
+
+```json
+{
+  "name": "my-smoke",
+  "samples": [
+    {
+      "Input": "Please echo: hello",
+      "ExpectedOutput": "hello",
+      "Turns": [
+        {"Role": "assistant", "ToolCalls": [{"ID": "call_1", "Name": "echo", "Arguments": "{\"message\":\"hello\"}"}]},
+        {"Role": "tool", "Content": "hello"},
+        {"Role": "assistant", "Content": "hello"}
+      ],
+      "ExpectedTools": ["echo"]
+    }
+  ]
+}
+```
+
+The `Turns` and `ExpectedTools` fields are the S4 additions and are optional — pre-existing `{Input, ExpectedOutput}` datasets continue to work unchanged. The canonical JSON Schema is embedded in the binary; dump it with:
+
+```bash
+beluga eval schema > eval-dataset.schema.json
+```
+
+Source: [`cmd/beluga/eval/schema.json`](../../cmd/beluga/eval/schema.json).
+
+**Config file (`.beluga/eval.yaml`).** Optional YAML config mapped to `[]eval.RunnerOption`; flag values always win over YAML, YAML always wins over built-in defaults.
+
+```yaml
+metrics:
+  - exact_match
+  - latency
+row_timeout: 30s
+parallel: 1
+```
+
+See [`cmd/beluga/scaffold/templates/basic/.beluga/eval.yaml.tmpl`](../../cmd/beluga/scaffold/templates/basic/.beluga/eval.yaml.tmpl) for the scaffolded default. Any flag listed above is representable as the corresponding lowercase YAML key.
+
+**Reports.** Every run writes `eval-report.json` at `<project-root>/eval-report.json` (stable location for CI artefact upload). The report is structurally:
+
+```json
+{
+  "run_id": "…uuid-v4…",
+  "dataset": "my-smoke",
+  "dataset_path": ".beluga/eval.smoke.json",
+  "started_at": "2026-04-22T…",
+  "duration": "…",
+  "samples": [{"index": 0, "row_id": "…", "input": "…", "output": "…", "scores": {"exact_match": 1.0, "latency": …}}],
+  "aggregate": {"exact_match": 1.0, "latency": …},
+  "errors": []
+}
+```
+
+Passing `--format junit` additionally writes `<report>.junit.xml` alongside (a single `<testsuite>` wrapping every sample; per-row `exec_error` or `exact_match=0` become `<failure>` children), consumable by [`dorny/test-reporter`](https://github.com/dorny/test-reporter) for PR-check annotations. Source: [`cmd/beluga/eval/render.go`](../../cmd/beluga/eval/render.go).
+
+**CI integration.** The scaffolded `Makefile` ships an `eval-ci` target that pins the five canonical env vars so CI gets deterministic, mock-provider pass/fail signal without API keys:
+
+```
+BELUGA_LLM_PROVIDER=mock BELUGA_DETERMINISTIC=1 BELUGA_SEED=42 OTEL_SDK_DISABLED=true \
+  go run github.com/lookatitude/beluga-ai/v2/cmd/beluga eval .beluga/eval.smoke.json
+```
+
+The scaffolded `ci.yml` gates every PR on `make eval-ci` via the Tier-1 `eval-smoke` job and uploads `eval-report.json` as a workflow artefact. A commented Tier-2 template exposes the real-provider opt-in; the template structure is the opt-in gate — Tier-1 stays the only mandatory evaluation on PRs until Tier-2 is explicitly enabled. See [Evaluation guide](../guides/evaluation.md) for the full CI tier model.
+
+**Observability.** When `OTEL_SDK_DISABLED` is not set, the framework-layer eval runner emits spans per the OpenTelemetry GenAI `gen_ai.evaluation.*` semantic convention: an `eval.run` span wraps the full CLI invocation, an `eval.row` child span wraps each dataset row, and per-metric scores attach as `gen_ai.evaluation.result` events on the row span. The aggregated `beluga.eval.metric.score` Histogram is emitted with two label dimensions — `beluga.eval.metric_name` and `beluga.eval.dataset` — **never** `row_id` or `row_index` (cardinality rule). The `beluga.eval.run_id` OTel resource attribute is the join key across traces + metrics + JSON artefact. See [DOC-14 Observability](../architecture/14-observability.md).
+
+Source: [`cmd/beluga/eval/`](../../cmd/beluga/eval/), [`cmd/beluga/eval.go`](../../cmd/beluga/eval.go).
+
 ### `beluga deploy`
 
 Generate deployment artifacts. S1 is a stub — prints what would be written without creating files.
@@ -149,6 +253,7 @@ To build a binary with a different provider set, write your own `main` package a
 ## Related
 
 - [Dev-loop guide](../guides/dev-loop.md) — task-oriented walkthrough of `beluga run` + `beluga dev` + `beluga test`.
+- [Evaluation guide](../guides/evaluation.md) — task-oriented walkthrough of `beluga eval` from hand-authored dataset to CI gating.
 - [Providers catalog](./providers.md) — every registered provider across categories.
 - [Architecture Overview — Layer 7](../architecture/01-overview.md#layer-7--application) — where the CLI fits in the stack.
 - [Goreleaser config](../../.goreleaser.yml) — the release build matrix.

--- a/eval/dataset_test.go
+++ b/eval/dataset_test.go
@@ -279,6 +279,107 @@ func TestDataset_WithEmptyRetrievedDocs(t *testing.T) {
 	assert.Empty(t, loaded.Samples[0].RetrievedDocs)
 }
 
+func TestDataset_BackwardCompat_LoadPreS4JSON(t *testing.T) {
+	// A v2.12.x-shaped dataset file that predates the Turns / ExpectedTools
+	// fields must still load cleanly. The new fields default to their zero
+	// values (nil slices) without error.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "pre-s4.json")
+
+	preS4 := []byte(`{
+  "name": "pre-s4-dataset",
+  "samples": [
+    {
+      "Input": "What is the capital of France?",
+      "Output": "Paris",
+      "ExpectedOutput": "Paris",
+      "RetrievedDocs": null,
+      "Metadata": {"latency_ms": 42.0}
+    }
+  ]
+}`)
+
+	require.NoError(t, os.WriteFile(path, preS4, 0o600))
+
+	ds, err := eval.LoadDataset(path)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+	require.Len(t, ds.Samples, 1)
+
+	s := ds.Samples[0]
+	assert.Equal(t, "Paris", s.Output)
+	assert.Equal(t, "Paris", s.ExpectedOutput)
+	assert.Equal(t, 42.0, s.Metadata["latency_ms"])
+	assert.Nil(t, s.Turns, "Turns defaults to nil when absent from pre-S4 JSON")
+	assert.Nil(t, s.ExpectedTools, "ExpectedTools defaults to nil when absent from pre-S4 JSON")
+}
+
+func TestDataset_Schema_TurnsAndExpectedToolsRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "s4.json")
+
+	original := eval.Dataset{
+		Name: "s4-trajectory",
+		Samples: []eval.EvalSample{
+			{
+				Input:          "What is the weather in Paris?",
+				Output:         "Sunny, 22C",
+				ExpectedOutput: "Sunny, 22C",
+				ExpectedTools:  []string{"weather_lookup"},
+				Turns: []eval.Turn{
+					{Role: "user", Content: "What is the weather in Paris?"},
+					{
+						Role: "assistant",
+						ToolCalls: []schema.ToolCall{
+							{ID: "call-1", Name: "weather_lookup", Arguments: `{"city":"Paris"}`},
+						},
+					},
+					{Role: "tool", Content: "Sunny, 22C"},
+					{Role: "assistant", Content: "Sunny, 22C"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, original.Save(path))
+
+	loaded, err := eval.LoadDataset(path)
+	require.NoError(t, err)
+	require.Len(t, loaded.Samples, 1)
+
+	got := loaded.Samples[0]
+	assert.Equal(t, []string{"weather_lookup"}, got.ExpectedTools)
+	require.Len(t, got.Turns, 4)
+	assert.Equal(t, "user", got.Turns[0].Role)
+	assert.Equal(t, "assistant", got.Turns[1].Role)
+	require.Len(t, got.Turns[1].ToolCalls, 1)
+	assert.Equal(t, "weather_lookup", got.Turns[1].ToolCalls[0].Name)
+	assert.Equal(t, "tool", got.Turns[2].Role)
+	assert.Equal(t, "Sunny, 22C", got.Turns[2].Content)
+}
+
+func TestDataset_Schema_OmitemptyPreservesPreS4Wire(t *testing.T) {
+	// Saving a sample that does NOT set Turns / ExpectedTools must not emit
+	// those keys, so v2.12.x consumers that tolerate only the old schema keep
+	// working against v2.13.0-produced artefacts.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "old-shape.json")
+
+	ds := eval.Dataset{
+		Name: "old-shape",
+		Samples: []eval.EvalSample{
+			{Input: "q", Output: "a", ExpectedOutput: "a"},
+		},
+	}
+
+	require.NoError(t, ds.Save(path))
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(raw), "Turns", "Turns must be omitted when empty")
+	assert.NotContains(t, string(raw), "ExpectedTools", "ExpectedTools must be omitted when empty")
+}
+
 func TestDataset_LargeSampleCount(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "large.json")

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -18,6 +18,18 @@ type Metric interface {
 	Score(ctx context.Context, sample EvalSample) (float64, error)
 }
 
+// Turn represents a single turn in a multi-turn evaluation trajectory.
+// Distinct from eval/clustering.Turn, which is a conversation-pattern type
+// used by the clustering sub-package.
+type Turn struct {
+	// Role is the speaker role for this turn ("user", "assistant", "tool").
+	Role string `json:",omitempty"`
+	// Content is the textual content of the turn.
+	Content string `json:",omitempty"`
+	// ToolCalls are tool invocations requested by the assistant in this turn.
+	ToolCalls []schema.ToolCall `json:",omitempty"`
+}
+
 // EvalSample represents a single evaluation sample containing the input
 // question, the generated output, the expected output, and any additional
 // context such as retrieved documents and metadata.
@@ -33,6 +45,14 @@ type EvalSample struct {
 	// Metadata holds arbitrary key-value pairs for metric-specific data,
 	// such as latency_ms, input_tokens, output_tokens, model, etc.
 	Metadata map[string]any
+	// Turns is the optional multi-turn history for trajectory evaluation.
+	// Leading-comma json tag preserves the existing PascalCase wire format
+	// while omitting the field when unset for backward-compat with pre-S4
+	// dataset files.
+	Turns []Turn `json:",omitempty"`
+	// ExpectedTools is the list of tool names expected in the trajectory
+	// for tool-use evaluation. Omitted when unset for backward-compat.
+	ExpectedTools []string `json:",omitempty"`
 }
 
 // SampleResult holds the evaluation scores for a single sample across

--- a/eval/metrics/exact_match.go
+++ b/eval/metrics/exact_match.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+
+	"github.com/lookatitude/beluga-ai/v2/eval"
+)
+
+// ExactMatch scores whether [eval.EvalSample.Output] equals
+// [eval.EvalSample.ExpectedOutput]. It is the only correctness metric that
+// runs with zero credentials and zero API calls — the canonical default for
+// the scaffolded-project smoke eval (DX-1 S4, specialist-ai-ml-expert §Q2).
+//
+// By default the comparison is case-insensitive with leading/trailing
+// whitespace trimmed; pass [WithCaseSensitive] for strict equality.
+type ExactMatch struct {
+	caseSensitive bool
+}
+
+// ExactMatchOption configures an [ExactMatch] metric.
+type ExactMatchOption func(*ExactMatch)
+
+// WithCaseSensitive flips the comparison to strict byte equality, preserving
+// case and whitespace. Useful when evaluating code snippets or JSON output
+// where case matters.
+func WithCaseSensitive() ExactMatchOption {
+	return func(e *ExactMatch) { e.caseSensitive = true }
+}
+
+// NewExactMatch creates a new ExactMatch metric with the given options.
+func NewExactMatch(opts ...ExactMatchOption) *ExactMatch {
+	e := &ExactMatch{}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Name returns "exact_match".
+func (e *ExactMatch) Name() string { return "exact_match" }
+
+// Score returns 1.0 when Output matches ExpectedOutput and 0.0 otherwise.
+// An empty ExpectedOutput is treated as "no ground truth available" and
+// yields 0.0 — callers wanting a different policy for unset ground truth
+// should filter those rows before scoring.
+func (e *ExactMatch) Score(_ context.Context, sample eval.EvalSample) (float64, error) {
+	if sample.ExpectedOutput == "" {
+		return 0.0, nil
+	}
+	got, want := sample.Output, sample.ExpectedOutput
+	if !e.caseSensitive {
+		got = strings.ToLower(strings.TrimSpace(got))
+		want = strings.ToLower(strings.TrimSpace(want))
+	}
+	if got == want {
+		return 1.0, nil
+	}
+	return 0.0, nil
+}

--- a/eval/metrics/exact_match_test.go
+++ b/eval/metrics/exact_match_test.go
@@ -1,0 +1,54 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lookatitude/beluga-ai/v2/eval"
+	"github.com/lookatitude/beluga-ai/v2/eval/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ eval.Metric = (*metrics.ExactMatch)(nil)
+
+func TestExactMatch_Name(t *testing.T) {
+	e := metrics.NewExactMatch()
+	assert.Equal(t, "exact_match", e.Name())
+}
+
+func TestExactMatch_Score_Table(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		expected      string
+		caseSensitive bool
+		want          float64
+	}{
+		{name: "exact match", output: "paris", expected: "paris", want: 1.0},
+		{name: "case-folded match", output: "Paris", expected: "paris", want: 1.0},
+		{name: "whitespace-trim match", output: "  Paris  ", expected: "paris", want: 1.0},
+		{name: "mismatch", output: "lisbon", expected: "paris", want: 0.0},
+		{name: "empty expected → zero", output: "anything", expected: "", want: 0.0},
+		{name: "empty both → zero", output: "", expected: "", want: 0.0},
+		{name: "case-sensitive mismatch", output: "Paris", expected: "paris", caseSensitive: true, want: 0.0},
+		{name: "case-sensitive exact", output: "paris", expected: "paris", caseSensitive: true, want: 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e *metrics.ExactMatch
+			if tt.caseSensitive {
+				e = metrics.NewExactMatch(metrics.WithCaseSensitive())
+			} else {
+				e = metrics.NewExactMatch()
+			}
+			got, err := e.Score(context.Background(), eval.EvalSample{
+				Output:         tt.output,
+				ExpectedOutput: tt.expected,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/eval/runner.go
+++ b/eval/runner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/lookatitude/beluga-ai/v2/o11y"
 )
 
 // Hooks provides optional callback functions invoked during evaluation.
@@ -78,12 +80,24 @@ func WithHooks(hooks Hooks) RunnerOption {
 	}
 }
 
+// WithDatasetName attaches the dataset identifier that is emitted as the
+// beluga.eval.dataset attribute on the eval.run and eval.row spans and as a
+// label dimension on the beluga.eval.metric.score Histogram. Empty names are
+// accepted and emitted unchanged — callers must set this when the metric
+// aggregation label matters.
+func WithDatasetName(name string) RunnerOption {
+	return func(r *EvalRunner) {
+		r.datasetName = name
+	}
+}
+
 // EvalRunner runs a set of metrics against a dataset of samples.
 type EvalRunner struct {
-	metrics []Metric
-	dataset []EvalSample
-	cfg     Config
-	hooks   Hooks
+	metrics     []Metric
+	dataset     []EvalSample
+	datasetName string
+	cfg         Config
+	hooks       Hooks
 }
 
 // NewRunner creates a new EvalRunner with the given options.
@@ -101,7 +115,8 @@ func NewRunner(opts ...RunnerOption) *EvalRunner {
 
 // Run executes all configured metrics against all samples and returns
 // an aggregate report. Samples are evaluated with the configured
-// concurrency level.
+// concurrency level. The entire run is wrapped in an eval.run span; each
+// sample in an eval.row child span.
 func (r *EvalRunner) Run(ctx context.Context) (*EvalReport, error) {
 	if r.cfg.Timeout > 0 {
 		var cancel context.CancelFunc
@@ -109,8 +124,13 @@ func (r *EvalRunner) Run(ctx context.Context) (*EvalReport, error) {
 		defer cancel()
 	}
 
+	ctx, runSpan := startRunSpan(ctx, r.datasetName, len(r.dataset), len(r.metrics))
+	defer runSpan.End()
+
 	if r.hooks.BeforeRun != nil {
 		if err := r.hooks.BeforeRun(ctx, r.dataset); err != nil {
+			runSpan.RecordError(err)
+			runSpan.SetStatus(o11y.StatusError, err.Error())
 			return nil, err
 		}
 	}
@@ -155,6 +175,15 @@ func (r *EvalRunner) Run(ctx context.Context) (*EvalReport, error) {
 
 	report := r.buildReport(results, time.Since(start))
 
+	if firstErr != nil {
+		runSpan.RecordError(firstErr)
+		runSpan.SetStatus(o11y.StatusError, firstErr.Error())
+	} else if len(report.Errors) > 0 {
+		runSpan.SetStatus(o11y.StatusError, "one or more samples failed")
+	} else {
+		runSpan.SetStatus(o11y.StatusOK, "")
+	}
+
 	if r.hooks.AfterRun != nil {
 		r.hooks.AfterRun(ctx, report)
 	}
@@ -163,19 +192,33 @@ func (r *EvalRunner) Run(ctx context.Context) (*EvalReport, error) {
 }
 
 // processSample evaluates a single sample with hooks and records the result.
+// Wraps the evaluation in an eval.row span so that per-metric
+// gen_ai.evaluation.result events attach to it.
 func (r *EvalRunner) processSample(ctx context.Context, idx int, s EvalSample, results []SampleResult, mu *sync.Mutex, stopped *bool, firstErr *error) {
+	rowCtx, rowSpan := startRowSpan(ctx, r.datasetName, idx)
+	defer rowSpan.End()
+
 	if r.hooks.BeforeSample != nil {
-		if err := r.hooks.BeforeSample(ctx, s); err != nil {
+		if err := r.hooks.BeforeSample(rowCtx, s); err != nil {
+			rowSpan.RecordError(err)
+			rowSpan.SetStatus(o11y.StatusError, err.Error())
 			r.recordResult(idx, SampleResult{Sample: s, Error: err}, results, mu, stopped, firstErr)
 			return
 		}
 	}
 
-	result := r.evaluateSample(ctx, s)
+	result := r.evaluateSample(rowCtx, s)
 	r.recordResult(idx, result, results, mu, stopped, firstErr)
 
+	if result.Error != nil {
+		rowSpan.RecordError(result.Error)
+		rowSpan.SetStatus(o11y.StatusError, result.Error.Error())
+	} else {
+		rowSpan.SetStatus(o11y.StatusOK, "")
+	}
+
 	if r.hooks.AfterSample != nil {
-		r.hooks.AfterSample(ctx, result)
+		r.hooks.AfterSample(rowCtx, result)
 	}
 }
 
@@ -192,7 +235,9 @@ func (r *EvalRunner) recordResult(idx int, result SampleResult, results []Sample
 	mu.Unlock()
 }
 
-// evaluateSample runs all metrics against a single sample.
+// evaluateSample runs all metrics against a single sample. On success, each
+// metric emits a gen_ai.evaluation.result event on the enclosing eval.row span
+// and a beluga.eval.metric.score Histogram sample.
 func (r *EvalRunner) evaluateSample(ctx context.Context, sample EvalSample) SampleResult {
 	scores := make(map[string]float64, len(r.metrics))
 	var sampleErr error
@@ -211,6 +256,8 @@ func (r *EvalRunner) evaluateSample(ctx context.Context, sample EvalSample) Samp
 			continue
 		}
 		scores[m.Name()] = score
+		recordEvalResult(ctx, m.Name(), score)
+		recordMetricScore(ctx, m.Name(), r.datasetName, score)
 	}
 
 	return SampleResult{

--- a/eval/runner_otel_test.go
+++ b/eval/runner_otel_test.go
@@ -45,21 +45,27 @@ func installSpanRecorder(t *testing.T) *tracetest.InMemoryExporter {
 
 // installMetricReader swaps the eval package's meter for an in-memory reader
 // and resets the histogram registration so the next record goes through the
-// reader. Restores global state on test cleanup.
+// reader. Mutations to evalMeter and evalMetricScoreInst run under
+// evalMetricScoreMu to match the read path in metricScoreHistogram — without
+// the lock, any future t.Parallel() on these tests would race with a live
+// metric record path. Restores global state on test cleanup.
 func installMetricReader(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
+	evalMetricScoreMu.Lock()
 	prevMeter := evalMeter
 	prevInst := evalMetricScoreInst
-
 	evalMeter = provider.Meter("github.com/lookatitude/beluga-ai/v2/eval")
 	evalMetricScoreInst = nil
+	evalMetricScoreMu.Unlock()
 
 	t.Cleanup(func() {
+		evalMetricScoreMu.Lock()
 		evalMeter = prevMeter
 		evalMetricScoreInst = prevInst
+		evalMetricScoreMu.Unlock()
 		_ = provider.Shutdown(context.Background())
 	})
 	return reader

--- a/eval/runner_otel_test.go
+++ b/eval/runner_otel_test.go
@@ -1,0 +1,281 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/lookatitude/beluga-ai/v2/o11y"
+)
+
+// stubMetric scores every sample with a fixed value and name. Used to drive
+// the OTel emission tests without touching real providers.
+type stubMetric struct {
+	name  string
+	score float64
+	err   error
+}
+
+func (s *stubMetric) Name() string { return s.name }
+func (s *stubMetric) Score(_ context.Context, _ EvalSample) (float64, error) {
+	return s.score, s.err
+}
+
+// installSpanRecorder wires an in-memory OTel span exporter for the duration
+// of the test and returns the exporter for assertions.
+func installSpanRecorder(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, err := o11y.InitTracer("eval-test",
+		o11y.WithSpanExporter(exporter),
+		o11y.WithSyncExport(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(shutdown)
+	return exporter
+}
+
+// installMetricReader swaps the eval package's meter for an in-memory reader
+// and resets the histogram registration so the next record goes through the
+// reader. Restores global state on test cleanup.
+func installMetricReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prevMeter := evalMeter
+	prevInst := evalMetricScoreInst
+
+	evalMeter = provider.Meter("github.com/lookatitude/beluga-ai/v2/eval")
+	evalMetricScoreInst = nil
+
+	t.Cleanup(func() {
+		evalMeter = prevMeter
+		evalMetricScoreInst = prevInst
+		_ = provider.Shutdown(context.Background())
+	})
+	return reader
+}
+
+func attrString(attrs []attribute.KeyValue, key string) (string, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func attrInt64(attrs []attribute.KeyValue, key string) (int64, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func attrFloat64(attrs []attribute.KeyValue, key string) (float64, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value.AsFloat64(), true
+		}
+	}
+	return 0, false
+}
+
+func TestRun_EmitsEvalRunAndEvalRowSpans(t *testing.T) {
+	exporter := installSpanRecorder(t)
+
+	runner := NewRunner(
+		WithDataset([]EvalSample{{Input: "q1", Output: "a1"}, {Input: "q2", Output: "a2"}}),
+		WithMetrics(&stubMetric{name: "exact_match", score: 1.0}),
+		WithDatasetName("ds-otel"),
+	)
+
+	_, err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	spans := exporter.GetSpans()
+
+	var runCount, rowCount int
+	for _, s := range spans {
+		switch s.Name {
+		case runSpanName:
+			runCount++
+			op, ok := attrString(s.Attributes, o11y.AttrOperationName)
+			assert.True(t, ok)
+			assert.Equal(t, "eval", op)
+			ds, _ := attrString(s.Attributes, attrBelugaDataset)
+			assert.Equal(t, "ds-otel", ds)
+			samples, _ := attrInt64(s.Attributes, attrBelugaSampleCt)
+			assert.Equal(t, int64(2), samples)
+			metrics, _ := attrInt64(s.Attributes, attrBelugaMetricCt)
+			assert.Equal(t, int64(1), metrics)
+		case rowSpanName:
+			rowCount++
+			op, _ := attrString(s.Attributes, o11y.AttrOperationName)
+			assert.Equal(t, "eval", op)
+			ds, _ := attrString(s.Attributes, attrBelugaDataset)
+			assert.Equal(t, "ds-otel", ds)
+		}
+	}
+
+	assert.Equal(t, 1, runCount, "exactly one eval.run span")
+	assert.Equal(t, 2, rowCount, "one eval.row span per sample")
+}
+
+func TestRun_EmitsGenAIEvaluationResultEventsPerMetric(t *testing.T) {
+	exporter := installSpanRecorder(t)
+
+	runner := NewRunner(
+		WithDataset([]EvalSample{{Input: "q", Output: "a"}}),
+		WithMetrics(
+			&stubMetric{name: "exact_match", score: 1.0},
+			&stubMetric{name: "pass_rate", score: 0.5},
+		),
+		WithDatasetName("ds-events"),
+	)
+	_, err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	var rowSpan *tracetest.SpanStub
+	spans := exporter.GetSpans()
+	for i := range spans {
+		if spans[i].Name == rowSpanName {
+			rowSpan = &spans[i]
+			break
+		}
+	}
+	require.NotNil(t, rowSpan, "eval.row span must be emitted")
+
+	require.Len(t, rowSpan.Events, 2, "one gen_ai.evaluation.result event per metric")
+
+	got := map[string]float64{}
+	for _, ev := range rowSpan.Events {
+		assert.Equal(t, evalResultEventName, ev.Name)
+		metricName, ok := attrString(ev.Attributes, attrEvalMetricName)
+		require.True(t, ok, "event missing gen_ai.evaluation.name")
+		score, ok := attrFloat64(ev.Attributes, attrEvalScoreValue)
+		require.True(t, ok, "event missing gen_ai.evaluation.score.value")
+		got[metricName] = score
+	}
+	assert.Equal(t, 1.0, got["exact_match"])
+	assert.Equal(t, 0.5, got["pass_rate"])
+}
+
+func TestRun_RecordsBelugaEvalMetricScoreHistogram(t *testing.T) {
+	installSpanRecorder(t)
+	reader := installMetricReader(t)
+
+	runner := NewRunner(
+		WithDataset([]EvalSample{{Input: "q1"}, {Input: "q2"}, {Input: "q3"}}),
+		WithMetrics(
+			&stubMetric{name: "exact_match", score: 1.0},
+			&stubMetric{name: "pass_rate", score: 0.5},
+		),
+		WithDatasetName("ds-histo"),
+	)
+	_, err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	histo := findHistogram(rm, metricScoreInstrument)
+	require.NotNil(t, histo, "beluga.eval.metric.score histogram must be recorded")
+
+	h, ok := histo.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Float64 histogram data")
+
+	require.Len(t, h.DataPoints, 2, "exactly two (metric_name, dataset) label combinations for two metrics on one dataset")
+
+	for _, dp := range h.DataPoints {
+		dsAttr, ok := dp.Attributes.Value(attribute.Key(attrBelugaDataset))
+		require.True(t, ok)
+		metricAttr, ok := dp.Attributes.Value(attribute.Key(attrBelugaMetricName))
+		require.True(t, ok)
+		assert.Equal(t, "ds-histo", dsAttr.AsString())
+		assert.Contains(t, []string{"exact_match", "pass_rate"}, metricAttr.AsString())
+		assert.Equal(t, uint64(3), dp.Count, "three samples recorded per (metric, dataset) bucket")
+	}
+}
+
+func TestRun_HistogramCardinality_StaysBoundedAtDatasetAndMetricOnly(t *testing.T) {
+	// Success criterion: cardinality test asserts <10 unique label combinations
+	// for a 1000-row fixture with two metrics. Expect exactly 2.
+	installSpanRecorder(t)
+	reader := installMetricReader(t)
+
+	samples := make([]EvalSample, 1000)
+	for i := range samples {
+		samples[i] = EvalSample{Input: fmt.Sprintf("q%d", i)}
+	}
+
+	runner := NewRunner(
+		WithDataset(samples),
+		WithMetrics(
+			&stubMetric{name: "exact_match", score: 1.0},
+			&stubMetric{name: "pass_rate", score: 1.0},
+		),
+		WithDatasetName("ds-cardinality"),
+		WithParallel(4),
+	)
+	_, err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	rm := metricdata.ResourceMetrics{}
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	histo := findHistogram(rm, metricScoreInstrument)
+	require.NotNil(t, histo)
+	h := histo.Data.(metricdata.Histogram[float64])
+	assert.Less(t, len(h.DataPoints), 10, "histogram cardinality must stay bounded: <10 combinations for 1000 rows × 2 metrics")
+	assert.Equal(t, 2, len(h.DataPoints), "expected exactly 2 (metric, dataset) combinations")
+}
+
+func TestRun_SetsErrorStatusOnSampleFailure(t *testing.T) {
+	exporter := installSpanRecorder(t)
+
+	runner := NewRunner(
+		WithDataset([]EvalSample{{Input: "q"}}),
+		WithMetrics(&stubMetric{name: "exact_match", err: errors.New("forced metric failure")}),
+		WithDatasetName("ds-err"),
+	)
+	_, err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	var sawRowErr, sawRunErr bool
+	for _, s := range exporter.GetSpans() {
+		if s.Name == rowSpanName && s.Status.Code.String() == "Error" {
+			sawRowErr = true
+		}
+		if s.Name == runSpanName && s.Status.Code.String() == "Error" {
+			sawRunErr = true
+		}
+	}
+	assert.True(t, sawRowErr, "eval.row span must record Error status on metric failure")
+	assert.True(t, sawRunErr, "eval.run span must propagate Error status when any sample fails")
+}
+
+// findHistogram returns a pointer to the histogram metric with the given name
+// from the ResourceMetrics, or nil if not present.
+func findHistogram(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for i := range rm.ScopeMetrics {
+		sm := &rm.ScopeMetrics[i]
+		for j := range sm.Metrics {
+			if sm.Metrics[j].Name == name {
+				return &sm.Metrics[j]
+			}
+		}
+	}
+	return nil
+}

--- a/eval/tracing.go
+++ b/eval/tracing.go
@@ -1,0 +1,99 @@
+package eval
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/lookatitude/beluga-ai/v2/o11y"
+)
+
+const (
+	attrEvalMetricName   = "gen_ai.evaluation.name"
+	attrEvalScoreValue   = "gen_ai.evaluation.score.value"
+	attrBelugaMetricName = "beluga.eval.metric_name"
+	attrBelugaDataset    = "beluga.eval.dataset"
+	attrBelugaRowIndex   = "beluga.eval.row_index"
+	attrBelugaSampleCt   = "beluga.eval.sample_count"
+	attrBelugaMetricCt   = "beluga.eval.metric_count"
+
+	evalResultEventName   = "gen_ai.evaluation.result"
+	metricScoreInstrument = "beluga.eval.metric.score"
+
+	runSpanName = "eval.run"
+	rowSpanName = "eval.row"
+)
+
+var (
+	evalMeter           = otel.Meter("github.com/lookatitude/beluga-ai/v2/eval")
+	evalMetricScoreMu   sync.Mutex
+	evalMetricScoreInst metric.Float64Histogram
+)
+
+func metricScoreHistogram() metric.Float64Histogram {
+	evalMetricScoreMu.Lock()
+	defer evalMetricScoreMu.Unlock()
+	if evalMetricScoreInst != nil {
+		return evalMetricScoreInst
+	}
+	h, err := evalMeter.Float64Histogram(
+		metricScoreInstrument,
+		metric.WithDescription("Per-metric evaluation score in [0, 1]"),
+	)
+	if err == nil {
+		evalMetricScoreInst = h
+	}
+	return evalMetricScoreInst
+}
+
+// recordMetricScore records a successful metric score on the beluga.eval.metric.score
+// Histogram with only metric_name + dataset label dimensions — never row_id or
+// row_index — per the brief's cardinality constraint.
+func recordMetricScore(ctx context.Context, metricName, datasetName string, score float64) {
+	h := metricScoreHistogram()
+	if h == nil {
+		return
+	}
+	h.Record(ctx, score,
+		metric.WithAttributes(
+			attribute.String(attrBelugaMetricName, metricName),
+			attribute.String(attrBelugaDataset, datasetName),
+		),
+	)
+}
+
+// recordEvalResult emits a gen_ai.evaluation.result event on the span currently
+// carried by ctx, per the OTel GenAI evaluation semantic conventions.
+func recordEvalResult(ctx context.Context, metricName string, score float64) {
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() {
+		return
+	}
+	span.AddEvent(evalResultEventName, trace.WithAttributes(
+		attribute.String(attrEvalMetricName, metricName),
+		attribute.Float64(attrEvalScoreValue, score),
+	))
+}
+
+// startRunSpan opens the top-level eval.run span at runner entry.
+func startRunSpan(ctx context.Context, dataset string, samples, metrics int) (context.Context, o11y.Span) {
+	return o11y.StartSpan(ctx, runSpanName, o11y.Attrs{
+		o11y.AttrOperationName: "eval",
+		attrBelugaDataset:      dataset,
+		attrBelugaSampleCt:     samples,
+		attrBelugaMetricCt:     metrics,
+	})
+}
+
+// startRowSpan opens the per-row eval.row span inside the eval.run span.
+func startRowSpan(ctx context.Context, dataset string, rowIndex int) (context.Context, o11y.Span) {
+	return o11y.StartSpan(ctx, rowSpanName, o11y.Attrs{
+		o11y.AttrOperationName: "eval",
+		attrBelugaDataset:      dataset,
+		attrBelugaRowIndex:     rowIndex,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	golang.org/x/time v0.15.0
 	google.golang.org/genai v1.54.0
 	google.golang.org/grpc v1.80.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.49.1
 )
 
@@ -156,7 +157,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/llm/providers/mock/mock.go
+++ b/llm/providers/mock/mock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lookatitude/beluga-ai/v2/config"
 	"github.com/lookatitude/beluga-ai/v2/core"
+	"github.com/lookatitude/beluga-ai/v2/eval"
 	"github.com/lookatitude/beluga-ai/v2/llm"
 	"github.com/lookatitude/beluga-ai/v2/schema"
 )
@@ -269,6 +270,39 @@ func (m *ChatModel) buildMessage(fx Fixture, idx int) *schema.AIMessage {
 	}
 	msg.ToolCalls = assignToolCallIDs(fx.ToolCalls, idx)
 	return msg
+}
+
+// FixturesFromTurns derives a mock-provider fixture queue from an
+// eval.Turn trajectory. Only assistant turns are converted; user, tool,
+// and system turns are skipped because the mock replays the LLM side of
+// a conversation, not the user or the tool outputs. For each assistant
+// turn the helper emits one Fixture carrying the turn's Content and a
+// defensive copy of its ToolCalls, preserving trajectory order so
+// replaying the fixture queue reproduces the original assistant outputs.
+//
+// Use with WithFixtures to seed a deterministic mock from a recorded
+// trajectory in scaffolded eval branches, e.g.:
+//
+//	mock.New(cfg, mock.WithFixtures(mock.FixturesFromTurns(sample.Turns)))
+func FixturesFromTurns(turns []eval.Turn) []Fixture {
+	if len(turns) == 0 {
+		return nil
+	}
+	out := make([]Fixture, 0, len(turns))
+	for _, t := range turns {
+		if t.Role != "assistant" {
+			continue
+		}
+		fx := Fixture{Content: t.Content}
+		if len(t.ToolCalls) > 0 {
+			fx.ToolCalls = append([]schema.ToolCall(nil), t.ToolCalls...)
+		}
+		out = append(out, fx)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // assignToolCallIDs returns a defensive copy of calls with missing IDs

--- a/llm/providers/mock/mock_test.go
+++ b/llm/providers/mock/mock_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lookatitude/beluga-ai/v2/config"
 	"github.com/lookatitude/beluga-ai/v2/core"
+	"github.com/lookatitude/beluga-ai/v2/eval"
 	"github.com/lookatitude/beluga-ai/v2/llm"
 	"github.com/lookatitude/beluga-ai/v2/schema"
 )
@@ -344,6 +345,115 @@ func TestFixturesFile_BadPathReturnsError(t *testing.T) {
 	var coreErr *core.Error
 	if !errors.As(err, &coreErr) || coreErr.Code != core.ErrInvalidInput {
 		t.Fatalf("error = %v, want core.ErrInvalidInput", err)
+	}
+}
+
+func TestFixturesFromTurns_EmptyAndNil(t *testing.T) {
+	t.Parallel()
+
+	if got := FixturesFromTurns(nil); got != nil {
+		t.Fatalf("FixturesFromTurns(nil)=%v want nil", got)
+	}
+	if got := FixturesFromTurns([]eval.Turn{}); got != nil {
+		t.Fatalf("FixturesFromTurns(empty)=%v want nil", got)
+	}
+}
+
+func TestFixturesFromTurns_SkipsNonAssistantTurns(t *testing.T) {
+	t.Parallel()
+
+	turns := []eval.Turn{
+		{Role: "user", Content: "hi"},
+		{Role: "system", Content: "you are a bot"},
+		{Role: "tool", Content: `{"result":"ok"}`},
+	}
+	if got := FixturesFromTurns(turns); len(got) != 0 {
+		t.Fatalf("FixturesFromTurns(non-assistant-only)=%v want empty", got)
+	}
+}
+
+func TestFixturesFromTurns_ToolCallThenText(t *testing.T) {
+	t.Parallel()
+
+	turns := []eval.Turn{
+		{Role: "user", Content: "what's the weather?"},
+		{Role: "assistant", ToolCalls: []schema.ToolCall{
+			{ID: "call_1", Name: "get_weather", Arguments: `{"city":"Lisbon"}`},
+		}},
+		{Role: "tool", Content: `{"temp":"22C"}`},
+		{Role: "assistant", Content: "It's 22°C in Lisbon."},
+	}
+
+	got := FixturesFromTurns(turns)
+	if len(got) != 2 {
+		t.Fatalf("FixturesFromTurns: got %d fixtures, want 2 (one per assistant turn)", len(got))
+	}
+	if len(got[0].ToolCalls) != 1 {
+		t.Fatalf("fixture[0].ToolCalls=%d want 1", len(got[0].ToolCalls))
+	}
+	if got[0].ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("fixture[0].ToolCalls[0].Name=%q want get_weather", got[0].ToolCalls[0].Name)
+	}
+	if got[0].Content != "" {
+		t.Fatalf("fixture[0].Content=%q want empty (tool-call turn)", got[0].Content)
+	}
+	if got[1].Content != "It's 22°C in Lisbon." {
+		t.Fatalf("fixture[1].Content=%q want final assistant text", got[1].Content)
+	}
+	if len(got[1].ToolCalls) != 0 {
+		t.Fatalf("fixture[1].ToolCalls=%v want empty", got[1].ToolCalls)
+	}
+}
+
+func TestFixturesFromTurns_DrivesMockReplay(t *testing.T) {
+	t.Parallel()
+
+	turns := []eval.Turn{
+		{Role: "user", Content: "q"},
+		{Role: "assistant", ToolCalls: []schema.ToolCall{
+			{ID: "call_a", Name: "search", Arguments: `{"q":"beluga"}`},
+		}},
+		{Role: "tool", Content: "result"},
+		{Role: "assistant", Content: "final"},
+	}
+
+	m, err := New(config.ProviderConfig{}, WithFixtures(FixturesFromTurns(turns)))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx := context.Background()
+
+	first, err := m.Generate(ctx, nil)
+	if err != nil {
+		t.Fatalf("Generate #1: %v", err)
+	}
+	if len(first.ToolCalls) != 1 || first.ToolCalls[0].Name != "search" {
+		t.Fatalf("Generate #1 ToolCalls=%v want [search]", first.ToolCalls)
+	}
+
+	second, err := m.Generate(ctx, nil)
+	if err != nil {
+		t.Fatalf("Generate #2: %v", err)
+	}
+	if second.Text() != "final" {
+		t.Fatalf("Generate #2 Text=%q want final", second.Text())
+	}
+}
+
+func TestFixturesFromTurns_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	original := []schema.ToolCall{{ID: "c", Name: "orig"}}
+	turns := []eval.Turn{{Role: "assistant", ToolCalls: original}}
+
+	got := FixturesFromTurns(turns)
+	if len(got) != 1 || len(got[0].ToolCalls) != 1 {
+		t.Fatalf("unexpected fixture shape: %+v", got)
+	}
+	// Mutate caller's slice — the helper must have copied.
+	original[0].Name = "mutated"
+	if got[0].ToolCalls[0].Name != "orig" {
+		t.Fatalf("fixture ToolCalls aliased caller slice: got Name=%q", got[0].ToolCalls[0].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

Ships DX-1 Slice 4 (LOO-154): `beluga eval` CLI + scaffolded `BELUGA_ENV=eval` branch, targeting framework release v2.13.0.

Per the approved brief at `research/briefs/2026-04-21-dx1-s4-eval.md` (all 22 non-negotiable design decisions honored):

- **`beluga eval <dataset>`** — new cobra subcommand that runs a scaffolded project once per dataset row via exec-once IPC (`BELUGA_ENV=eval` + `BELUGA_EVAL_SAMPLE_JSON`), collects trajectories, scores via the configured metric, and emits `eval-report.json`.
- **Turn schema + OTel GenAI** — `eval.Turn` carries `Input`, `ExpectedOutput`, and `ExpectedTools`; runner emits `gen_ai.evaluation.*` events and a `beluga.eval.metric.score` histogram keyed only by `{metric_name, dataset}` (never `row_id`), plus a `beluga.eval.run_id` resource attribute for cross-signal join.
- **`llm/providers/mock` FixturesFromTurns(Turn)** — helper lets a mock provider replay a Turn trajectory deterministically, so the Tier-1 smoke is a hermetic offline run.
- **`eval/metrics.ExactMatch`** — default metric; Tier-1 smoke asserts aggregate ≥ 0.999.
- **Renderers** — text, JSON (`eval-report.json`), and JUnit XML (`--format junit`) for PR annotations via `dorny/test-reporter`.
- **Scaffold wiring** — generated projects ship with `.beluga/eval.yaml`, a `.beluga/eval.smoke.json` 3-row mock-fixture dataset, a `make eval-ci` target pinning the 5 canonical env vars (`BELUGA_LLM_PROVIDER=mock`, `BELUGA_DETERMINISTIC=1`, `BELUGA_SEED=42`, `OTEL_SDK_DISABLED=true`), and a `BELUGA_ENV=eval` branch in the scaffolded `main.go`.
- **Framework CI** — new `eval-integration.yml` Linux-only job: scaffolds `basic` into `/tmp`, points go.mod at the in-tree framework via `-replace`, runs `make eval-ci`, and asserts `run_id + 3 samples + 0 errors + exact_match ≥ 0.999` via a stdlib-only Python3 heredoc. Budget < 90s cold cache.
- **Docs** — `docs/reference/cli.md` adds the `beluga eval` section (eighth subcommand); new `docs/guides/evaluation.md` walks from hand-authored dataset → mock smoke → real-provider opt-in → CI gating → OTel observability. `docs/guides/README.md` updated.

## Commits (8)

- `237f95dd` feat(eval): Turn schema + OTel GenAI spans/events/histogram
- `003d97b9` feat(llm/providers/mock): FixturesFromTurns(eval.Turn)
- `4bf88f62` feat(eval/metrics): ExactMatch
- `0f84eb74` feat(cmd/beluga/eval): CLI config + runner with exec-once IPC
- `157f9f31` feat(cmd/beluga/eval): text/JSON/JUnit renderers + embedded schema
- `8b0a28b7` feat(cmd/beluga): wire `beluga eval` cobra subcommand
- `96a3498e` feat(scaffold): wire BELUGA_ENV=eval branch + eval.yaml + smoke dataset
- `1a2d2432` docs(cli)+ci(eval): beluga eval docs + framework eval-integration CI

## Scope

**In:** Tier-1 mock-mode smoke path; exec-once IPC; `ExactMatch` default metric; text/JSON/JUnit renderers; scaffold eval branch + smoke dataset; `eval-integration.yml` CI.

**Out (deferred to S4.5):** real-provider `eval-provider`/`judge-model`/`max-cost` flags (reserved in CLI, not yet wired); Braintrust/DeepEval/RAGAS runner integration (providers exist; runner side is future work).

## Test plan

- [ ] `_ci-checks.yml` (build/vet/test-race/tidy/gofmt/lint/sec) green on PR
- [ ] `_security-checks.yml` (gosec/govulncheck) green on PR
- [ ] `scaffold-integration.yml` still green (no regression)
- [ ] `devloop-integration.yml` still green (no regression)
- [ ] `eval-integration.yml` (new) green — Linux-only, < 90s cold cache, asserts `run_id + 3 samples + 0 errors + exact_match ≥ 0.999`
- [ ] Greptile: zero P0/P1 on first submission
- [ ] SonarCloud: `new_coverage ≥ 80%` on touched packages, `new_security_hotspots_reviewed = 100%` (apply canonical `hotspot-triage.md` Safe-review comment for `githubactions:S7637` on `eval-integration.yml` mutable `@vN` tags after scan)

Closes LOO-154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)