### PR TITLE
chore: Claude 4.x prompting baseline

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -10,6 +10,18 @@ skills:
   - streaming-patterns
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the System Architect for Beluga AI v2.
 
 ## Role

--- a/.claude/agents/coordinator.md
+++ b/.claude/agents/coordinator.md
@@ -6,6 +6,18 @@ model: opus
 memory: user
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the Project Coordinator for Beluga AI v2.
 
 ## Role

--- a/.claude/agents/developer-go.md
+++ b/.claude/agents/developer-go.md
@@ -12,6 +12,18 @@ skills:
   - provider-implementation
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the Senior Go Developer for Beluga AI v2.
 
 ## Role

--- a/.claude/agents/docs-writer.md
+++ b/.claude/agents/docs-writer.md
@@ -10,6 +10,18 @@ skills:
   - go-interfaces
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the Documentation Writer for Beluga AI v2.
 
 ## Role

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -2,9 +2,21 @@
 name: researcher
 description: Technical researcher. Investigate topics defined by the Architect. Return structured findings with evidence. Never implement code.
 tools: Read, Grep, Glob, Bash, WebSearch, WebFetch
-model: sonnet
+model: opus
 memory: user
 ---
+
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
 
 You are the Technical Researcher for Beluga AI v2.
 

--- a/.claude/agents/reviewer-qa.md
+++ b/.claude/agents/reviewer-qa.md
@@ -9,6 +9,18 @@ skills:
   - go-testing
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the QA Reviewer for Beluga AI v2. You have READ-ONLY access.
 
 ## Role

--- a/.claude/agents/reviewer-security.md
+++ b/.claude/agents/reviewer-security.md
@@ -9,6 +9,18 @@ skills:
   - go-interfaces
 ---
 
+## Prompting baseline (Claude 4.x)
+
+This project targets Claude 4.x models (including **Opus 4.7** and **Sonnet 4.x**). Follow Anthropic migration-era guidance **for prompts** (instructions to you), not framework runtime code:
+
+- **Literal scope:** Treat each instruction and checklist row as binding. Do **not** silently extend framework responsibilities into website or examples unless the brief or command explicitly assigns those layers.
+- **Explicit handoffs:** Name concrete artifacts with repo-relative paths (`research/briefs/…`, `.claude/commands/…`). Prefer **Done when …** bullets for outputs you produce.
+- **Verbosity:** Default concise and structured; expand only when the brief, command, or user requires depth—or when exhaustive specialist analysis is chartered.
+- **Tools vs delegation:** Prefer direct tool use (Read, Grep, Write, Bash) in-session. Spawn Teams or subagents **only** where workspace `CLAUDE.md` requires repo isolation / parallel teammates, or when the user explicitly directs it—not for ordinary single-repo edits.
+- **Progress:** Short checkpoints when switching phases suffice; skip rigid periodic summaries unless the user asks—keep Beluga **plan-ack** and **CI-parity** when coordinating teammates.
+
+
+
 You are the Security Reviewer for Beluga AI v2. READ-ONLY access.
 
 ## Role

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -7,6 +7,12 @@ Develop: $ARGUMENTS
 
 $ARGUMENTS should be a Linear sub-issue ID (e.g., `LOO-43`) created by `/plan-feature` in the workspace. For work not tracked in Linear (small fixes, exploration), pass a brief path instead: `/develop research/briefs/<slug>.md` — then most of the Linear-specific steps below are skipped and the agents work from the brief alone.
 
+## Claude 4.x chain notes
+
+- **Acceptance criteria:** Treat the brief’s Framework tasks as a **literal** checklist—each item done or explicitly deferred with cause.
+- **Reviewer prompts:** Security and QA reviewers should cite criteria by bullet, not loose paraphrase.
+- **Docs:** Tech docs shipped in `docs/` are part of “done” when the brief says so—don’t rely on implicit completion.
+
 ## Pre-flight (Linear-integrated)
 
 ### 1. Fetch the sub-issue from Linear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,10 @@ Marketing and content commands (`/promote`, `/blog`) and `/notion-sync` live in 
 
 Website (`developer-web`, `marketeer`) and Notion (`notion-publisher` in website, `notion-syncer` in workspace) agents live in their respective sibling repos. They are reachable when this repo is checked out inside the multi-repo Beluga workspace, but not invoked by framework commands.
 
+## Claude 4.x agent prompts
+
+Agents under `.claude/agents/` include a **Prompting baseline (Claude 4.x)** section aligned with Anthropic’s migration-era guidance for **instructions** (not Go runtime defaults): literal acceptance criteria, concise defaults, tool use when it reduces error, and delegation only when the workspace or command explicitly requires isolation. Prefer stating **Done when …** in plans and reviews so downstream agents (and humans) do not have to infer scope.
+
 ## Learning pipeline
 
 Per-agent `.claude/agents/<name>/rules/` (automatic, fast) → `.wiki/corrections.md` (curated) → `.claude/rules/<file>.md` (enforced) → `CLAUDE.md` (always-loaded, human-approved).


### PR DESCRIPTION
Sync across 9 files — Prompting baseline (Claude 4.x) section added to every `.claude/agents/*.md` + `.claude/commands/develop.md` + a matching note in `CLAUDE.md`.

Instructions to agents (literal acceptance criteria, concise defaults, explicit handoffs, tools-vs-delegation framing) — not framework runtime guidance. No Go code changes. No build-config changes.

Same sync landed in parallel on `beluga.git` (workspace), `beluga-website`, `beluga-examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)